### PR TITLE
retry failed transcations in TPCC benchmark tests

### DIFF
--- a/src/k2/cmd/tpcc/transactions.h
+++ b/src/k2/cmd/tpcc/transactions.h
@@ -92,11 +92,12 @@ public:
 
     future<bool> run() {
         // retry 10 times for a failed transaction
-        auto retryStrategy = make_shared<FixedRetryStrategy>(10);
-        return retryStrategy->run([this]() {
-            return attempt();
-        }).then_wrapped([this] (auto&& fut) {
-            return make_ready_future<bool>(!fut.failed());
+        return do_with(FixedRetryStrategy(10),  [this] (auto& retryStrategy) {
+            return retryStrategy.run([this]() {
+                return attempt();
+            }).then_wrapped([this] (auto&& fut) {
+                return make_ready_future<bool>(!fut.failed());
+            });
         });
     }
 };


### PR DESCRIPTION
1) changed origin run() as attempt()
2) added retry strategy to try for a number of attempts.
3) tpcc integration tests succeeded

./test_k23si_tpcc.sh
>>>> Test ./test_k23si_tpcc.sh finished with code 0