### PR TITLE
During TSO client initialization, when there are app requests (for ti…

### DIFF
--- a/src/k2/cmd/demo/tso_sample_app.cpp
+++ b/src/k2/cmd/demo/tso_sample_app.cpp
@@ -141,7 +141,7 @@ int main(int argc, char **argv)
     app.addOptions()
     ("tso_endpoint", bpo::value<k2::String>()->default_value("tcp+k2rpc://127.0.0.1:9000"), "URL of Timestamp Oracle (TSO), e.g. 'tcp+k2rpc://192.168.1.2:12345'");
 
-    app.addApplet<k2::TSO_ClientLib>(1s);
+    app.addApplet<k2::TSO_ClientLib>();
     app.addApplet<k2::TSOService>();
     app.addApplet<k2::sampleTSOApp>();
 

--- a/src/k2/cmd/nodepool/nodepool_main.cpp
+++ b/src/k2/cmd/nodepool/nodepool_main.cpp
@@ -41,7 +41,7 @@ int main(int argc, char** argv) {
         ("k23si_query_push_limit", bpo::value<uint32_t>(), "Min records in response needed to avoid a push during query processing")
         ("k23si_persistence_endpoints", bpo::value<std::vector<k2::String>>()->multitoken()->default_value(std::vector<k2::String>()), "A space-delimited list of k2 persistence endpoints, each core will pick one endpoint");
 
-    app.addApplet<k2::TSO_ClientLib>(10ms);
+    app.addApplet<k2::TSO_ClientLib>();
     app.addApplet<k2::CollectionMetadataCache>();
     app.addApplet<k2::NodePoolMonitor>();
     app.addApplet<k2::AssignmentManager>();

--- a/src/k2/cmd/tpcc/tpcc_client.cpp
+++ b/src/k2/cmd/tpcc/tpcc_client.cpp
@@ -368,7 +368,7 @@ int main(int argc, char** argv) {;
         ("cpo_request_timeout", bpo::value<ParseableDuration>(), "CPO request timeout")
         ("cpo_request_backoff", bpo::value<ParseableDuration>(), "CPO request backoff");
 
-    app.addApplet<k2::TSO_ClientLib>(0s);
+    app.addApplet<k2::TSO_ClientLib>();
     app.addApplet<Client>();
     return app.start(argc, argv);
 }

--- a/src/k2/cmd/txbench/k23sibench_client.cpp
+++ b/src/k2/cmd/txbench/k23sibench_client.cpp
@@ -321,7 +321,7 @@ private://metrics
 
 int main(int argc, char** argv) {
     k2::App app("K23SIBenchClient");
-    app.addApplet<k2::TSO_ClientLib>(0s);
+    app.addApplet<k2::TSO_ClientLib>();
     app.addApplet<Client>();
     app.addOptions()
         ("data_size", bpo::value<uint32_t>()->default_value(512), "How many bytes to write in records")

--- a/src/k2/tso/client/tso_clientlib.cpp
+++ b/src/k2/tso/client/tso_clientlib.cpp
@@ -174,7 +174,7 @@ seastar::future<Timestamp> TSO_ClientLib::GetTimestampFromTSO(const TimePoint& r
     {
         // if not ready to serve yet, wait on a new ready promise then call get this function self, as each promise can only chain one then lamda
         K2INFO("TSO Timestamp requested when not ready to serve, request pending...");
-        _promiseReadyToServe.emplace_back(seastar::promise<>());
+        _promiseReadyToServe.emplace_back();
         return _promiseReadyToServe.back().get_future()
             .then([this, triggeredTime = requestLocalTime] { return GetTimestampFromTSO(triggeredTime); });
     }

--- a/src/k2/tso/client/tso_clientlib.cpp
+++ b/src/k2/tso/client/tso_clientlib.cpp
@@ -37,13 +37,13 @@ namespace k2
 
 seastar::future<> TSO_ClientLib::start()
 {
+    // TODO: instead of using config value TSOServerURL, we need to change later to CPO URL and get URLs of TSO servers from there instead.
     K2INFO("start with server url: " << TSOServerURL());
     _stopped = false;
 
     _tSOServerURLs.emplace_back(TSOServerURL());
     // for now we use the first server URL only, in the future, allow to check other server in case first one is not available
-    return seastar::sleep(_startDelay)
-        .then([this] () mutable { return DiscoverServerWorkerEndPoints(_tSOServerURLs[0]); });
+    return DiscoverServerWorkerEndPoints(_tSOServerURLs[0]);
 }
 
 seastar::future<> TSO_ClientLib::gracefulStop() {
@@ -134,6 +134,16 @@ seastar::future<> TSO_ClientLib::DiscoverServerWorkerEndPoints(const k2::String&
 
             std::shuffle(_curTSOServerWorkerEndPoints.begin(), _curTSOServerWorkerEndPoints.end(), ranAlg);
 
+            // set ready to serve requests
+            _readyToServe = true;
+            for (auto&& readyPromise : _promiseReadyToServe)
+            {
+                readyPromise.set_value();
+            }
+            // we have signaled any waiting request so we should free the memory now. 
+            _promiseReadyToServe.clear();
+            K2INFO("Successfully getting remote data endpoint, ready to serve.");
+
             return seastar::make_ready_future<>();
         })
         .then_wrapped([this](auto&& fut) {
@@ -158,6 +168,17 @@ seastar::future<Timestamp> TSO_ClientLib::GetTimestampFromTSO(const TimePoint& r
         K2INFO("Stopping issuing timestamp since we were stopped");
         return seastar::make_exception_future<Timestamp>(TSOClientLibShutdownException());
     }
+
+    // TSO client may not yet ready (discover the tso server endpoint), let the request wait in this case.
+    if (!_readyToServe)
+    {
+        // if not ready to serve yet, wait on a new ready promise then call get this function self, as each promise can only chain one then lamda
+        K2INFO("TSO Timestamp requested when not ready to serve, request pending...");
+        _promiseReadyToServe.emplace_back(seastar::promise<>());
+        return _promiseReadyToServe.back().get_future()
+            .then([this, triggeredTime = requestLocalTime] { return GetTimestampFromTSO(triggeredTime); });
+    }
+    
 
     // step 1/4 - sanity check if we got out of order client timestamp request
     if (requestLocalTime < _lastSeenRequestTime)

--- a/src/k2/tso/client/tso_clientlib.h
+++ b/src/k2/tso/client/tso_clientlib.h
@@ -45,9 +45,7 @@ class TSO_ClientLib
 {
 public:
     // constructor
-    // startDelay - a delay/sleep duration in start(). This is for testing purpose where the client lib start need to delay waiting for server starts
-    // TODO: instead of pass in TSOServerURL, we need to change later to CPO URL and get URLs of TSO servers from there instead.
-    TSO_ClientLib(Duration startDelay) : _startDelay(startDelay) { K2INFO("ctor");}
+    TSO_ClientLib() { K2INFO("ctor");}
 
     ~TSO_ClientLib() { K2INFO("dtor");}
 
@@ -73,6 +71,10 @@ private:
 
     bool _stopped{false};
 
+    // a promise/signal for ready to serve request when they come earlier than TSO server end point set up
+    volatile bool _readyToServe {false};
+    std::vector<seastar::promise<>> _promiseReadyToServe;  // have to use a seperate promise/future for each early request to hold on
+
     // a vector of TSO servers
     // TODO: currently just use one, we will use multiple later, with more info like location(local or remote), availability status etc. Also get them from CPO instead.
     //       the CPO should give the list of TSO servers in preference order in the vector.
@@ -89,9 +91,6 @@ private:
     // For correctness verification purpose, we keep track of the latest _triggeredTime of the batches whenever we issued timestamp from a (new) batch
     // So that if an out-of-order old batch comes in, we will discard it.
     TimePoint _lastIssuedBatchTriggeredTime;
-
-    // startDelay - a delay/sleep duration in start(). This is for testing purpose where the client lib start need to delay waiting for server starts
-    Duration _startDelay;
 
     // info about queued request that is promised but not yet fulfilled
     struct ClientRequest

--- a/src/k2/tso/client/tso_clientlib.h
+++ b/src/k2/tso/client/tso_clientlib.h
@@ -72,7 +72,7 @@ private:
     bool _stopped{false};
 
     // a promise/signal for ready to serve request when they come earlier than TSO server end point set up
-    volatile bool _readyToServe {false};
+    bool _readyToServe {false};
     std::vector<seastar::promise<>> _promiseReadyToServe;  // have to use a seperate promise/future for each early request to hold on
 
     // a vector of TSO servers

--- a/test/dto/PartitionTest.cpp
+++ b/test/dto/PartitionTest.cpp
@@ -187,7 +187,7 @@ int main(int argc, char** argv) {
         ("tcp_remotes", bpo::value<std::vector<k2::String>>()->multitoken()->default_value(std::vector<k2::String>()), "A list(space-delimited) of endpoints to assign in the test collection")
         ("tso_endpoint", bpo::value<k2::String>(), "URL of Timestamp Oracle (TSO), e.g. 'tcp+k2rpc://192.168.1.2:12345'")
         ("cpo", bpo::value<k2::String>(), "URL of Control Plane Oracle (CPO), e.g. 'tcp+k2rpc://192.168.1.2:12345'");
-    app.addApplet<k2::TSO_ClientLib>(0s);
+    app.addApplet<k2::TSO_ClientLib>();
     app.addApplet<PartitionTest>();
     return app.start(argc, argv);
 }

--- a/test/k23si/QueryTest.cpp
+++ b/test/k23si/QueryTest.cpp
@@ -552,7 +552,7 @@ int main(int argc, char** argv) {
         ("tcp_remotes", bpo::value<std::vector<k2::String>>()->multitoken()->default_value(std::vector<k2::String>()), "A list(space-delimited) of endpoints to assign in the test collection")
         ("tso_endpoint", bpo::value<k2::String>(), "URL of Timestamp Oracle (TSO), e.g. 'tcp+k2rpc://192.168.1.2:12345'")
         ("cpo", bpo::value<k2::String>(), "URL of Control Plane Oracle (CPO), e.g. 'tcp+k2rpc://192.168.1.2:12345'");
-    app.addApplet<k2::TSO_ClientLib>(0s);
+    app.addApplet<k2::TSO_ClientLib>();
     app.addApplet<QueryTest>();
     return app.start(argc, argv);
 }

--- a/test/k23si/SKVClientTest.cpp
+++ b/test/k23si/SKVClientTest.cpp
@@ -1124,7 +1124,7 @@ int main(int argc, char** argv) {
         ("tcp_remotes", bpo::value<std::vector<k2::String>>()->multitoken()->default_value(std::vector<k2::String>()), "A list(space-delimited) of endpoints to assign in the test collection")
         ("tso_endpoint", bpo::value<k2::String>(), "URL of Timestamp Oracle (TSO), e.g. 'tcp+k2rpc://192.168.1.2:12345'")
         ("cpo", bpo::value<k2::String>(), "URL of Control Plane Oracle (CPO), e.g. 'tcp+k2rpc://192.168.1.2:12345'");
-    app.addApplet<k2::TSO_ClientLib>(0s);
+    app.addApplet<k2::TSO_ClientLib>();
     app.addApplet<SKVClientTest>();
     return app.start(argc, argv);
 }


### PR DESCRIPTION
…mestamp) before TSO server end point is discoverd, let's these request wait after discovery is done.