### PR TITLE
Fix query prefix scan bug plus TPC-C fixes

### DIFF
--- a/src/k2/cmd/tpcc/datagen.h
+++ b/src/k2/cmd/tpcc/datagen.h
@@ -55,15 +55,16 @@ struct TPCCDataGen {
     {
         for (uint16_t i=1; i <= _customers_per_district(); ++i) {
             auto customer = Customer(random, w_id, d_id, i);
-            data.push_back([_customer=std::move(customer)] (k2::K2TxnHandle& txn) mutable {
-                return writeRow<Customer>(_customer, txn);
-            });
 
             // populate secondary index idx_customer_name
             auto idx_customer_name = IdxCustomerName(customer.WarehouseID.value(), customer.DistrictID.value(),
-                customer.LastName.value(), customer.FirstName.value(), customer.CustomerID.value());
+                customer.LastName.value(), customer.CustomerID.value());
             data.push_back([_idx_customer_name=std::move(idx_customer_name)] (k2::K2TxnHandle& txn) mutable {
                 return writeRow<IdxCustomerName>(_idx_customer_name, txn);
+            });
+
+            data.push_back([_customer=std::move(customer)] (k2::K2TxnHandle& txn) mutable {
+                return writeRow<Customer>(_customer, txn);
             });
 
             auto history = History(random, w_id, d_id, i);

--- a/src/k2/cmd/tpcc/schema.h
+++ b/src/k2/cmd/tpcc/schema.h
@@ -308,27 +308,25 @@ public:
             {dto::FieldType::INT16T, "ID", false, false},
             {dto::FieldType::INT16T, "DID", false, false},
             {dto::FieldType::STRING, "LastName", false, false},
-            {dto::FieldType::STRING, "FirstName", false, false},
             {dto::FieldType::INT32T, "CID", false, false}
         },
         .partitionKeyFields = std::vector<uint32_t> { 0 },
-        .rangeKeyFields = std::vector<uint32_t> { 1, 2, 3, 4}
+        .rangeKeyFields = std::vector<uint32_t> { 1, 2, 3 }
     };
 
-    IdxCustomerName(int16_t w_id, int16_t d_id, String c_last, String c_first, int32_t c_id) :
-        WarehouseID(w_id), DistrictID(d_id), FirstName(c_last), LastName(c_first), CustomerID(c_id) {};
+    IdxCustomerName(int16_t w_id, int16_t d_id, String c_last, int32_t c_id) :
+        WarehouseID(w_id), DistrictID(d_id), LastName(c_last), CustomerID(c_id) {};
 
     IdxCustomerName() = default;
 
     std::optional<int16_t> WarehouseID;
     std::optional<int16_t> DistrictID;
-    std::optional<String> FirstName;
     std::optional<String> LastName;
     std::optional<int32_t> CustomerID;
 
     static inline thread_local std::shared_ptr<dto::Schema> schema;
     static inline String collectionName = tpccCollectionName;
-    SKV_RECORD_FIELDS(WarehouseID, DistrictID, FirstName, LastName, CustomerID);
+    SKV_RECORD_FIELDS(WarehouseID, DistrictID, LastName, CustomerID);
 };
 
 class History {

--- a/src/k2/cmd/tpcc/tpcc_client.cpp
+++ b/src/k2/cmd/tpcc/tpcc_client.cpp
@@ -110,6 +110,7 @@ public:  // application lifespan
         _stopped = false;
 
         _weights = _aggregate_weights(_txn_weights());
+        _global_id = (seastar::smp::count * _instance_id()) + seastar::this_shard_id();
 
         setupSchemaPointers();
 
@@ -224,11 +225,8 @@ private:
     seastar::future<> _data_load() {
         K2LOG_I(log::tpcc, "Creating DataLoader");
         int cpus = seastar::smp::count;
-        int id = seastar::this_shard_id();
         int total_cpus = cpus * _num_instances();
         int share = _max_warehouses() / total_cpus;
-
-        _global_id = (cpus * _instance_id()) + id;
 
         if (_max_warehouses() % total_cpus != 0) {
             K2LOG_W(log::tpcc, "CPUs must divide evenly into num warehouses!");

--- a/src/k2/module/k23si/client/k23si_client.cpp
+++ b/src/k2/module/k23si/client/k23si_client.cpp
@@ -520,10 +520,8 @@ void K2TxnHandle::_prepareQueryRequest(Query& query) {
         // If we've padded the end key for a forward prefix scan, we need to add one more byte
         // because the end key is exclusive but we want to include any record that may actually
         // have null last key fields set
-        query.request.endKey.partitionKey.append(" ", 1);
         query.request.endKey.rangeKey.append(" ", 1);
     }
-
 
     if (query.request.key > query.request.endKey && !query.request.reverseDirection &&
                 query.request.endKey.partitionKey != "") {


### PR DESCRIPTION
- Fix query prefix scan bug that caused many extra records to be returned when there are both partition and range keys. This fixed the TPC-C performance bug.
- Add command line options to support TPC-C with multiple client instances
- Fix unsafe use after move in TPC-C data load
- Remove unneeded first name field from TPC-C customer secondary index

Tested with 4 server cores, 2 client instances with 2 client cores: 10,000 txns/sec with payment and new order txn types.