### PR TITLE
Heartbeat fix

### DIFF
--- a/src/k2/module/k23si/TxnManager.cpp
+++ b/src/k2/module/k23si/TxnManager.cpp
@@ -60,11 +60,15 @@ seastar::future<> TxnManager::start(const String& collectionName, dto::Timestamp
     _collectionName = collectionName;
     _hbDeadline = hbDeadline;
     updateRetentionTimestamp(rts);
+    // We need to call this now so that a recent time is used for a new
+    // transaction's heartbeat expiry if it comes in before the first heartbeat timer callback
+    CachedSteadyClock::now(true);
+
     _hbTimer.set_callback([this] {
         K2LOG_D(log::skvsvr, "txn manager check hb");
         _hbTask = _hbTask.then([this] {
             // refresh the clock
-            auto now = Clock::now();
+            auto now = CachedSteadyClock::now(true);
             return seastar::do_until(
                 [this, now] {
                     auto noHB = _hblist.empty() || _hblist.front().hbExpiry > now;
@@ -168,7 +172,7 @@ TxnRecord& TxnManager::_createRecord(dto::TxnId txnId) {
         rec.txnId = it.first->first;
         rec.state = dto::TxnRecordState::Created;
         rec.rwExpiry = txnId.mtr.timestamp;
-        rec.hbExpiry = Clock::now() + 2*_hbDeadline;
+        rec.hbExpiry = CachedSteadyClock::now() + 2*_hbDeadline;
 
         _hblist.push_back(rec);
         _rwlist.push_back(rec);

--- a/src/k2/module/k23si/TxnManager.cpp
+++ b/src/k2/module/k23si/TxnManager.cpp
@@ -381,7 +381,7 @@ seastar::future<> TxnManager::_heartbeat(TxnRecord& rec) {
     // set state: no change
     // manage hb expiry
     rec.unlinkHB(_hblist);
-    rec.hbExpiry = Clock::now() + 2*_hbDeadline;
+    rec.hbExpiry = CachedSteadyClock::now() + 2*_hbDeadline;
     _hblist.push_back(rec);
     // manage rw expiry: no change
     // persist if needed: no need

--- a/src/k2/module/k23si/TxnManager.cpp
+++ b/src/k2/module/k23si/TxnManager.cpp
@@ -64,7 +64,7 @@ seastar::future<> TxnManager::start(const String& collectionName, dto::Timestamp
         K2LOG_D(log::skvsvr, "txn manager check hb");
         _hbTask = _hbTask.then([this] {
             // refresh the clock
-            auto now = CachedSteadyClock::now(true);
+            auto now = Clock::now();
             return seastar::do_until(
                 [this, now] {
                     auto noHB = _hblist.empty() || _hblist.front().hbExpiry > now;
@@ -168,7 +168,7 @@ TxnRecord& TxnManager::_createRecord(dto::TxnId txnId) {
         rec.txnId = it.first->first;
         rec.state = dto::TxnRecordState::Created;
         rec.rwExpiry = txnId.mtr.timestamp;
-        rec.hbExpiry = CachedSteadyClock::now() + 2*_hbDeadline;
+        rec.hbExpiry = Clock::now() + 2*_hbDeadline;
 
         _hblist.push_back(rec);
         _rwlist.push_back(rec);
@@ -377,7 +377,7 @@ seastar::future<> TxnManager::_heartbeat(TxnRecord& rec) {
     // set state: no change
     // manage hb expiry
     rec.unlinkHB(_hblist);
-    rec.hbExpiry = CachedSteadyClock::now() + 2*_hbDeadline;
+    rec.hbExpiry = Clock::now() + 2*_hbDeadline;
     _hblist.push_back(rec);
     // manage rw expiry: no change
     // persist if needed: no need

--- a/test/integration/heartbeat.sh
+++ b/test/integration/heartbeat.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+topname=$(dirname "$0")
+cd ${topname}/../..
+set -e
+CPODIR=/tmp/___cpo_integ_test
+rm -rf ${CPODIR}
+EPS="tcp+k2rpc://0.0.0.0:10000"
+
+PERSISTENCE=tcp+k2rpc://0.0.0.0:12001
+CPO=tcp+k2rpc://0.0.0.0:9000
+TSO=tcp+k2rpc://0.0.0.0:13000
+COMMON_ARGS="--poll-mode --thread-affinity false --enable_tx_checksum true"
+
+# start CPO on 1 cores
+./build/src/k2/cmd/controlPlaneOracle/cpo_main -c1 --tcp_endpoints ${CPO} --data_dir ${CPODIR} --enable_tx_checksum true --reactor-backend epoll --thread-affinity false --prometheus_port 63000 --assignment_timeout=1s --heartbeat_deadline=1s &
+cpo_child_pid=$!
+
+# start nodepool on 1 cores
+./build/src/k2/cmd/nodepool/nodepool -c1 --tcp_endpoints ${EPS} --k23si_persistence_endpoint ${PERSISTENCE} ${COMMON_ARGS} --prometheus_port 63001 -m 4G --k23si_cpo_endpoint ${CPO} --tso_endpoint ${TSO} &
+nodepool_child_pid=$!
+
+# start persistence on 1 cores
+./build/src/k2/cmd/persistence/persistence -c1 --tcp_endpoints ${PERSISTENCE} ${COMMON_ARGS} --prometheus_port 63002 &
+persistence_child_pid=$!
+
+# start tso on 2 cores
+./build/src/k2/cmd/tso/tso -c2 --tcp_endpoints ${TSO} 13001 --enable_tx_checksum true --reactor-backend epoll --prometheus_port 63003 --thread-affinity false &
+tso_child_pid=$!
+
+function finish {
+  # cleanup code
+  rm -rf ${CPODIR}
+
+  kill ${cpo_child_pid}
+  echo "Waiting for cpo child pid: ${cpo_child_pid}"
+  wait ${cpo_child_pid}
+
+  kill ${nodepool_child_pid}
+  echo "Waiting for nodepool child pid: ${nodepool_child_pid}"
+  wait ${nodepool_child_pid}
+
+  kill ${persistence_child_pid}
+  echo "Waiting for persistence child pid: ${persistence_child_pid}"
+  wait ${persistence_child_pid}
+
+  kill ${tso_child_pid}
+  echo "Waiting for tso child pid: ${tso_child_pid}"
+  wait ${tso_child_pid}
+}
+trap finish EXIT
+
+sleep 5
+
+./build/test/k23si/heartbeat_test --cpo ${CPO} --tcp_remotes ${EPS} ${COMMON_ARGS} -m 16G --prometheus_port 63100 --tso_endpoint ${TSO} --partition_request_timeout=1s --hugepages

--- a/test/integration/heartbeat.sh
+++ b/test/integration/heartbeat.sh
@@ -15,17 +15,18 @@ COMMON_ARGS="--poll-mode --thread-affinity false --enable_tx_checksum true"
 ./build/src/k2/cmd/controlPlaneOracle/cpo_main -c1 --tcp_endpoints ${CPO} --data_dir ${CPODIR} --enable_tx_checksum true --reactor-backend epoll --thread-affinity false --prometheus_port 63000 --assignment_timeout=1s --heartbeat_deadline=1s &
 cpo_child_pid=$!
 
-# start nodepool on 1 cores
-./build/src/k2/cmd/nodepool/nodepool -c1 --tcp_endpoints ${EPS} --k23si_persistence_endpoint ${PERSISTENCE} ${COMMON_ARGS} --prometheus_port 63001 -m 4G --k23si_cpo_endpoint ${CPO} --tso_endpoint ${TSO} &
-nodepool_child_pid=$!
+# start tso on 2 cores
+./build/src/k2/cmd/tso/tso -c2 --tcp_endpoints ${TSO} 13001 --enable_tx_checksum true --reactor-backend epoll --prometheus_port 63003 --thread-affinity false &
+tso_child_pid=$!
 
 # start persistence on 1 cores
 ./build/src/k2/cmd/persistence/persistence -c1 --tcp_endpoints ${PERSISTENCE} ${COMMON_ARGS} --prometheus_port 63002 &
 persistence_child_pid=$!
 
-# start tso on 2 cores
-./build/src/k2/cmd/tso/tso -c2 --tcp_endpoints ${TSO} 13001 --enable_tx_checksum true --reactor-backend epoll --prometheus_port 63003 --thread-affinity false &
-tso_child_pid=$!
+# start nodepool on 1 cores
+./build/src/k2/cmd/nodepool/nodepool -c1 --tcp_endpoints ${EPS} --k23si_persistence_endpoint ${PERSISTENCE} ${COMMON_ARGS} --prometheus_port 63001 -m 4G --k23si_cpo_endpoint ${CPO} --tso_endpoint ${TSO} &
+nodepool_child_pid=$!
+
 
 function finish {
   # cleanup code

--- a/test/k23si/CMakeLists.txt
+++ b/test/k23si/CMakeLists.txt
@@ -11,6 +11,7 @@ add_executable (3si_txn_test ${HEADERS} 3SITxnTest.cpp)
 add_executable (skv_client_test ${HEADERS} SKVClientTest.cpp)
 add_executable (query_test ${HEADERS} QueryTest.cpp)
 add_executable (expression_test ${HEADERS} ExpressionTest.cpp)
+add_executable (heartbeat_test ${HEADERS} HeartbeatTest.cpp)
 
 target_link_libraries (k23si_test PRIVATE appbase Seastar::seastar k23si)
 target_link_libraries (read_cache_test PRIVATE k23si)
@@ -22,6 +23,7 @@ target_link_libraries (3si_txn_test PRIVATE appbase dto transport Seastar::seast
 target_link_libraries (skv_client_test PRIVATE tso_client k23si_client cpo_client appbase dto transport Seastar::seastar)
 target_link_libraries (query_test PRIVATE tso_client k23si_client cpo_client appbase dto transport Seastar::seastar)
 target_link_libraries (expression_test PRIVATE dto transport Seastar::seastar)
+target_link_libraries (heartbeat_test PRIVATE tso_client k23si_client cpo_client appbase dto transport Seastar::seastar)
 
 add_test(NAME readcache COMMAND read_cache_test)
 add_test(NAME skv_record COMMAND skv_record_test)

--- a/test/k23si/HeartbeatTest.cpp
+++ b/test/k23si/HeartbeatTest.cpp
@@ -1,0 +1,193 @@
+/*
+MIT License
+
+Copyright(c) 2021 Futurewei Cloud
+
+    Permission is hereby granted,
+    free of charge, to any person obtaining a copy of this software and associated documentation files(the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and / or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions :
+
+    The above copyright notice and this permission notice shall be included in all copies
+    or
+    substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS",
+    WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+    DAMAGES OR OTHER
+    LIABILITY,
+    WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+*/
+
+#include <k2/appbase/AppEssentials.h>
+#include <k2/appbase/Appbase.h>
+#include <k2/cpo/client/CPOClient.h>
+#include <k2/module/k23si/client/k23si_client.h>
+#include <seastar/core/sleep.hh>
+using namespace k2;
+#include "Log.h"
+const char* collname = "k23si_test_collection";
+
+class HeartbeatTest {
+
+public:  // application lifespan
+    HeartbeatTest() : _client(K23SIClientConfig()) {}
+
+    // required for seastar::distributed interface
+    seastar::future<> gracefulStop() {
+        K2LOG_I(log::k23si, "stop");
+        return std::move(_testFuture);
+    }
+
+    seastar::future<> start(){
+        K2LOG_I(log::k23si, "start");
+
+        _testTimer.set_callback([this] {
+            _testFuture = seastar::make_ready_future()
+            .then([this] () {
+                return _client.start();
+            })
+            .then([this] {
+                K2LOG_I(log::k23si, "Creating test collection...");
+                return _client.makeCollection(collname);
+            })
+            .then([](auto&& status) {
+                K2EXPECT(log::k23si, status.is2xxOK(), true);
+            })
+            .then([this] () {
+                dto::Schema schema;
+                schema.name = "schema";
+                schema.version = 1;
+                schema.fields = std::vector<dto::SchemaField> {
+                        {dto::FieldType::STRING, "partition", false, false},
+                        {dto::FieldType::STRING, "range", false, false},
+                        {dto::FieldType::STRING, "f1", false, false},
+                        {dto::FieldType::STRING, "f2", false, false},
+                };
+
+                schema.setPartitionKeyFieldsByName(std::vector<String>{"partition"});
+                schema.setRangeKeyFieldsByName(std::vector<String> {"range"});
+
+                return _client.createSchema(collname, std::move(schema));
+            })
+            .then([] (auto&& result) {
+                K2EXPECT(log::k23si, result.status.is2xxOK(), true);
+            })
+            .then([this] { return runScenario(); })
+            .then([this] {
+                K2LOG_I(log::k23si, "======= All tests passed ========");
+                exitcode = 0;
+            })
+            .handle_exception([this](auto exc) {
+                try {
+                    std::rethrow_exception(exc);
+                } catch (std::exception& e) {
+                    K2LOG_E(log::k23si, "======= Test failed with exception [{}] ========", e.what());
+                    exitcode = -1;
+                } catch (...) {
+                    K2LOG_E(log::k23si, "Test failed with unknown exception");
+                    exitcode = -1;
+                }
+            })
+            .finally([this] {
+                K2LOG_I(log::k23si, "======= Test ended ========");
+                seastar::engine().exit(exitcode);
+            });
+        });
+
+        _testTimer.arm(0ms);
+        return seastar::make_ready_future();
+    }
+
+private:
+    int exitcode = -1;
+
+    seastar::timer<> _testTimer;
+    seastar::future<> _testFuture = seastar::make_ready_future();
+    seastar::future<> _writeFuture = seastar::make_ready_future();
+    K2TxnHandle _txn;
+    dto::SKVRecord _record;
+    TimePoint _start;
+
+    K23SIClient _client;
+
+public: // tests
+
+
+// This queues up writes for a specified duration. It is designed to test the heartbeat
+// mechanism in the presence of heavy load. It should be used in --poll-mode
+seastar::future<> runScenario() {
+    K2TxnOptions options{};
+    options.syncFinalize = true;
+    return _client.beginTxn(options)
+    .then([this] (K2TxnHandle&& txn) {
+        _txn = std::move(txn);
+    })
+    .then([this] () {
+        return _client.getSchema(collname, "schema", 1)
+        .then([this] (auto&& response) {
+            auto& [status, schemaPtr] = response;
+            K2EXPECT(log::k23si, status.is2xxOK(), true);
+
+            _record = dto::SKVRecord(collname, schemaPtr);
+            _record.serializeNext<String>("partkey");
+            _record.serializeNext<String>("rangekey");
+            _record.serializeNext<String>("data1");
+            _record.serializeNext<String>("data2");
+        });
+    })
+    .then([this] () {
+        Deadline<> deadline(50ms);
+
+        K2LOG_I(log::k23si, "start time: {}", Clock::now());
+        return seastar::do_until(
+            [this, d=std::move(deadline)] () { return d.isOver(); },
+            [this] () {
+
+                _writeFuture = _writeFuture.then([this] () {
+                    return _txn.write<dto::SKVRecord>(_record);
+                })
+                .then([this](auto&& response) {
+                    if (!response.status.is2xxOK()) {
+                        K2LOG_W(log::k23si, "failed write: {}", response.status);
+                    }
+                    K2EXPECT(log::k23si, response.status, dto::K23SIStatus::Created);
+                    return seastar::make_ready_future<>();
+                });
+                return seastar::make_ready_future<>();
+        });
+    })
+    .then([this] () {
+        _start = k2::Clock::now();
+
+        return std::move(_writeFuture);
+    })
+    .then([this] () {
+        auto end = k2::Clock::now();
+        auto dur = end - _start;
+        K2LOG_I(log::k23si, "Flush time: {}", dur);
+
+        return _txn.end(true);
+    })
+    .then([](auto&& response) {
+
+        K2EXPECT(log::k23si, response.status, dto::K23SIStatus::OK);
+        return seastar::make_ready_future<>();
+    });
+}
+
+};  // class HeartbeatTest
+
+int main(int argc, char** argv) {
+    App app("HeartbeatTest");
+    app.addOptions()
+        ("tcp_remotes", bpo::value<std::vector<String>>()->multitoken()->default_value(std::vector<String>()), "A list(space-delimited) of endpoints to assign in the test collection")
+        ("tso_endpoint", bpo::value<String>(), "URL of Timestamp Oracle (TSO), e.g. 'tcp+k2rpc://192.168.1.2:12345'")
+        ("partition_request_timeout", bpo::value<ParseableDuration>(), "Timeout of K23SI operations, as chrono literals")
+        ("cpo", bpo::value<String>(), "URL of Control Plane Oracle (CPO), e.g. 'tcp+k2rpc://192.168.1.2:12345'");
+    app.addApplet<TSO_ClientLib>();
+    app.addApplet<HeartbeatTest>();
+    return app.start(argc, argv);
+}


### PR DESCRIPTION
The heartbeat.sh test failed 4 times in a row before the TxnManager heartbeat clock fix. Instrumentation showed  that the client was sending the heartbeat on time and it got a response from the server in under 100usec, so the problem was not overloading the network or future scheduling. After the TxnManager clock fix the test passed 4 times in a row.