### PR TITLE
add transaction weights to TPCC client

### DIFF
--- a/cluster/configs/tpcc_client.cfg
+++ b/cluster/configs/tpcc_client.cfg
@@ -15,4 +15,4 @@ data_load = false
 num_warehouses = 12
 num_concurrent_txns = 1
 do_verification = false
-txn_weights = "43,4,4,45,4"
+txn_weights = {43,4,4,45,4}

--- a/cluster/configs/tpcc_client.cfg
+++ b/cluster/configs/tpcc_client.cfg
@@ -15,3 +15,4 @@ data_load = false
 num_warehouses = 12
 num_concurrent_txns = 1
 do_verification = false
+txn_weights = "43,4,4,45,4"

--- a/cluster/configs/tpcc_load.cfg
+++ b/cluster/configs/tpcc_load.cfg
@@ -4,10 +4,9 @@ binary = ./tpcc_client
 
 [program_args]
 test_duration_s = 30
-tcp_remotes = tcp+k2rpc://192.168.1.4:10000 tcp+k2rpc://192.168.1.4:10001 tcp+k2rpc://192.168.1.4:10002 tcp+k2rpc://192.168.1.4:10003 tcp+k2rpc://192.168.1.2:10000 tcp+k2rpc://192.168.1.2:10001 tcp+k2rpc://192.168.1.2:10002 tcp+k2rpc://192.168.1.2:10003
-#tcp_remotes = tcp+k2rpc://192.168.1.4:10000
-cpo = auto-rrdma+k2rpc://192.168.1.8:7000
-tso_endpoint = auto-rrdma+k2rpc://192.168.1.8:8000
+tcp_remotes = $$nodepool_endpoints
+cpo = $$cpo_endpoints
+tso_endpoint = $$tso_endpoints
 memory = 30G
 partition_request_timeout = 20s
 cpo_request_timeout = 5s

--- a/cluster/configs/tpcc_load.cfg
+++ b/cluster/configs/tpcc_load.cfg
@@ -16,4 +16,4 @@ data_load = true
 num_warehouses = 12
 num_concurrent_txns = 1
 do_verification = false
-txn_weights = "43,4,4,45,4"
+txn_weights = {43,4,4,45,4}

--- a/cluster/configs/tpcc_load.cfg
+++ b/cluster/configs/tpcc_load.cfg
@@ -4,7 +4,7 @@ binary = ./tpcc_client
 
 [program_args]
 test_duration_s = 30
-tcp_remotes = tcp+k2rpc://192.168.1.4:10000 tcp+k2rpc://192.168.1.4:10001 tcp+k2rpc://192.168.1.4:10002 tcp+k2rpc://192.168.1.4:10003 tcp+k2rpc://192.168.1.2:10000 tcp+k2rpc://192.168.1.2:10001 tcp+k2rpc://192.168.1.2:10002 tcp+k2rpc://192.168.1.2:10003 
+tcp_remotes = tcp+k2rpc://192.168.1.4:10000 tcp+k2rpc://192.168.1.4:10001 tcp+k2rpc://192.168.1.4:10002 tcp+k2rpc://192.168.1.4:10003 tcp+k2rpc://192.168.1.2:10000 tcp+k2rpc://192.168.1.2:10001 tcp+k2rpc://192.168.1.2:10002 tcp+k2rpc://192.168.1.2:10003
 #tcp_remotes = tcp+k2rpc://192.168.1.4:10000
 cpo = auto-rrdma+k2rpc://192.168.1.8:7000
 tso_endpoint = auto-rrdma+k2rpc://192.168.1.8:8000
@@ -16,3 +16,4 @@ data_load = true
 num_warehouses = 12
 num_concurrent_txns = 1
 do_verification = false
+txn_weights = "43,4,4,45,4"

--- a/src/k2/cmd/tpcc/README
+++ b/src/k2/cmd/tpcc/README
@@ -4,14 +4,16 @@ Start CPO, TSO, K2 server, and persistence
 
 Run load phase:
 ./tpcc_client <Normal seastar args> --tcp_remotes <Server data URLs> --cpo <CPU URL> --tso_endpoint <TSO URL>
-        --data_load true num_warehouses <Number of warehouses (size of data)>
+        --data_load true --num_warehouses <Number of warehouses (size of data)>
+        --txn_weights <transaction type percentages>
 
 Wait for "Done with benchmark" message and kill process.
 
 
 Run bechmark phase:
 ./tpcc_client <Normal seastar args> --tcp_remotes <Server data URLs> --cpo <CPU URL> --tso_endpoint <TSO URL>
-        --data_load false num_warehouses <Same as load phase> clients_per_core <Number of concurrent transactions to run>
+        --data_load false --num_warehouses <Same as load phase> clients_per_core <Number of concurrent transactions to run>
+        --txn_weights <transaction type percentages>
 
 Wait for "Done with benchmark" message
 

--- a/src/k2/cmd/tpcc/tpcc_client.cpp
+++ b/src/k2/cmd/tpcc/tpcc_client.cpp
@@ -109,7 +109,7 @@ public:  // application lifespan
     seastar::future<> start() {
         _stopped = false;
 
-        _weights = _parse_weights(_txn_weights());
+        _weights = _aggregate_weights(_txn_weights());
 
         setupSchemaPointers();
 
@@ -151,19 +151,16 @@ public:  // application lifespan
     }
 
 private:
-    std::vector<uint32_t> _parse_weights(k2::String txn_weights) {
-        K2LOG_D(log::tpcc, "Parsing transaction weights {}", txn_weights);
-        std::stringstream ss(txn_weights);
-        std::string weight_str;
-        std::vector<uint32_t> weights;
+    // aggregate the weights so that we use them as bucket boundaries
+    std::vector<uint32_t> _aggregate_weights(const std::vector<int>& txn_weights) {
+        K2ASSERT(log::tpcc, txn_weights.size() == 5, "The number of transaction types should be 5, but the actual is {}", txn_weights.size());
 
+        std::vector<uint32_t> weights;
         uint32_t sum = 0;
-        while (getline (ss, weight_str, ',')) {
-            uint32_t weight = std::stoi(weight_str);
+        for(int weight : txn_weights) {
             sum += weight;
             weights.push_back(sum);
         }
-        K2ASSERT(log::tpcc, weights.size() == 5, "number of transaction types should be 5, but the actual is {}", weights.size());
         K2ASSERT(log::tpcc, sum == 100, "The sum of transaction weights should be 100, but the actual value is {}", sum);
         return weights;
     }
@@ -369,7 +366,7 @@ private:
     ConfigVar<int> _num_concurrent_txns{"num_concurrent_txns"};
     ConfigVar<uint16_t> _delivery_txn_batch_size{"delivery_txn_batch_size"};
     ConfigVar<uint16_t> _districts_per_warehouse{"districts_per_warehouse"};
-    ConfigVar<k2::String> _txn_weights{"txn_weights"};
+    ConfigVar<std::vector<int>> _txn_weights{"txn_weights"};
 
     sm::metric_groups _metric_groups;
     k2::ExponentialHistogram _newOrderLatency;
@@ -407,7 +404,7 @@ int main(int argc, char** argv) {;
         ("cpo_request_timeout", bpo::value<ParseableDuration>(), "CPO request timeout")
         ("cpo_request_backoff", bpo::value<ParseableDuration>(), "CPO request backoff")
         ("delivery_txn_batch_size", bpo::value<uint16_t>()->default_value(10), "The batch number of Delivery transaction")
-        ("txn_weights", bpo::value<k2::String>(), "Workload percentages for transaction types: Payment, OrderStatus, Delivery, NewOrder, and StockLevel, the sum should be 100");
+        ("txn_weights", bpo::value<std::vector<int>>()->multitoken()->default_value(std::vector<int>({43,4,4,45,4})), "A comma-separated list of exactly 5 elements denoting the percentage for each txn type: Payment, OrderStatus, Delivery, NewOrder, and StockLevel");
 
     app.addApplet<k2::TSO_ClientLib>();
     app.addApplet<Client>();

--- a/test/integration/test_k23si_tpcc.sh
+++ b/test/integration/test_k23si_tpcc.sh
@@ -56,7 +56,7 @@ sleep 5
 NUMWH=1
 NUMDIST=1
 echo ">>> Starting load ..."
-./build/src/k2/cmd/tpcc/tpcc_client -c1 --tcp_remotes ${EPS} --cpo ${CPO} --tso_endpoint ${TSO} --data_load true --num_warehouses ${NUMWH} --districts_per_warehouse ${NUMDIST} --prometheus_port 63100 ${COMMON_ARGS} --memory=512M --partition_request_timeout=6s --dataload_txn_timeout=600s --do_verification false --num_concurrent_txns=2
+./build/src/k2/cmd/tpcc/tpcc_client -c1 --tcp_remotes ${EPS} --cpo ${CPO} --tso_endpoint ${TSO} --data_load true --num_warehouses ${NUMWH} --districts_per_warehouse ${NUMDIST} --prometheus_port 63100 ${COMMON_ARGS} --memory=512M --partition_request_timeout=6s --dataload_txn_timeout=600s --do_verification false --num_concurrent_txns=2 --txn_weights="43,4,4,45,4"
 
 sleep 1
 
@@ -64,4 +64,4 @@ echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"
 echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"
 echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"
 echo ">>> Starting benchmark ..."
-./build/src/k2/cmd/tpcc/tpcc_client -c1 --tcp_remotes ${EPS} --cpo ${CPO} --tso_endpoint ${TSO} --num_warehouses ${NUMWH} --districts_per_warehouse ${NUMDIST} --prometheus_port 63101 ${COMMON_ARGS} --memory=512M --partition_request_timeout=1s  --num_concurrent_txns=1 --do_verification false --delivery_txn_batch_size=10
+./build/src/k2/cmd/tpcc/tpcc_client -c1 --tcp_remotes ${EPS} --cpo ${CPO} --tso_endpoint ${TSO} --num_warehouses ${NUMWH} --districts_per_warehouse ${NUMDIST} --prometheus_port 63101 ${COMMON_ARGS} --memory=512M --partition_request_timeout=1s  --num_concurrent_txns=1 --do_verification false --delivery_txn_batch_size=10 --txn_weights="43,4,4,45,4"

--- a/test/integration/test_k23si_tpcc.sh
+++ b/test/integration/test_k23si_tpcc.sh
@@ -56,7 +56,7 @@ sleep 5
 NUMWH=1
 NUMDIST=1
 echo ">>> Starting load ..."
-./build/src/k2/cmd/tpcc/tpcc_client -c1 --tcp_remotes ${EPS} --cpo ${CPO} --tso_endpoint ${TSO} --data_load true --num_warehouses ${NUMWH} --districts_per_warehouse ${NUMDIST} --prometheus_port 63100 ${COMMON_ARGS} --memory=512M --partition_request_timeout=6s --dataload_txn_timeout=600s --do_verification false --num_concurrent_txns=2 --txn_weights="43,4,4,45,4"
+./build/src/k2/cmd/tpcc/tpcc_client -c1 --tcp_remotes ${EPS} --cpo ${CPO} --tso_endpoint ${TSO} --data_load true --num_warehouses ${NUMWH} --districts_per_warehouse ${NUMDIST} --prometheus_port 63100 ${COMMON_ARGS} --memory=512M --partition_request_timeout=6s --dataload_txn_timeout=600s --do_verification false --num_concurrent_txns=2 --txn_weights={43,4,4,45,4}
 
 sleep 1
 
@@ -64,4 +64,4 @@ echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"
 echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"
 echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"
 echo ">>> Starting benchmark ..."
-./build/src/k2/cmd/tpcc/tpcc_client -c1 --tcp_remotes ${EPS} --cpo ${CPO} --tso_endpoint ${TSO} --num_warehouses ${NUMWH} --districts_per_warehouse ${NUMDIST} --prometheus_port 63101 ${COMMON_ARGS} --memory=512M --partition_request_timeout=1s  --num_concurrent_txns=1 --do_verification false --delivery_txn_batch_size=10 --txn_weights="43,4,4,45,4"
+./build/src/k2/cmd/tpcc/tpcc_client -c1 --tcp_remotes ${EPS} --cpo ${CPO} --tso_endpoint ${TSO} --num_warehouses ${NUMWH} --districts_per_warehouse ${NUMDIST} --prometheus_port 63101 ${COMMON_ARGS} --memory=512M --partition_request_timeout=1s  --num_concurrent_txns=1 --do_verification false --delivery_txn_batch_size=10 --txn_weights={43,4,4,45,4}


### PR DESCRIPTION
Introduced an option --txn_weights for tpcc client, for example,

./build/src/k2/cmd/tpcc/tpcc_client -c1 --tcp_remotes ${EPS} --cpo ${CPO} --tso_endpoint ${TSO} --num_warehouses ${NUMWH} --districts_per_warehouse ${NUMDIST} --prometheus_port 63101 ${COMMON_ARGS} --memory=512M --partition_request_timeout=1s  --num_concurrent_txns=1 --do_verification false --delivery_txn_batch_size=10 --txn_weights={43,4,4,45,4}

Updated integration test script and doc. 

TPCC integration tests passed.

>>>> Test ./test_k23si_tpcc.sh finished with code 0