### PR TITLE
validate checksum only if present

### DIFF
--- a/src/k2/transport/RPCParser.cpp
+++ b/src/k2/transport/RPCParser.cpp
@@ -427,12 +427,7 @@ void RPCParser::_stWAIT_FOR_PAYLOAD() {
 
 void RPCParser::_stREADY_TO_DISPATCH() {
     K2DEBUG("ready_to_dispatch: cursize=" << _currentBinary.size());
-    if (_useChecksum && _payload) {
-        if (!_metadata.isChecksumSet()) {
-            K2DEBUG("metadata doesn't have crc checksum");
-            _setParserFailure(ChecksumValidationException());
-            return;
-        }
+    if (_useChecksum && _payload && _metadata.isChecksumSet()) {
         auto checksum = _payload->computeCrc32c();
         if (checksum != _metadata.checksum) {
             K2DEBUG("checksum doesn't match: have=" << _metadata.checksum << ", received=" << checksum);

--- a/test/integration/test_3si_txn.sh
+++ b/test/integration/test_3si_txn.sh
@@ -11,7 +11,7 @@ CPO=tcp+k2rpc://0.0.0.0:9000
 TSO=tcp+k2rpc://0.0.0.0:13000
 
 # start CPO on 2 cores
-./build/src/k2/cmd/controlPlaneOracle/cpo_main -c1 --tcp_endpoints ${CPO} 9001 --data_dir ${CPODIR} --heartbeat_deadline=10s --enable_tx_checksum true --reactor-backend epoll --prometheus_port 63000 &
+./build/src/k2/cmd/controlPlaneOracle/cpo_main -c1 --tcp_endpoints ${CPO} 9001 --data_dir ${CPODIR} --heartbeat_deadline=10s --enable_tx_checksum true --reactor-backend epoll --prometheus_port 63000 --assignment_timeout=1s &
 cpo_child_pid=$!
 
 # start nodepool on 3 cores

--- a/test/integration/test_collection.sh
+++ b/test/integration/test_collection.sh
@@ -11,7 +11,7 @@ CPO=tcp+k2rpc://0.0.0.0:9000
 TSO=tcp+k2rpc://0.0.0.0:13000
 
 # start CPO on 2 cores
-./build/src/k2/cmd/controlPlaneOracle/cpo_main -c2 --tcp_endpoints ${CPO} --data_dir ${CPODIR} --enable_tx_checksum true --reactor-backend epoll --prometheus_port 63000 &
+./build/src/k2/cmd/controlPlaneOracle/cpo_main -c2 --tcp_endpoints ${CPO} --data_dir ${CPODIR} --enable_tx_checksum true --reactor-backend epoll --prometheus_port 63000 --assignment_timeout=1s &
 cpo_child_pid=$!
 
 # start nodepool on 3 cores

--- a/test/integration/test_k23si.sh
+++ b/test/integration/test_k23si.sh
@@ -11,7 +11,7 @@ CPO=tcp+k2rpc://0.0.0.0:9000
 TSO=tcp+k2rpc://0.0.0.0:13000
 
 # start CPO on 2 cores
-./build/src/k2/cmd/controlPlaneOracle/cpo_main -c1 --tcp_endpoints ${CPO} 9001 --data_dir ${CPODIR} --enable_tx_checksum true --reactor-backend epoll --prometheus_port 63000 &
+./build/src/k2/cmd/controlPlaneOracle/cpo_main -c1 --tcp_endpoints ${CPO} 9001 --data_dir ${CPODIR} --enable_tx_checksum true --reactor-backend epoll --prometheus_port 63000 --assignment_timeout=1s &
 cpo_child_pid=$!
 
 # start nodepool on 3 cores

--- a/test/integration/test_partition.sh
+++ b/test/integration/test_partition.sh
@@ -11,7 +11,7 @@ CPO=tcp+k2rpc://0.0.0.0:9000
 TSO=tcp+k2rpc://0.0.0.0:13000
 
 # start CPO on 2 cores
-./build/src/k2/cmd/controlPlaneOracle/cpo_main -c2 --tcp_endpoints ${CPO} --data_dir ${CPODIR} --enable_tx_checksum true --reactor-backend epoll --prometheus_port 63000 &
+./build/src/k2/cmd/controlPlaneOracle/cpo_main -c2 --tcp_endpoints ${CPO} --data_dir ${CPODIR} --enable_tx_checksum true --reactor-backend epoll --prometheus_port 63000 --assignment_timeout=1s &
 cpo_child_pid=$!
 
 # start nodepool on 3 cores

--- a/test/integration/test_plog.sh
+++ b/test/integration/test_plog.sh
@@ -8,7 +8,7 @@ rm -rf ${CPODIR}
 CPO=tcp+k2rpc://0.0.0.0:9000
 
 # start CPO
-./build/src/k2/cmd/controlPlaneOracle/cpo_main -c1 --tcp_endpoints ${CPO} 9001 --data_dir ${CPODIR} --prometheus_port 63000 &
+./build/src/k2/cmd/controlPlaneOracle/cpo_main -c1 --tcp_endpoints ${CPO} 9001 --data_dir ${CPODIR} --prometheus_port 63000 --assignment_timeout=1s &
 cpo_child_pid=$!
 
 # start plog

--- a/test/integration/test_query.sh
+++ b/test/integration/test_query.sh
@@ -11,7 +11,7 @@ CPO=tcp+k2rpc://0.0.0.0:9000
 TSO=tcp+k2rpc://0.0.0.0:13000
 
 # start CPO on 2 cores
-./build/src/k2/cmd/controlPlaneOracle/cpo_main -c1 --tcp_endpoints ${CPO} 9001 --data_dir ${CPODIR} --enable_tx_checksum true --reactor-backend epoll --prometheus_port 63000 &
+./build/src/k2/cmd/controlPlaneOracle/cpo_main -c1 --tcp_endpoints ${CPO} 9001 --data_dir ${CPODIR} --enable_tx_checksum true --reactor-backend epoll --prometheus_port 63000 --assignment_timeout=1s &
 cpo_child_pid=$!
 
 # start nodepool on 2 cores

--- a/test/integration/test_schema_create.sh
+++ b/test/integration/test_schema_create.sh
@@ -11,7 +11,7 @@ CPO=tcp+k2rpc://0.0.0.0:9000
 TSO=tcp+k2rpc://0.0.0.0:13000
 
 # start CPO on 2 cores
-./build/src/k2/cmd/controlPlaneOracle/cpo_main -c1 --tcp_endpoints ${CPO} 9001 --data_dir ${CPODIR} --enable_tx_checksum true --reactor-backend epoll --prometheus_port 63000 &
+./build/src/k2/cmd/controlPlaneOracle/cpo_main -c1 --tcp_endpoints ${CPO} 9001 --data_dir ${CPODIR} --enable_tx_checksum true --reactor-backend epoll --prometheus_port 63000 --assignment_timeout=1s &
 cpo_child_pid=$!
 
 # start nodepool on 3 cores

--- a/test/integration/test_skv_client.sh
+++ b/test/integration/test_skv_client.sh
@@ -11,7 +11,7 @@ CPO=tcp+k2rpc://0.0.0.0:9000
 TSO=tcp+k2rpc://0.0.0.0:13000
 
 # start CPO on 2 cores
-./build/src/k2/cmd/controlPlaneOracle/cpo_main -c1 --tcp_endpoints ${CPO} 9001 --data_dir ${CPODIR} --enable_tx_checksum true --reactor-backend epoll --prometheus_port 63000 &
+./build/src/k2/cmd/controlPlaneOracle/cpo_main -c1 --tcp_endpoints ${CPO} 9001 --data_dir ${CPODIR} --enable_tx_checksum true --reactor-backend epoll --prometheus_port 63000 --assignment_timeout=1s &
 cpo_child_pid=$!
 
 # start nodepool on 1 cores


### PR DESCRIPTION
This allows a mix of checksum and non-checksum endpoints to still communicate with each-other