### PR TITLE
Idempotent write ops and DataRecord refactor

### DIFF
--- a/src/k2/dto/K23SI.h
+++ b/src/k2/dto/K23SI.h
@@ -141,21 +141,16 @@ struct WriteIntent {
     DataRecord data;
     TxnId txnId;
 
-    enum Status: uint8_t {
-        InProgress,  // the record hasn't been committed/aborted yet
-        Aborted       // the record has been aborted and should be removed
-    } status;
-
     // The request_id as given to the server by the client, it is used to
     // provide idempotent behavior in the case of retries
     uint64_t request_id = 0;
 
     WriteIntent() = default;
-    WriteIntent(DataRecord&& d, TxnId txn, Status s, uint64_t id) : data(std::move(d)),
-            txnId(std::move(txn)), status(s), request_id(id) {}
+    WriteIntent(DataRecord&& d, TxnId txn, uint64_t id) : data(std::move(d)),
+            txnId(std::move(txn)), request_id(id) {}
 
-    K2_PAYLOAD_FIELDS(data, txnId, status, request_id);
-    K2_DEF_FMT(WriteIntent, data, txnId, status, request_id);
+    K2_PAYLOAD_FIELDS(data, txnId, request_id);
+    K2_DEF_FMT(WriteIntent, data, txnId, request_id);
 };
 
 // A committed record in the 3SI version cache.

--- a/src/k2/dto/K23SIInspect.h
+++ b/src/k2/dto/K23SIInspect.h
@@ -86,7 +86,7 @@ struct K23SIInspectWIsRequest {
 };
 
 struct K23SIInspectWIsResponse {
-    std::vector<DataRecord> WIs;
+    std::vector<WriteIntent> WIs;
     K2_PAYLOAD_FIELDS(WIs);
 };
 

--- a/src/k2/module/k23si/Module.cpp
+++ b/src/k2/module/k23si/Module.cpp
@@ -1241,11 +1241,10 @@ K23SIPartitionModule::handleTxnFinalize(dto::K23SITxnFinalizeRequest&& request) 
     // Check for a matching committed record if needed
     if (!found) {
         for (const CommittedRecord& record : versions.committed) {
+            int comp = record.timestamp.compareCertain(txnId.mtr.timestamp);
             // timestamps are unique, so they can identify a txn match
-            if (record.timestamp.compareCertain(txnId.mtr.timestamp) == 0) {
-                found = true;
-                break;
-            } else if (record.timestamp.compareCertain(txnId.mtr.timestamp) < 0) {
+            found = comp == 0;
+            if (comp <= 0) {
                 break;
             }
         }

--- a/src/k2/module/k23si/Module.h
+++ b/src/k2/module/k23si/Module.h
@@ -240,11 +240,15 @@ private: // methods
 
     // the the data record in the version set which is not newer than the given timestsamp
     // The returned pointer is invalid if any modifications are made to the indexer. Will also
-    // return the current WI if it matches exactly the given timestamp.
-    dto::DataRecord* _getDataRecord(VersionSet& versions, dto::Timestamp& timestamp);
+    // return the current WI if it matches exactly the given timestamp. In other words, it
+    // returns a record that is valid to return for to a read request for the given timestamp.
+    dto::DataRecord* _getDataRecordForRead(VersionSet& versions, dto::Timestamp& timestamp);
 
     // For a given challenger timestamp and key, check if a push is needed against a WI
     bool _needPush(const VersionSet& versions, const dto::Timestamp& timestamp);
+
+    // Helper to remove a WI and delete the key from the indexer of there are no committed records
+    void _removeWI(IndexerIterator it);
 
     // get timeNow Timestamp from TSO
     seastar::future<dto::Timestamp> getTimeNow() {

--- a/src/k2/module/k23si/Module.h
+++ b/src/k2/module/k23si/Module.h
@@ -44,10 +44,16 @@ Copyright(c) 2020 Futurewei Cloud
 namespace k2 {
 
 
-// the type holding multiple versions of a key
-typedef std::deque<dto::DataRecord> VersionsT;
+// the type holding multiple committed versions of a key
+typedef std::deque<dto::CommittedRecord> VersionsT;
+
+struct VersionSet {
+    std::optional<WriteIntent> WI;
+    VersionsT versions;
+};
+
 // the type holding versions for all keys, i.e. the indexer
-typedef std::map<dto::Key, VersionsT> IndexerT;
+typedef std::map<dto::Key, VersionSet> IndexerT;
 typedef IndexerT::iterator IndexerIterator;
 
 class K23SIPartitionModule {
@@ -192,7 +198,7 @@ private: // methods
     }
 
     // helper method used to create and persist a WriteIntent
-    seastar::future<> _createWI(dto::K23SIWriteRequest&& request, VersionsT& versions, FastDeadline deadline);
+    seastar::future<> _createWI(dto::K23SIWriteRequest&& request, VersionSet& versions, FastDeadline deadline);
 
     // helper method used to make a projection SKVRecord payload
     bool _makeProjection(dto::SKVRecord::Storage& fullRec, dto::K23SIQueryRequest& request, dto::SKVRecord::Storage& projectionRec);
@@ -232,23 +238,30 @@ private: // methods
 
     std::tuple<Status, bool> _doQueryFilter(dto::K23SIQueryRequest& request, dto::SKVRecord::Storage& storage);
 
+    // the the data record with the given key which is not newer than the given timestsamp
+    // The returned pointer is invalid if any modifications are made to the indexer. Will also
+    // return the current WI if it matches the given timestamp.
+    dto::DataRecord* _getDataRecord(const dto::Key& key, const dto::Timestamp& timestamp);
+    dto::DataRecord* _getDataRecord(const VersionsT& versions, const dto::Timestamp& timestamp);
+
+    // For a given challenger timestamp and key, check if a push is needed against a WI
+    bool _needPush(const VersionsT& versions, const dto::Timestamp& timestamp);
+
+    // utility method used to update the indexer when removing a record
+    void _removeRecord(const dto::Key& key, const dto::Timestamp& timestamp);
+
+    // get timeNow Timestamp from TSO
+    seastar::future<dto::Timestamp> getTimeNow() {
+        TSO_ClientLib& tsoClient = AppBase().getDist<TSO_ClientLib>().local();
+        return tsoClient.GetTimestampFromTSO(Clock::now());
+    }
+
 private: // members
     // the metadata of our collection
     dto::CollectionMetadata _cmeta;
 
     // the partition we're assigned
     dto::OwnerPartition _partition;
-
-    // get the data record iterator from the given versions which is not newer than the given timestamp
-    // The returned iterator is invalid if any modifications are made to the indexer;
-    VersionsT::iterator _getVersion(VersionsT& versions, const dto::Timestamp& timestamp);
-
-    // the the data record with the given key which is not newer than the given timestsamp
-    // The returned pointer is invalid if any modifications are made to the indexer;
-    dto::DataRecord* _getDataRecord(const dto::Key& key, const dto::Timestamp& timestamp);
-
-    // utility method used to update the indexer when removing a record
-    void _removeRecord(dto::DataRecord& rec);
 
     // to store data. The deque contains versions of a key, sorted in decreasing order of their ts.end.
     // (newest item is at front of the deque)
@@ -280,12 +293,6 @@ private: // members
     Persistence _persistence;
 
     CPOClient _cpo;
-
-    // get timeNow Timestamp from TSO
-    seastar::future<dto::Timestamp> getTimeNow() {
-        thread_local TSO_ClientLib& tsoClient = AppBase().getDist<TSO_ClientLib>().local();
-        return tsoClient.GetTimestampFromTSO(Clock::now());
-    }
 };
 
 } // ns k2

--- a/src/k2/module/k23si/Module.h
+++ b/src/k2/module/k23si/Module.h
@@ -245,7 +245,7 @@ private: // methods
     dto::DataRecord* _getDataRecordForRead(VersionSet& versions, dto::Timestamp& timestamp);
 
     // For a given challenger timestamp and key, check if a push is needed against a WI
-    bool _needPush(const VersionSet& versions, const dto::Timestamp& timestamp);
+    bool _checkPushForRead(const VersionSet& versions, const dto::Timestamp& timestamp);
 
     // Helper to remove a WI and delete the key from the indexer of there are no committed records
     void _removeWI(IndexerIterator it);

--- a/src/k2/module/k23si/client/k23si_client.cpp
+++ b/src/k2/module/k23si/client/k23si_client.cpp
@@ -183,6 +183,7 @@ std::unique_ptr<dto::K23SIWriteRequest> K2TxnHandle::makeWriteRequest(dto::SKVRe
         erase,
         _write_set.size() == 1,
         rejectIfExists,
+        _client->write_ops,
         key,
         record.storage.share(),
         std::vector<uint32_t>()
@@ -205,6 +206,7 @@ std::unique_ptr<dto::K23SIWriteRequest> K2TxnHandle::makePartialUpdateRequest(dt
             false, // Partial update cannot be a delete
             _write_set.size() == 1,
             false, // Partial update must be applied on existing record
+            _client->write_ops,
             std::move(key),
             record.storage.share(),
             fieldsForPartialUpdate

--- a/test/k23si/3SITxnTest.cpp
+++ b/test/k23si/3SITxnTest.cpp
@@ -2358,7 +2358,6 @@ seastar::future<> testScenario06() {
         }); // end do-with
     }) // end case 11
     .then([&] {
-        K2LOG_I(log::k23si, "------- SC06.case12 ( The TRH and MTR parameters of Finalize do not match ) -------");
         return getTimeNow();
     })
     .then([this](dto::Timestamp&& ts) {
@@ -2379,14 +2378,7 @@ seastar::future<> testScenario06() {
                 K2EXPECT(log::k23si, status2, dto::K23SIStatus::Created);
             })
             .then([&] {
-                return doFinalize(k8, k8, mtr, collname, true, ErrorCaseOpt::NoInjection)
-                .then([](auto&& response)  {
-                    auto& [status, val] = response;
-                    K2EXPECT(log::k23si, status, dto::K23SIStatus::OperationNotAllowed);
-                });
-            })
-            .then([&] {
-                K2LOG_I(log::k23si, "------- SC06.case13 ( During async end_abort interval, finalize_commit those keys ) -------");
+                K2LOG_I(log::k23si, "------- SC06.case12 ( During async end_abort interval, finalize_commit those keys ) -------");
                 return doEnd(k7, mtr, collname, false, {k7, k8}, Duration{200ms}, ErrorCaseOpt::NoInjection)
                 .then([](auto&& response)  {
                     auto& [status, val] = response;

--- a/test/k23si/K23SITest.cpp
+++ b/test/k23si/K23SITest.cpp
@@ -185,6 +185,8 @@ private:
 
     seastar::future<std::tuple<Status, dto::K23SIWriteResponse>>
     doWrite(const dto::Key& key, const DataRec& data, const dto::K23SI_MTR& mtr, const dto::Key& trh, const String& cname, bool isDelete, bool isTRH) {
+        uint64_t id = 0;
+
         SKVRecord record(cname, std::make_shared<k2::dto::Schema>(_schema));
         record.serializeNext<String>(key.partitionKey);
         record.serializeNext<String>(key.rangeKey);
@@ -200,6 +202,7 @@ private:
             .isDelete = isDelete,
             .designateTRH = isTRH,
             .rejectIfExists = false,
+            .request_id = id++,
             .key = key,
             .value = std::move(record.storage),
             .fieldsForPartialUpdate = std::vector<uint32_t>()
@@ -400,7 +403,6 @@ cases requiring client to refresh collection pmap
                         auto& [status, k2response] = response;
                         K2EXPECT(log::k23si, status, Statuses::S200_OK);
                         K2EXPECT(log::k23si, k2response.records.size(), 1);
-                        K2EXPECT(log::k23si, k2response.records[0].status, k2::DataRecord::Status::WriteIntent);
                         return seastar::make_ready_future<>();
                     });
                 })
@@ -474,7 +476,6 @@ seastar::future<> runScenario04() {
                     auto& [status, k2response] = response;
                     K2EXPECT(log::k23si, status, Statuses::S200_OK);
                     K2EXPECT(log::k23si, k2response.records.size(), 1);
-                    K2EXPECT(log::k23si, k2response.records[0].status, k2::DataRecord::Status::WriteIntent);
 
                     return doRequestTRH(k2, m2);
                 })


### PR DESCRIPTION
Makes write ops idempotent, which fixes failures on rejectIfExist=true retries. Also refactors DataRecord to split committed records from write intents, and removes unnecessary data from committed records. Closes #116 