### PR TITLE
Allow multiple persistence endpoints

### DIFF
--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -1,4 +1,4 @@
-# Initial performance results as of 5/15/2020 with no performance tuning thus far
+# Initial performance results as of 5/15/2020 with no performance tuning thus far (see below for summary of changes)
 
 ## Experimental setup
 - Each cluster component is run with on a single NUMA node on a server with Intel Xeon Silver 4114 CPUs.
@@ -73,7 +73,7 @@ Transaction Latency percentiles:
 ### Multi-partition throughput test
 10 client cores, 2 servers with 4 cores each, pipeline depth 1, 1 read and 2 writes per transaction:
 
-|                      | 5/15/2020   | 6/8/2020   |
+|                      | 5/15/2020   | 6/08/2020  |
 | :---                 | :---------: | :--------: |
 | Aggregate Txns/sec   | 64,500      | 66,000     |
 | 50% Latency (usec)   | 119         | 116        |
@@ -106,3 +106,8 @@ New Order Transaction Latency percentiles:
 - p90:    900 usec
 - p99:   1200 usec
 - p99.9: 1500 usec
+
+## Summary of performance-relevant changes by date
+
+5/15/2020: Initial open source release
+6/08/2020: Allow multiple persistence endpoints, instead of one per process. Update dependecy packages.

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -109,5 +109,5 @@ New Order Transaction Latency percentiles:
 
 ## Summary of performance-relevant changes by date
 
-5/15/2020: Initial open source release
-6/08/2020: Allow multiple persistence endpoints, instead of one per process. Update dependecy packages.
+- 5/15/2020: Initial open source release
+- 6/08/2020: Allow multiple persistence endpoints, instead of one per process. Update dependecy packages.

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -70,6 +70,17 @@ Transaction Latency percentiles:
 - p99:   198 usec
 - p99.9: 232 usec
 
+### Multi-partition throughput test
+10 client cores, 2 servers with 4 cores each, pipeline depth 1, 1 read and 2 writes per transaction:
+
+|                      | 5/15/2020   | 6/8/2020   |
+| :---                 | :---------: | :--------: |
+| Aggregate Txns/sec   | 64,500      | 66,000     |
+| 50% Latency (usec)   | 119         | 116        |
+| 90% Latency (usec)   | 193         | 189        |
+| 99% Latency (usec)   | 278         | 274        |
+| 99.9% Latency (usec) | 341         | 339        |
+
 
 ## TPC-C Benchmark, New Order and Payment transaction types (src/k2/cmd/tpcc/)
 

--- a/src/k2/cmd/nodepool/nodepool_main.cpp
+++ b/src/k2/cmd/nodepool/nodepool_main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char** argv) {
         ("cpo_request_timeout", bpo::value<k2::ParseableDuration>(), "CPO request timeout")
         ("cpo_request_backoff", bpo::value<k2::ParseableDuration>(), "CPO request backoff")
         ("k23si_cpo_endpoint", bpo::value<k2::String>(), "the endpoint for k2 CPO service")
-        ("k23si_persistence_endpoint", bpo::value<k2::String>(), "the endpoint for k2 persistence");
+        ("k23si_persistence_endpoints", bpo::value<std::vector<k2::String>>()->multitoken()->default_value(std::vector<k2::String>()), "A space-delimited list of k2 persistence endpoints, each core will pick one endpoint");
 
     app.addApplet<k2::TSO_ClientLib>(10ms);
     app.addApplet<k2::CollectionMetadataCache>();

--- a/src/k2/module/k23si/Config.h
+++ b/src/k2/module/k23si/Config.h
@@ -57,7 +57,7 @@ struct K23SIConfig {
     ConfigVar<uint64_t> finalizeBatchSize{"k23si_txn_finalize_batch_size", 20};
 
     // the endpoint for our persistence
-    ConfigVar<String> persistenceEndpoint{"k23si_persistence_endpoint", "tcp+k2rpc://127.0.0.1:12345"};
+    ConfigVar<std::vector<String>> persistenceEndpoint{"k23si_persistence_endpoints"};
     ConfigDuration persistenceTimeout{"k23si_persistence_timeout", 10s};
 
     // the endpoint for the CPO

--- a/src/k2/module/k23si/Persistence.cpp
+++ b/src/k2/module/k23si/Persistence.cpp
@@ -26,8 +26,9 @@ Copyright(c) 2020 Futurewei Cloud
 namespace k2 {
 
 Persistence::Persistence() {
-    //TODO discover RDMA endpoint
-    _remoteEndpoint = RPC().getTXEndpoint(_config.persistenceEndpoint());
+    int id = seastar::engine().cpu_id();
+    String endpoint = _config.persistenceEndpoint()[id % _config.persistenceEndpoint().size()];
+    _remoteEndpoint = RPC().getTXEndpoint(endpoint);
     K2INFO("ctor with endpoint: " << _remoteEndpoint->getURL());
 }
 


### PR DESCRIPTION
Allow multiple persistence endpoints to be passed on the command line. Each core will pick a different persistence endpoint to connect to.