### PR TITLE
Add dto::Key interface to SKV client

### DIFF
--- a/src/k2/dto/K23SI.h
+++ b/src/k2/dto/K23SI.h
@@ -169,6 +169,11 @@ struct K23SIReadRequest {
     K23SI_MTR mtr; // the MTR for the issuing transaction
     // use the name "key" so that we can use common routing from CPO client
     Key key; // the key to read
+
+    K23SIReadRequest() = default;
+    K23SIReadRequest(Partition::PVID p, String cname, K23SI_MTR _mtr, Key _key) : 
+        pvid(std::move(p)), collectionName(std::move(cname)), mtr(std::move(_mtr)), key(std::move(_key)) {}
+
     K2_PAYLOAD_FIELDS(pvid, collectionName, mtr, key);
     friend std::ostream& operator<<(std::ostream& os, const K23SIReadRequest& r) {
         return os << "{" << "pvid=" << r.pvid << ", colName=" << r.collectionName
@@ -211,6 +216,14 @@ struct K23SIWriteRequest {
     Key key; // the key for the write
     SKVRecord::Storage value; // the value of the write
     std::vector<uint32_t> fieldsForPartialUpdate; // if size() > 0 then this is a partial update
+
+    K23SIWriteRequest() = default;
+    K23SIWriteRequest(Partition::PVID _pvid, String cname, K23SI_MTR _mtr, Key _trh, bool _isDelete, 
+                      bool _designateTRH, Key _key, SKVRecord::Storage _value, std::vector<uint32_t> _fields) :
+        pvid(std::move(_pvid)), collectionName(std::move(cname)), mtr(std::move(_mtr)), trh(std::move(_trh)),
+        isDelete(_isDelete), designateTRH(_designateTRH), key(std::move(_key)), value(std::move(_value)),
+        fieldsForPartialUpdate(std::move(_fields)) {}
+
     K2_PAYLOAD_FIELDS(pvid, collectionName, mtr, trh, isDelete, designateTRH, key, value, fieldsForPartialUpdate);
     friend std::ostream& operator<<(std::ostream& os, const K23SIWriteRequest& r) {
         return os << "{pvid=" << r.pvid << ", colName=" << r.collectionName

--- a/src/k2/module/k23si/client/k23si_client.cpp
+++ b/src/k2/module/k23si/client/k23si_client.cpp
@@ -79,12 +79,12 @@ void K2TxnHandle::makeHeartbeatTimer() {
 
 std::unique_ptr<dto::K23SIReadRequest> K2TxnHandle::makeReadRequest(
                         const dto::Key& key, const String& collection) const {
-    return std::make_unique<dto::K23SIReadRequest>(dto::K23SIReadRequest{
+    return std::make_unique<dto::K23SIReadRequest>(
         dto::Partition::PVID(), // Will be filled in by PartitionRequest
         collection,
         _mtr,
         key
-    });
+    );
 }
 
 template <>
@@ -174,7 +174,7 @@ std::unique_ptr<dto::K23SIWriteRequest> K2TxnHandle::makeWriteRequest(dto::SKVRe
     }
     _write_set.push_back(key);
 
-    return std::make_unique<dto::K23SIWriteRequest>(dto::K23SIWriteRequest{
+    return std::make_unique<dto::K23SIWriteRequest>(
         dto::Partition::PVID(), // Will be filled in by PartitionRequest
         record.collectionName,
         _mtr,
@@ -184,7 +184,7 @@ std::unique_ptr<dto::K23SIWriteRequest> K2TxnHandle::makeWriteRequest(dto::SKVRe
         key,
         record.storage.share(),
         std::vector<uint32_t>()
-    });
+    );
 }
 
 std::unique_ptr<dto::K23SIWriteRequest> K2TxnHandle::makePartialUpdateRequest(dto::SKVRecord& record,

--- a/src/k2/module/k23si/client/k23si_client.cpp
+++ b/src/k2/module/k23si/client/k23si_client.cpp
@@ -77,7 +77,18 @@ void K2TxnHandle::makeHeartbeatTimer() {
     });
 }
 
-std::unique_ptr<dto::K23SIReadRequest> K2TxnHandle::makeReadRequest(const dto::SKVRecord& record) const {
+std::unique_ptr<dto::K23SIReadRequest> K2TxnHandle::makeReadRequest(
+                        const dto::Key& key, const String& collection) const {
+    return std::make_unique<dto::K23SIReadRequest>(dto::K23SIReadRequest{
+        dto::Partition::PVID(), // Will be filled in by PartitionRequest
+        collection,
+        _mtr,
+        key
+    });
+}
+
+template <>
+seastar::future<ReadResult<dto::SKVRecord>> K2TxnHandle::read(dto::SKVRecord record) {
     for (const String& key : record.partitionKeys) {
         if (key == "") {
             throw K23SIClientException("Partition key field not set for read request");
@@ -89,13 +100,59 @@ std::unique_ptr<dto::K23SIReadRequest> K2TxnHandle::makeReadRequest(const dto::S
         }
     }
 
-    return std::make_unique<dto::K23SIReadRequest>(dto::K23SIReadRequest{
-        dto::Partition::PVID(), // Will be filled in by PartitionRequest
-        record.collectionName,
-        _mtr,
-        record.getKey()
-    });
+    return read(record.getKey(), record.collectionName);
 }
+
+seastar::future<ReadResult<dto::SKVRecord>> K2TxnHandle::read(dto::Key key, String collection) {
+    if (!_valid) {
+        return seastar::make_exception_future<ReadResult<dto::SKVRecord>>(
+                K23SIClientException("Invalid use of K2TxnHandle"));
+    }
+    if (_failed) {
+        return seastar::make_ready_future<ReadResult<dto::SKVRecord>>(
+                ReadResult<dto::SKVRecord>(_failed_status, dto::SKVRecord()));
+    }
+
+    K2INFO("making request for: " << key.schemaName << " " << collection);
+    std::unique_ptr<dto::K23SIReadRequest> request = makeReadRequest(key, collection);
+
+    _client->read_ops++;
+    _ongoing_ops++;
+
+    return _cpo_client->PartitionRequest
+        <dto::K23SIReadRequest, dto::K23SIReadResponse, dto::Verbs::K23SI_READ>
+        (_options.deadline, *request).
+        then([this, schemaName=std::move(key.schemaName), &collName=request->collectionName] (auto&& response) {
+            auto& [status, k2response] = response;
+            checkResponseStatus(status);
+            _ongoing_ops--;
+
+            K2INFO("got status: " << status);
+            if (!status.is2xxOK()) {
+                return seastar::make_ready_future<ReadResult<dto::SKVRecord>>(
+                            ReadResult<dto::SKVRecord>(std::move(status), SKVRecord()));
+            }
+
+            return _client->getSchema(collName, schemaName, k2response.value.schemaVersion)
+            .then([s=std::move(status), storage=std::move(k2response.value), &collName] (auto&& response) mutable {
+                auto& [status, schema_ptr] = response;
+                K2INFO("got status for getSchema: " << status);
+
+                if (!status.is2xxOK()) {
+                    return seastar::make_ready_future<ReadResult<dto::SKVRecord>>(
+                        ReadResult<dto::SKVRecord>(
+                        dto::K23SIStatus::OperationNotAllowed("Matching schema could not be found"), 
+                        SKVRecord()));
+                }
+
+                SKVRecord skv_record(collName, schema_ptr);
+                skv_record.storage = std::move(storage);
+                return seastar::make_ready_future<ReadResult<dto::SKVRecord>>(
+                        ReadResult<dto::SKVRecord>(std::move(s), std::move(skv_record)));
+            });
+        }).finally([r = std::move(request)] () { (void)r; });
+}
+
 
 std::unique_ptr<dto::K23SIWriteRequest> K2TxnHandle::makeWriteRequest(dto::SKVRecord& record, bool erase) {
     for (const String& key : record.partitionKeys) {
@@ -131,9 +188,7 @@ std::unique_ptr<dto::K23SIWriteRequest> K2TxnHandle::makeWriteRequest(dto::SKVRe
 }
 
 std::unique_ptr<dto::K23SIWriteRequest> K2TxnHandle::makePartialUpdateRequest(dto::SKVRecord& record,
-                    std::vector<uint32_t> fieldsForPartialUpdate) {
-        dto::Key key = record.getKey();
-
+                    std::vector<uint32_t> fieldsForPartialUpdate, dto::Key&& key) {
         if (!_write_set.size()) {
             _trh_key = key;
             _trh_collection = record.collectionName;
@@ -147,7 +202,7 @@ std::unique_ptr<dto::K23SIWriteRequest> K2TxnHandle::makePartialUpdateRequest(dt
             _trh_key,
             false, // Partial update cannot be a delete
             _write_set.size() == 1,
-            key,
+            std::move(key),
             record.storage.share(),
             fieldsForPartialUpdate
         });

--- a/src/k2/module/k23si/client/k23si_client.h
+++ b/src/k2/module/k23si/client/k23si_client.h
@@ -291,7 +291,7 @@ public:
                     PartialUpdateResult(dto::K23SIStatus::BadParameter("error parameter: fieldsForPartialUpdate")) );
         }
 
-        return partialUpdate(record, fieldsForPartialUpdate, std::move(key));
+        return partialUpdate(record, std::move(fieldsForPartialUpdate), std::move(key));
     }
 
     template <typename T1>

--- a/test/k23si/SKVClientTest.cpp
+++ b/test/k23si/SKVClientTest.cpp
@@ -81,6 +81,7 @@ public:  // application lifespan
             .then([this] { return runScenario04(); })
             .then([this] { return runScenario05(); })
             .then([this] { return runScenario06(); })
+            .then([this] { return runScenario07(); })
             .then([this] {
                 K2INFO("======= All tests passed ========");
                 exitcode = 0;
@@ -872,8 +873,8 @@ seastar::future<> runScenario05() {
                                         
                     K2EXPECT(*partkey, "partkey_s05");
                     K2EXPECT(*rangekey, "rangekey_s05");
-                    K2EXPECT(*data2, ""); // parital update value-field to null
-                    K2EXPECT(*data1, ""); // parital update value-field to null
+                    K2EXPECT(data2.has_value(), false); // parital update value-field to null
+                    K2EXPECT(data1.has_value(), false); // parital update value-field to null
                 })
                 // case 6: update fields from null to null
                 .then([&] {
@@ -916,8 +917,8 @@ seastar::future<> runScenario05() {
                                         
                     K2EXPECT(*partkey, "partkey_s05");
                     K2EXPECT(*rangekey, "rangekey_s05");
-                    K2EXPECT(*data1, ""); // parital update null-field to null
-                    K2EXPECT(*data2, ""); // parital update null-field to null
+                    K2EXPECT(data1.has_value(), false); // parital update null-field to null
+                    K2EXPECT(data2.has_value(), false); // parital update null-field to null
                 });
             }) // end do-with txnHandle
             .then([] {
@@ -957,6 +958,80 @@ seastar::future<> runScenario06() {
                 });
         });
     });
+}
+
+// Read and partial update using key-oriented interface
+seastar::future<> runScenario07() {
+    K2INFO("Scenario 07");
+    k2::K2TxnOptions options{};
+    options.syncFinalize = true;
+    return _client.beginTxn(options)
+    .then([this] (k2::K2TxnHandle&& txn) {
+        return seastar::do_with(
+            std::move(txn), k2::dto::Key(), std::shared_ptr<k2::dto::Schema>(),
+            [this] (k2::K2TxnHandle& txnHandle, k2::dto::Key& key, std::shared_ptr<k2::dto::Schema>& my_schema) {
+                return _client.getSchema(collname, "schema", 1)
+                .then([this, &txnHandle, &key, &my_schema] (auto&& response) {
+                    auto& [status, schemaPtr] = response;
+                    K2EXPECT(status.is2xxOK(), true);
+
+                    k2::dto::SKVRecord record(collname, schemaPtr);
+                    record.serializeNext<k2::String>("partkey07");
+                    record.serializeNext<k2::String>("rangekey07");
+                    record.serializeNext<k2::String>("data1");
+                    record.serializeNext<k2::String>("data2");
+                    key = record.getKey();
+                    my_schema = schemaPtr;
+
+                    return txnHandle.write<k2::dto::SKVRecord>(record);
+                })
+                .then([](auto&& response) {
+                    K2EXPECT(response.status, k2::dto::K23SIStatus::Created);
+                    return seastar::make_ready_future<>();
+                })
+                .then([this, &txnHandle, &key, &my_schema] () {
+                    // Partial update without needing to serialize key
+                    k2::dto::SKVRecord record(collname, my_schema);
+                    record.skipNext();
+                    record.skipNext();
+                    record.serializeNext<k2::String>("partialupdate");
+                    record.skipNext();
+                    std::vector<uint32_t> fields = {2};
+
+                    return txnHandle.partialUpdate(record, fields, key);
+                })
+                .then([](auto&& response) {
+                    K2EXPECT(response.status, k2::dto::K23SIStatus::Created);
+                    return seastar::make_ready_future<>();
+                })
+                .then([&txnHandle, &key, &my_schema] () {
+                    // Read without needing to serialize key again
+                    return txnHandle.read(key, collname);
+                })
+                .then([](k2::ReadResult<k2::dto::SKVRecord>&& response) {
+                    K2EXPECT(response.status, k2::dto::K23SIStatus::OK);
+                                
+                    std::optional<k2::String> partkey = response.value.deserializeNext<k2::String>();
+                    std::optional<k2::String> rangekey = response.value.deserializeNext<k2::String>();
+                    std::optional<k2::String> data1 = response.value.deserializeNext<k2::String>();
+                    std::optional<k2::String> data2 = response.value.deserializeNext<k2::String>();
+                                        
+                    K2EXPECT(*partkey, "partkey07");
+                    K2EXPECT(*rangekey, "rangekey07");
+                    K2EXPECT(*data1, "partialupdate");
+                    K2EXPECT(*data2, "data2");
+
+                    return seastar::make_ready_future<>();
+                })
+                .then([&txnHandle] () {
+                    return txnHandle.end(false);
+                })
+                .then([] (auto&& response) {
+                    K2EXPECT(response.status, k2::dto::K23SIStatus::OK);
+                    return seastar::make_ready_future<>();
+                });
+            }); // end do_with
+        });
 }
 
 };  // class SKVClientTest


### PR DESCRIPTION
This is to support rowID for SQL and allow more efficient operations when the key can be reused to avoid extra serialization.