### PR TITLE
change to use BinaryAllocator to replace BinaryAllocatorFunctor

### DIFF
--- a/src/k2/appbase/Appbase.h
+++ b/src/k2/appbase/Appbase.h
@@ -59,7 +59,7 @@ class MultiAddressProvider : public k2::IAddressProvider {
     seastar::socket_address getAddress(int coreID) const override {
         if (size_t(coreID) < _urls.size()) {
             K2LOG_D(log::appbase, "On core {} have url {}", coreID, _urls[coreID]);
-            auto ep = k2::TXEndpoint::fromURL(_urls[coreID], nullptr);
+            auto ep = k2::TXEndpoint::fromURL(_urls[coreID], BinaryAllocator());
             if (ep) {
                 return seastar::socket_address(seastar::ipv4_addr(ep->ip, uint16_t(ep->port)));
             }

--- a/src/k2/cmd/txbench/rpcbench_common.h
+++ b/src/k2/cmd/txbench/rpcbench_common.h
@@ -46,7 +46,7 @@ struct BenchSession {
     uint64_t sessionId = 0;
     uint64_t totalSize=0;
     uint64_t totalCount=0;
-    Payload dataShare{Payload::DefaultAllocator};
+    Payload dataShare{Payload::DefaultAllocator()};
     String dataCopy;
     std::vector<std::unique_ptr<TXEndpoint>> endpoints;
 };

--- a/src/k2/common/Common.h
+++ b/src/k2/common/Common.h
@@ -92,25 +92,33 @@ typedef seastar::sstring String;
 //
 typedef seastar::temporary_buffer<char> Binary;
 
+//
+// The type for a function which can allocate Binary
+//
+typedef std::function<Binary(size_t)> BinaryAllocatorFunctor;
+
 // define a binary allocator either by a default size or by a specific size
 class BinaryAllocator {
 public:
-    BinaryAllocator(size_t size) : _size(size) {
+    // pass in a default size and an allocation function
+    BinaryAllocator(size_t size, BinaryAllocatorFunctor func) : _size(size), _func(func) {
     }
 
     // allocate by the default size
     Binary allocate() {
-        return Binary(_size);
+        return _func(_size);
     }
 
     // allocate by a specific size
     Binary allocate(size_t bsize) {
-        return Binary(bsize);
+        return _func(bsize);
     }
 
 private:
     // default allocation size
     size_t _size;
+    // location function
+    BinaryAllocatorFunctor _func;
 };
 
 class HexCodec {

--- a/src/k2/common/Common.h
+++ b/src/k2/common/Common.h
@@ -100,8 +100,17 @@ typedef std::function<Binary(size_t)> BinaryAllocatorFunctor;
 // define a binary allocator either by a default size or by a specific size
 class BinaryAllocator {
 public:
+    // constructor without an allocation function
+    BinaryAllocator() : _size(0), _func(nullptr) {
+    }
+
     // pass in a default size and an allocation function
     BinaryAllocator(size_t size, BinaryAllocatorFunctor func) : _size(size), _func(func) {
+    }
+
+    // whether we can use this allocator
+    bool canAllocate() const {
+        return _func != nullptr;
     }
 
     // allocate by the default size

--- a/src/k2/common/Common.h
+++ b/src/k2/common/Common.h
@@ -92,10 +92,26 @@ typedef seastar::sstring String;
 //
 typedef seastar::temporary_buffer<char> Binary;
 
-//
-// The type for a function which can allocate Binary
-//
-typedef std::function<Binary()> BinaryAllocatorFunctor;
+// define a binary allocator either by a default size or by a specific size
+class BinaryAllocator {
+public:
+    BinaryAllocator(size_t size) : _size(size) {
+    }
+
+    // allocate by the default size
+    Binary allocate() {
+        return Binary(_size);
+    }
+
+    // allocate by a specific size
+    Binary allocate(size_t bsize) {
+        return Binary(bsize);
+    }
+
+private:
+    // default allocation size
+    size_t _size;
+};
 
 class HexCodec {
 private:

--- a/src/k2/cpo/service/CPOService.cpp
+++ b/src/k2/cpo/service/CPOService.cpp
@@ -554,7 +554,7 @@ Status CPOService::_loadSchemas(const String& collectionName) {
 
 Status CPOService::_saveCollection(dto::Collection& collection) {
     auto cpath = _getCollectionPath(collection.metadata.name);
-    Payload p(std::make_shared<BinaryAllocator>(4096));
+    Payload p(Payload::DefaultAllocator(4096));
     p.write(collection);
     if (!fileutil::writeFile(std::move(p), cpath)) {
         return Statuses::S500_Internal_Server_Error("unable to write collection data");
@@ -566,7 +566,7 @@ Status CPOService::_saveCollection(dto::Collection& collection) {
 
 Status CPOService::_saveSchemas(const String& collectionName) {
     auto cpath = _getSchemasPath(collectionName);
-    Payload p(std::make_shared<BinaryAllocator>(4096));
+    Payload p(Payload::DefaultAllocator(4096));
     p.write(schemas[collectionName]);
     if (!fileutil::writeFile(std::move(p), cpath)) {
         return Statuses::S500_Internal_Server_Error("unable to write schema data");
@@ -586,7 +586,7 @@ CPOService::handlePersistenceClusterCreate(dto::PersistenceClusterCreateRequest&
         return RPCResponse(Statuses::S409_Conflict("persistence cluster already exists"), dto::PersistenceClusterCreateResponse());
     }
 
-    Payload q(std::make_shared<BinaryAllocator>(4096));
+    Payload q(Payload::DefaultAllocator(4096));
     q.write(request.cluster);
     if (!fileutil::writeFile(std::move(q), cpath)) {
         return RPCResponse(Statuses::S500_Internal_Server_Error("unable to write persistence cluster data"), dto::PersistenceClusterCreateResponse());

--- a/src/k2/cpo/service/CPOService.cpp
+++ b/src/k2/cpo/service/CPOService.cpp
@@ -554,7 +554,7 @@ Status CPOService::_loadSchemas(const String& collectionName) {
 
 Status CPOService::_saveCollection(dto::Collection& collection) {
     auto cpath = _getCollectionPath(collection.metadata.name);
-    Payload p([] { return Binary(4096); });
+    Payload p(std::make_shared<BinaryAllocator>(4096));
     p.write(collection);
     if (!fileutil::writeFile(std::move(p), cpath)) {
         return Statuses::S500_Internal_Server_Error("unable to write collection data");
@@ -566,7 +566,7 @@ Status CPOService::_saveCollection(dto::Collection& collection) {
 
 Status CPOService::_saveSchemas(const String& collectionName) {
     auto cpath = _getSchemasPath(collectionName);
-    Payload p([] { return Binary(4096); });
+    Payload p(std::make_shared<BinaryAllocator>(4096));
     p.write(schemas[collectionName]);
     if (!fileutil::writeFile(std::move(p), cpath)) {
         return Statuses::S500_Internal_Server_Error("unable to write schema data");
@@ -586,7 +586,7 @@ CPOService::handlePersistenceClusterCreate(dto::PersistenceClusterCreateRequest&
         return RPCResponse(Statuses::S409_Conflict("persistence cluster already exists"), dto::PersistenceClusterCreateResponse());
     }
 
-    Payload q([] { return Binary(4096); });
+    Payload q(std::make_shared<BinaryAllocator>(4096));
     q.write(request.cluster);
     if (!fileutil::writeFile(std::move(q), cpath)) {
         return RPCResponse(Statuses::S500_Internal_Server_Error("unable to write persistence cluster data"), dto::PersistenceClusterCreateResponse());
@@ -634,7 +634,7 @@ CPOService::handleMetadataPut(dto::MetadataPutRequest&& request){
         dto::PartitionMetdataRecord element{.plogId=std::move(request.new_plogId), .sealed_offset=0};
         records->second.push_back(std::move(element));
     }
-    
+
     return RPCResponse(Statuses::S201_Created("metadata log updates successfully"), dto::MetadataPutResponse{});
 }
 

--- a/src/k2/dto/Expression.h
+++ b/src/k2/dto/Expression.h
@@ -74,7 +74,7 @@ K2_DEF_ENUM(Operation,
 struct Value {
     String fieldName;
     FieldType type = FieldType::NOT_KNOWN;
-    Payload literal{Payload::DefaultAllocator};
+    Payload literal{Payload::DefaultAllocator()};
     bool isReference() const { return !fieldName.empty();}
 
     K2_PAYLOAD_FIELDS(fieldName, type, literal);

--- a/src/k2/dto/SKVRecord.cpp
+++ b/src/k2/dto/SKVRecord.cpp
@@ -102,7 +102,7 @@ const SKVRecord::Storage& SKVRecord::getStorage() {
 SKVRecord::SKVRecord(const String& collection, std::shared_ptr<Schema> s) :
             schema(s), collectionName(collection), keyValuesAvailable(true), keyStringsConstructed(true) {
     storage.schemaVersion = schema->version;
-    storage.fieldData = Payload(Payload::DefaultAllocator);
+    storage.fieldData = Payload(Payload::DefaultAllocator());
     partitionKeys.resize(schema->partitionKeyFields.size());
     rangeKeys.resize(schema->rangeKeyFields.size());
 }

--- a/src/k2/infrastructure/APIServer.cpp
+++ b/src/k2/infrastructure/APIServer.cpp
@@ -55,7 +55,7 @@ APIServer::start() {
     seastar::ipv4_addr listenAddr;
     bool parsed = false;
     if (size_t(coreID) < _tcp_endpoints().size()) {
-        auto ep = k2::TXEndpoint::fromURL(_tcp_endpoints()[coreID], nullptr);
+        auto ep = k2::TXEndpoint::fromURL(_tcp_endpoints()[coreID], BinaryAllocator());
         if (ep) {
             parsed = true;
             listenAddr = seastar::ipv4_addr(ep->ip, uint16_t(ep->port + API_PORT_OFFSET));

--- a/src/k2/module/k23si/Module.cpp
+++ b/src/k2/module/k23si/Module.cpp
@@ -774,7 +774,7 @@ bool K23SIPartitionModule::_isUpdatedField(uint32_t fieldIdx, std::vector<uint32
 
 bool K23SIPartitionModule::_makeFieldsForSameVersion(dto::Schema& schema, dto::K23SIWriteRequest& request, dto::DataRecord& version) {
     Payload basePayload = version.value.fieldData.shareAll();   // base payload
-    Payload payload(Payload::DefaultAllocator);                     // payload for new record
+    Payload payload(Payload::DefaultAllocator());                     // payload for new record
 
     for (std::size_t i = 0; i < schema.fields.size(); ++i) {
         if (_isUpdatedField(i, request.fieldsForPartialUpdate)) {
@@ -860,7 +860,7 @@ bool K23SIPartitionModule::_makeFieldsForDiffVersion(dto::Schema& schema, dto::S
     std::size_t baseCursor = 0; // indicate fieldsOffset cursor
 
     Payload basePayload = version.value.fieldData.shareAll();   // base payload
-    Payload payload(Payload::DefaultAllocator);                     // payload for new record
+    Payload payload(Payload::DefaultAllocator());                     // payload for new record
 
     // make every fields in schema for new full-record-WI
     for (std::size_t i = 0; i < schema.fields.size(); ++i) {
@@ -985,7 +985,7 @@ bool K23SIPartitionModule::_makeProjection(dto::SKVRecord::Storage& fullRec, dto
     auto schemaVer = schemaIt->second.find(fullRec.schemaVersion);
     dto::Schema& schema = *(schemaVer->second);
     std::vector<bool> excludedFields(schema.fields.size(), true);   // excludedFields for projection
-    Payload projectedPayload(Payload::DefaultAllocator);            // payload for projection
+    Payload projectedPayload(Payload::DefaultAllocator());            // payload for projection
 
     for (uint32_t i = 0; i < schema.fields.size(); ++i) {
         if (fullRec.excludedFields.size() && fullRec.excludedFields[i]) {

--- a/src/k2/persistence/logStream/LogStream.cpp
+++ b/src/k2/persistence/logStream/LogStream.cpp
@@ -460,7 +460,7 @@ std::tuple<Status, std::shared_ptr<LogStream>> PartitionMetadataMgr::obtainLogSt
 
 seastar::future<Status>
 PartitionMetadataMgr::addNewPLogIntoLogStream(LogStreamType name, uint32_t sealed_offset, String new_plogId){
-    Payload temp_payload(Payload::DefaultAllocator);
+    Payload temp_payload(Payload::DefaultAllocator());
     temp_payload.write(name);
     temp_payload.write(sealed_offset);
     temp_payload.write(std::move(new_plogId));

--- a/src/k2/persistence/plog_service/PlogServer.h
+++ b/src/k2/persistence/plog_service/PlogServer.h
@@ -53,8 +53,8 @@ private:
         InternalPlog(){
             sealed=false;
             offset=0;
-            payload = Payload(std::make_shared<BinaryAllocator>(PLOG_MAX_SIZE));
-        }
+            payload = Payload(Payload::DefaultAllocator(PLOG_MAX_SIZE));
+       }
 
         bool sealed;
         uint32_t offset;

--- a/src/k2/persistence/plog_service/PlogServer.h
+++ b/src/k2/persistence/plog_service/PlogServer.h
@@ -53,12 +53,12 @@ private:
         InternalPlog(){
             sealed=false;
             offset=0;
-            payload = Payload(([] { return Binary(PLOG_MAX_SIZE); }));
+            payload = Payload(std::make_shared<BinaryAllocator>(PLOG_MAX_SIZE));
         }
 
         bool sealed;
         uint32_t offset;
-        Payload payload; 
+        Payload payload;
     };
 
     // a map to store all the plogs based on plog id
@@ -83,7 +83,7 @@ private:
     //handle the seal request
     seastar::future<std::tuple<Status, dto::PlogGetStatusResponse>>
     _handleGetStatus(dto::PlogGetStatusRequest&& request);
-    
+
 public:
      PlogServer();
     ~PlogServer();

--- a/src/k2/transport/Payload.cpp
+++ b/src/k2/transport/Payload.cpp
@@ -36,8 +36,8 @@ Payload::PayloadPosition::PayloadPosition(_Size bIdx, _Size bOff, size_t offset)
     // Empty payload will have position of (bidx=0, boff=0, off=0)
 }
 
-Payload::Payload(BinaryAllocator allocator):
-    _size(0), _capacity(0), _allocator(allocator) {
+Payload::Payload(BinaryAllocator&& allocator):
+    _size(0), _capacity(0), _allocator(std::move(allocator)) {
 }
 
 Payload::Payload(std::vector<Binary>&& externallyAllocatedBuffers, size_t containedDataSize):
@@ -409,7 +409,8 @@ Payload Payload::shareRegion(size_t startOffset, size_t nbytes){
     seek(startOffset);
     nbytes = std::min(_size - _currentPosition.offset, nbytes);
 
-    Payload shared(_allocator);
+    BinaryAllocator copied_allocator = _allocator;
+    Payload shared(std::move(copied_allocator));
     shared._size = nbytes;
     shared._capacity = nbytes; // the capacity of the new payload stops with the current data written
 
@@ -434,7 +435,7 @@ Payload Payload::shareRegion(size_t startOffset, size_t nbytes){
     return shared;
 }
 
-Payload Payload::copy(BinaryAllocator allocator) {
+Payload Payload::copy(BinaryAllocator&& allocator) {
     Payload copied;
     Binary b = allocator.allocate(_size);
 
@@ -451,7 +452,7 @@ Payload Payload::copy(BinaryAllocator allocator) {
     }
 
     copied.appendBinary(std::move(b));
-    copied._allocator = allocator;
+    copied._allocator = std::move(allocator);
     return copied;
 }
 

--- a/src/k2/transport/Payload.cpp
+++ b/src/k2/transport/Payload.cpp
@@ -53,8 +53,8 @@ Payload::Payload():
     _allocator(nullptr) {
 }
 
-std::shared_ptr<BinaryAllocator> Payload::DefaultAllocator() {
-    return std::make_shared<BinaryAllocator>(8196);
+std::shared_ptr<BinaryAllocator> Payload::DefaultAllocator(size_t default_size) {
+    return std::make_shared<BinaryAllocator>(default_size, [](size_t bsize) { return Binary(bsize); });
 }
 
 bool Payload::isEmpty() const {

--- a/src/k2/transport/Payload.cpp
+++ b/src/k2/transport/Payload.cpp
@@ -409,8 +409,7 @@ Payload Payload::shareRegion(size_t startOffset, size_t nbytes){
     seek(startOffset);
     nbytes = std::min(_size - _currentPosition.offset, nbytes);
 
-    BinaryAllocator copied_allocator = _allocator;
-    Payload shared(std::move(copied_allocator));
+    Payload shared(std::move(BinaryAllocator(_allocator)));
     shared._size = nbytes;
     shared._capacity = nbytes; // the capacity of the new payload stops with the current data written
 

--- a/src/k2/transport/Payload.h
+++ b/src/k2/transport/Payload.h
@@ -131,8 +131,8 @@ public: // types
 
 public: // Lifecycle
     // Create a blank payload which can grow by allocating with the given allocator
-    Payload(BinaryAllocatorFunctor allocator);
-    static Binary DefaultAllocator();
+    Payload(std::shared_ptr<BinaryAllocator> allocator);
+    static std::shared_ptr<BinaryAllocator> DefaultAllocator();
 
     Payload(Payload&&) = default;
     Payload& operator=(Payload&& other) = default;
@@ -165,7 +165,10 @@ public: // memory management
     Payload shareRegion(size_t startOffset, size_t nbytes);
 
     // Creates a new payload as a copy of this payload. The underlying data is copied over to the new payload
-    Payload copy(BinaryAllocatorFunctor dest_allocator=DefaultAllocator);
+    Payload copy(std::shared_ptr<BinaryAllocator> dest_allocator);
+
+    // copy with the default binary allocator
+    Payload copy();
 
     // clear this payload
     void clear();
@@ -664,7 +667,7 @@ private:  // types and fields
     std::vector<Binary> _buffers;
     size_t _size; // total bytes of user data present
     size_t _capacity; // total bytes allocated in the buffers.
-    BinaryAllocatorFunctor _allocator;
+    std::shared_ptr<BinaryAllocator> _allocator;
     PayloadPosition _currentPosition;
 
 private: // helper methods

--- a/src/k2/transport/Payload.h
+++ b/src/k2/transport/Payload.h
@@ -131,7 +131,7 @@ public: // types
 
 public: // Lifecycle
     // Create a blank payload which can grow by allocating with the given allocator
-    Payload(BinaryAllocator allocator);
+    Payload(BinaryAllocator&& allocator);
     static BinaryAllocator DefaultAllocator(size_t default_size=8196);
 
     Payload(Payload&&) = default;
@@ -165,7 +165,7 @@ public: // memory management
     Payload shareRegion(size_t startOffset, size_t nbytes);
 
     // Creates a new payload as a copy of this payload. The underlying data is copied over to the new payload
-    Payload copy(BinaryAllocator dest_allocator);
+    Payload copy(BinaryAllocator&& dest_allocator);
 
     // copy with the default binary allocator
     Payload copy();

--- a/src/k2/transport/Payload.h
+++ b/src/k2/transport/Payload.h
@@ -131,8 +131,8 @@ public: // types
 
 public: // Lifecycle
     // Create a blank payload which can grow by allocating with the given allocator
-    Payload(seastar::lw_shared_ptr<BinaryAllocator> allocator);
-    static seastar::lw_shared_ptr<BinaryAllocator> DefaultAllocator(size_t default_size=8196);
+    Payload(BinaryAllocator allocator);
+    static BinaryAllocator DefaultAllocator(size_t default_size=8196);
 
     Payload(Payload&&) = default;
     Payload& operator=(Payload&& other) = default;
@@ -165,7 +165,7 @@ public: // memory management
     Payload shareRegion(size_t startOffset, size_t nbytes);
 
     // Creates a new payload as a copy of this payload. The underlying data is copied over to the new payload
-    Payload copy(seastar::lw_shared_ptr<BinaryAllocator> dest_allocator);
+    Payload copy(BinaryAllocator dest_allocator);
 
     // copy with the default binary allocator
     Payload copy();
@@ -667,7 +667,7 @@ private:  // types and fields
     std::vector<Binary> _buffers;
     size_t _size; // total bytes of user data present
     size_t _capacity; // total bytes allocated in the buffers.
-    seastar::lw_shared_ptr<BinaryAllocator> _allocator;
+    BinaryAllocator _allocator;
     PayloadPosition _currentPosition;
 
 private: // helper methods

--- a/src/k2/transport/Payload.h
+++ b/src/k2/transport/Payload.h
@@ -131,8 +131,8 @@ public: // types
 
 public: // Lifecycle
     // Create a blank payload which can grow by allocating with the given allocator
-    Payload(std::shared_ptr<BinaryAllocator> allocator);
-    static std::shared_ptr<BinaryAllocator> DefaultAllocator(size_t default_size=8196);
+    Payload(seastar::lw_shared_ptr<BinaryAllocator> allocator);
+    static seastar::lw_shared_ptr<BinaryAllocator> DefaultAllocator(size_t default_size=8196);
 
     Payload(Payload&&) = default;
     Payload& operator=(Payload&& other) = default;
@@ -165,7 +165,7 @@ public: // memory management
     Payload shareRegion(size_t startOffset, size_t nbytes);
 
     // Creates a new payload as a copy of this payload. The underlying data is copied over to the new payload
-    Payload copy(std::shared_ptr<BinaryAllocator> dest_allocator);
+    Payload copy(seastar::lw_shared_ptr<BinaryAllocator> dest_allocator);
 
     // copy with the default binary allocator
     Payload copy();
@@ -667,7 +667,7 @@ private:  // types and fields
     std::vector<Binary> _buffers;
     size_t _size; // total bytes of user data present
     size_t _capacity; // total bytes allocated in the buffers.
-    std::shared_ptr<BinaryAllocator> _allocator;
+    seastar::lw_shared_ptr<BinaryAllocator> _allocator;
     PayloadPosition _currentPosition;
 
 private: // helper methods

--- a/src/k2/transport/Payload.h
+++ b/src/k2/transport/Payload.h
@@ -132,7 +132,7 @@ public: // types
 public: // Lifecycle
     // Create a blank payload which can grow by allocating with the given allocator
     Payload(std::shared_ptr<BinaryAllocator> allocator);
-    static std::shared_ptr<BinaryAllocator> DefaultAllocator();
+    static std::shared_ptr<BinaryAllocator> DefaultAllocator(size_t default_size=8196);
 
     Payload(Payload&&) = default;
     Payload& operator=(Payload&& other) = default;

--- a/src/k2/transport/RPCDispatcher.cpp
+++ b/src/k2/transport/RPCDispatcher.cpp
@@ -265,7 +265,7 @@ void RPCDispatcher::registerLowTransportMemoryObserver(LowTransportMemoryObserve
 std::unique_ptr<TXEndpoint> RPCDispatcher::getTXEndpoint(String url) {
     K2LOG_D(log::tx, "get endpoint for {}", url)
     // temporary endpoint just so that we can see what the protocol is supposed to be
-    auto ep = TXEndpoint::fromURL(url, nullptr);
+    auto ep = TXEndpoint::fromURL(url, BinaryAllocator());
     if (!ep) {
         K2LOG_W(log::tx, "Unable to get tx endpoint for url: {}", url);
         return nullptr;

--- a/src/k2/transport/TXEndpoint.cpp
+++ b/src/k2/transport/TXEndpoint.cpp
@@ -38,7 +38,7 @@ namespace k2 {
 // must have: protocol(group1), ip(group2==ipv4, group3==ipv6), port(group4)
 const std::regex urlregex{"(.+)://(?:([^:\\[\\]]+)|\\[(.+)\\]):(\\d+)"};
 
-std::unique_ptr<TXEndpoint> TXEndpoint::fromURL(const String& url, BinaryAllocatorFunctor&& allocator) {
+std::unique_ptr<TXEndpoint> TXEndpoint::fromURL(const String& url, std::shared_ptr<BinaryAllocator> allocator) {
     K2LOG_D(log::tx, "Parsing url {}", url);
     std::cmatch matches;
     if (!std::regex_match(url.c_str(), matches, urlregex)) {
@@ -72,18 +72,18 @@ std::unique_ptr<TXEndpoint> TXEndpoint::fromURL(const String& url, BinaryAllocat
         }
         ip = seastar::rdma::EndPoint::GIDToString(tmpip6);
     }
-    return std::make_unique<TXEndpoint>(std::move(protocol), std::move(ip), port, std::move(allocator));
+    return std::make_unique<TXEndpoint>(std::move(protocol), std::move(ip), port, allocator);
 }
 
 TXEndpoint::~TXEndpoint() {
     K2LOG_D(log::tx, "dtor");
 }
 
-TXEndpoint::TXEndpoint(String&& pprotocol, String&& pip, uint32_t pport, BinaryAllocatorFunctor&& allocator):
+TXEndpoint::TXEndpoint(String&& pprotocol, String&& pip, uint32_t pport, std::shared_ptr<BinaryAllocator> allocator):
     protocol(std::move(pprotocol)),
     ip(std::move(pip)),
     port(pport),
-    _allocator(std::move(allocator)) {
+    _allocator(allocator) {
     bool isIpv6 = ip.find(":") != String::npos;
     url = protocol + "://" + (isIpv6?"[":"") + ip + (isIpv6?"]":"");
     url += ":" + std::to_string(port);

--- a/src/k2/transport/TXEndpoint.cpp
+++ b/src/k2/transport/TXEndpoint.cpp
@@ -38,7 +38,7 @@ namespace k2 {
 // must have: protocol(group1), ip(group2==ipv4, group3==ipv6), port(group4)
 const std::regex urlregex{"(.+)://(?:([^:\\[\\]]+)|\\[(.+)\\]):(\\d+)"};
 
-std::unique_ptr<TXEndpoint> TXEndpoint::fromURL(const String& url, seastar::lw_shared_ptr<BinaryAllocator> allocator) {
+std::unique_ptr<TXEndpoint> TXEndpoint::fromURL(const String& url, BinaryAllocator allocator) {
     K2LOG_D(log::tx, "Parsing url {}", url);
     std::cmatch matches;
     if (!std::regex_match(url.c_str(), matches, urlregex)) {
@@ -79,7 +79,7 @@ TXEndpoint::~TXEndpoint() {
     K2LOG_D(log::tx, "dtor");
 }
 
-TXEndpoint::TXEndpoint(String&& pprotocol, String&& pip, uint32_t pport, seastar::lw_shared_ptr<BinaryAllocator> allocator):
+TXEndpoint::TXEndpoint(String&& pprotocol, String&& pip, uint32_t pport, BinaryAllocator allocator):
     protocol(std::move(pprotocol)),
     ip(std::move(pip)),
     port(pport),
@@ -115,7 +115,7 @@ TXEndpoint::TXEndpoint(TXEndpoint&& o) {
     url = std::move(o.url);
     _hash = o._hash; o._hash = 0;
     _allocator = std::move(o._allocator);
-    o._allocator = nullptr;
+    o._allocator = BinaryAllocator();
 
     K2LOG_D(log::tx, "move ctor done");
 }
@@ -127,7 +127,7 @@ bool TXEndpoint::operator==(const TXEndpoint& other) const {
 size_t TXEndpoint::hash() const { return _hash; }
 
 std::unique_ptr<Payload> TXEndpoint::newPayload() {
-    K2ASSERT(log::tx, _allocator.get() != nullptr, "asked to create payload from non-allocating endpoint");
+    K2ASSERT(log::tx, _allocator.canAllocate(), "asked to create payload from non-allocating endpoint");
     auto result = std::make_unique<Payload>(_allocator);
     // rewind enough bytes to write out a header when we're sending
     result->reserve(txconstants::MAX_HEADER_SIZE);
@@ -135,7 +135,7 @@ std::unique_ptr<Payload> TXEndpoint::newPayload() {
 }
 
 bool TXEndpoint::canAllocate() const {
-    return _allocator.get() != nullptr;
+    return _allocator.canAllocate();
 }
 
 }

--- a/src/k2/transport/TXEndpoint.cpp
+++ b/src/k2/transport/TXEndpoint.cpp
@@ -128,8 +128,7 @@ size_t TXEndpoint::hash() const { return _hash; }
 
 std::unique_ptr<Payload> TXEndpoint::newPayload() {
     K2ASSERT(log::tx, _allocator.canAllocate(), "asked to create payload from non-allocating endpoint");
-    BinaryAllocator copied_allocator = _allocator;
-    auto result = std::make_unique<Payload>(std::move(copied_allocator));
+    auto result = std::make_unique<Payload>(BinaryAllocator(_allocator));
     // rewind enough bytes to write out a header when we're sending
     result->reserve(txconstants::MAX_HEADER_SIZE);
     return result;

--- a/src/k2/transport/TXEndpoint.h
+++ b/src/k2/transport/TXEndpoint.h
@@ -44,7 +44,7 @@ class TXEndpoint {
 public: // lifecycle
     // construct an endpoint from a url with the given allocator
     // Returns nullptr if there was a problem parsing the url
-    static std::unique_ptr<TXEndpoint> fromURL(const String& url, seastar::lw_shared_ptr<BinaryAllocator> allocator);
+    static std::unique_ptr<TXEndpoint> fromURL(const String& url, BinaryAllocator allocator);
 
     // default ctor
     TXEndpoint() = default;
@@ -56,7 +56,7 @@ public: // lifecycle
     TXEndpoint& operator=(TXEndpoint&&) = default;
 
     // construct an endpoint from the tuple (protocol, ip, port) with the given allocator and protocol
-    TXEndpoint(String&& protocol, String&& ip, uint32_t port, seastar::lw_shared_ptr<BinaryAllocator>allocator);
+    TXEndpoint(String&& protocol, String&& ip, uint32_t port, BinaryAllocator allocator);
 
     // copy constructor
     TXEndpoint(const TXEndpoint& o);
@@ -92,7 +92,7 @@ public: // API
 
 private:
     size_t _hash;
-    seastar::lw_shared_ptr<BinaryAllocator> _allocator;
+    BinaryAllocator _allocator;
 
 }; // class TXEndpoint
 } // namespace k2

--- a/src/k2/transport/TXEndpoint.h
+++ b/src/k2/transport/TXEndpoint.h
@@ -44,7 +44,7 @@ class TXEndpoint {
 public: // lifecycle
     // construct an endpoint from a url with the given allocator
     // Returns nullptr if there was a problem parsing the url
-    static std::unique_ptr<TXEndpoint> fromURL(const String& url, BinaryAllocator allocator);
+    static std::unique_ptr<TXEndpoint> fromURL(const String& url, BinaryAllocator&& allocator);
 
     // default ctor
     TXEndpoint() = default;
@@ -56,7 +56,7 @@ public: // lifecycle
     TXEndpoint& operator=(TXEndpoint&&) = default;
 
     // construct an endpoint from the tuple (protocol, ip, port) with the given allocator and protocol
-    TXEndpoint(String&& protocol, String&& ip, uint32_t port, BinaryAllocator allocator);
+    TXEndpoint(String&& protocol, String&& ip, uint32_t port, BinaryAllocator&& allocator);
 
     // copy constructor
     TXEndpoint(const TXEndpoint& o);

--- a/src/k2/transport/TXEndpoint.h
+++ b/src/k2/transport/TXEndpoint.h
@@ -44,7 +44,7 @@ class TXEndpoint {
 public: // lifecycle
     // construct an endpoint from a url with the given allocator
     // Returns nullptr if there was a problem parsing the url
-    static std::unique_ptr<TXEndpoint> fromURL(const String& url, std::shared_ptr<BinaryAllocator> allocator);
+    static std::unique_ptr<TXEndpoint> fromURL(const String& url, seastar::lw_shared_ptr<BinaryAllocator> allocator);
 
     // default ctor
     TXEndpoint() = default;
@@ -56,7 +56,7 @@ public: // lifecycle
     TXEndpoint& operator=(TXEndpoint&&) = default;
 
     // construct an endpoint from the tuple (protocol, ip, port) with the given allocator and protocol
-    TXEndpoint(String&& protocol, String&& ip, uint32_t port, std::shared_ptr<BinaryAllocator>allocator);
+    TXEndpoint(String&& protocol, String&& ip, uint32_t port, seastar::lw_shared_ptr<BinaryAllocator>allocator);
 
     // copy constructor
     TXEndpoint(const TXEndpoint& o);
@@ -92,7 +92,7 @@ public: // API
 
 private:
     size_t _hash;
-    std::shared_ptr<BinaryAllocator> _allocator;
+    seastar::lw_shared_ptr<BinaryAllocator> _allocator;
 
 }; // class TXEndpoint
 } // namespace k2

--- a/src/k2/transport/TXEndpoint.h
+++ b/src/k2/transport/TXEndpoint.h
@@ -44,7 +44,7 @@ class TXEndpoint {
 public: // lifecycle
     // construct an endpoint from a url with the given allocator
     // Returns nullptr if there was a problem parsing the url
-    static std::unique_ptr<TXEndpoint> fromURL(const String& url, BinaryAllocatorFunctor&& allocator);
+    static std::unique_ptr<TXEndpoint> fromURL(const String& url, std::shared_ptr<BinaryAllocator> allocator);
 
     // default ctor
     TXEndpoint() = default;
@@ -56,7 +56,7 @@ public: // lifecycle
     TXEndpoint& operator=(TXEndpoint&&) = default;
 
     // construct an endpoint from the tuple (protocol, ip, port) with the given allocator and protocol
-    TXEndpoint(String&& protocol, String&& ip, uint32_t port, BinaryAllocatorFunctor&& allocator);
+    TXEndpoint(String&& protocol, String&& ip, uint32_t port, std::shared_ptr<BinaryAllocator>allocator);
 
     // copy constructor
     TXEndpoint(const TXEndpoint& o);
@@ -92,7 +92,7 @@ public: // API
 
 private:
     size_t _hash;
-    BinaryAllocatorFunctor _allocator;
+    std::shared_ptr<BinaryAllocator> _allocator;
 
 }; // class TXEndpoint
 } // namespace k2

--- a/src/k2/transport/VirtualNetworkStack.cpp
+++ b/src/k2/transport/VirtualNetworkStack.cpp
@@ -79,7 +79,7 @@ std::shared_ptr<BinaryAllocator> VirtualNetworkStack::getTCPAllocator() {
 
     // NB, there is no performance benefit of allocating smaller chunks. Chunks up to 16384 are allocated from
     // seastar pool allocator and overhead is the same regardless of size(~10ns per allocation)
-    return std::make_shared<BinaryAllocator>(tcpsegsize);
+    return Payload::DefaultAllocator(tcpsegsize);
 }
 
 void VirtualNetworkStack::registerLowTCPMemoryObserver(LowMemoryObserver_t observer) {
@@ -111,7 +111,7 @@ VirtualNetworkStack::connectRRDMA(seastar::rdma::EndPoint remoteAddress) {
 }
 
 std::shared_ptr<BinaryAllocator> VirtualNetworkStack::getRRDMAAllocator() {
-    return std::make_shared<BinaryAllocator>(rrdmasegsize);
+    return Payload::DefaultAllocator(rrdmasegsize);
 }
 
 void VirtualNetworkStack::registerLowRRDMAMemoryObserver(LowMemoryObserver_t observer) {

--- a/src/k2/transport/VirtualNetworkStack.cpp
+++ b/src/k2/transport/VirtualNetworkStack.cpp
@@ -68,7 +68,7 @@ void VirtualNetworkStack::start(){
     K2LOG_D(log::tx, "start");
 }
 
-std::shared_ptr<BinaryAllocator> VirtualNetworkStack::getTCPAllocator() {
+seastar::lw_shared_ptr<BinaryAllocator> VirtualNetworkStack::getTCPAllocator() {
     // The seastar stacks don't expose allocation mechanism so we just allocate
     // the binaries in user space
 
@@ -110,7 +110,7 @@ VirtualNetworkStack::connectRRDMA(seastar::rdma::EndPoint remoteAddress) {
     return seastar::engine()._rdma_stack->connect(std::move(remoteAddress));
 }
 
-std::shared_ptr<BinaryAllocator> VirtualNetworkStack::getRRDMAAllocator() {
+seastar::lw_shared_ptr<BinaryAllocator> VirtualNetworkStack::getRRDMAAllocator() {
     return Payload::DefaultAllocator(rrdmasegsize);
 }
 

--- a/src/k2/transport/VirtualNetworkStack.cpp
+++ b/src/k2/transport/VirtualNetworkStack.cpp
@@ -24,7 +24,6 @@ Copyright(c) 2020 Futurewei Cloud
 #include "VirtualNetworkStack.h"
 
 // third-party
-#include <memory>
 #include <seastar/core/reactor.hh>
 #include <seastar/net/net.hh>
 

--- a/src/k2/transport/VirtualNetworkStack.cpp
+++ b/src/k2/transport/VirtualNetworkStack.cpp
@@ -68,7 +68,7 @@ void VirtualNetworkStack::start(){
     K2LOG_D(log::tx, "start");
 }
 
-seastar::lw_shared_ptr<BinaryAllocator> VirtualNetworkStack::getTCPAllocator() {
+BinaryAllocator VirtualNetworkStack::getTCPAllocator() {
     // The seastar stacks don't expose allocation mechanism so we just allocate
     // the binaries in user space
 
@@ -110,7 +110,7 @@ VirtualNetworkStack::connectRRDMA(seastar::rdma::EndPoint remoteAddress) {
     return seastar::engine()._rdma_stack->connect(std::move(remoteAddress));
 }
 
-seastar::lw_shared_ptr<BinaryAllocator> VirtualNetworkStack::getRRDMAAllocator() {
+BinaryAllocator VirtualNetworkStack::getRRDMAAllocator() {
     return Payload::DefaultAllocator(rrdmasegsize);
 }
 

--- a/src/k2/transport/VirtualNetworkStack.h
+++ b/src/k2/transport/VirtualNetworkStack.h
@@ -64,8 +64,8 @@ public: // TCP API
     // It is up to caller to shutdown the input/output when the socket should be closed
     seastar::future<seastar::connected_socket> connectTCP(SocketAddress remoteAddress, SocketAddress sourceAddress={});
 
-    // Create a payload from the TCP provider
-    BinaryAllocatorFunctor getTCPAllocator();
+    // Create a binary allocator from the TCP provider
+    std::shared_ptr<BinaryAllocator> getTCPAllocator();
 
     // registerLowTCPMemoryObserver allows the user to register a observer which will be called when
     // the TCP stack becomes low on memory and requires the application to release some buffers back.
@@ -87,8 +87,8 @@ public: // RDMA API
     // Create an RRDMA connection to connect to a given remote address.
     std::unique_ptr<seastar::rdma::RDMAConnection> connectRRDMA(seastar::rdma::EndPoint remoteAddress);
 
-    // Create a binary from the RRDMA provider
-    BinaryAllocatorFunctor getRRDMAAllocator();
+    // Create a binary allocator from the RRDMA provider
+    std::shared_ptr<BinaryAllocator> getRRDMAAllocator();
 
     // RegisterLowRRDMAMemoryObserver allows the user to register a observer which will be called when
     // the RRDMA stack becomes low on memory and requires the application to release some buffers back.

--- a/src/k2/transport/VirtualNetworkStack.h
+++ b/src/k2/transport/VirtualNetworkStack.h
@@ -65,7 +65,7 @@ public: // TCP API
     seastar::future<seastar::connected_socket> connectTCP(SocketAddress remoteAddress, SocketAddress sourceAddress={});
 
     // Create a binary allocator from the TCP provider
-    std::shared_ptr<BinaryAllocator> getTCPAllocator();
+    seastar::lw_shared_ptr<BinaryAllocator> getTCPAllocator();
 
     // registerLowTCPMemoryObserver allows the user to register a observer which will be called when
     // the TCP stack becomes low on memory and requires the application to release some buffers back.
@@ -88,7 +88,7 @@ public: // RDMA API
     std::unique_ptr<seastar::rdma::RDMAConnection> connectRRDMA(seastar::rdma::EndPoint remoteAddress);
 
     // Create a binary allocator from the RRDMA provider
-    std::shared_ptr<BinaryAllocator> getRRDMAAllocator();
+    seastar::lw_shared_ptr<BinaryAllocator> getRRDMAAllocator();
 
     // RegisterLowRRDMAMemoryObserver allows the user to register a observer which will be called when
     // the RRDMA stack becomes low on memory and requires the application to release some buffers back.

--- a/src/k2/transport/VirtualNetworkStack.h
+++ b/src/k2/transport/VirtualNetworkStack.h
@@ -65,7 +65,7 @@ public: // TCP API
     seastar::future<seastar::connected_socket> connectTCP(SocketAddress remoteAddress, SocketAddress sourceAddress={});
 
     // Create a binary allocator from the TCP provider
-    seastar::lw_shared_ptr<BinaryAllocator> getTCPAllocator();
+    BinaryAllocator getTCPAllocator();
 
     // registerLowTCPMemoryObserver allows the user to register a observer which will be called when
     // the TCP stack becomes low on memory and requires the application to release some buffers back.
@@ -88,7 +88,7 @@ public: // RDMA API
     std::unique_ptr<seastar::rdma::RDMAConnection> connectRRDMA(seastar::rdma::EndPoint remoteAddress);
 
     // Create a binary allocator from the RRDMA provider
-    seastar::lw_shared_ptr<BinaryAllocator> getRRDMAAllocator();
+    BinaryAllocator getRRDMAAllocator();
 
     // RegisterLowRRDMAMemoryObserver allows the user to register a observer which will be called when
     // the RRDMA stack becomes low on memory and requires the application to release some buffers back.

--- a/test/k23si/SKVRecordTest.cpp
+++ b/test/k23si/SKVRecordTest.cpp
@@ -236,7 +236,7 @@ TEST_CASE("Test4: getSKVKeyRecord test") {
     // to payload and then read back later
     k2::dto::SKVRecord key_record = doc.getSKVKeyRecord();
     const k2::dto::SKVRecord::Storage& storage = key_record.getStorage();
-    k2::Payload payload(k2::Payload::DefaultAllocator);
+    k2::Payload payload(k2::Payload::DefaultAllocator());
     payload.write(storage);
     k2::dto::SKVRecord::Storage read_storage{};
     payload.seek(0);

--- a/test/plog/LogStreamTest.cpp
+++ b/test/plog/LogStreamTest.cpp
@@ -130,7 +130,7 @@ public:  // application lifespan
             _logStream = logStream;
         }
         String data_to_append(10000, '2');
-        Payload payload(std::make_shared<BinaryAllocator>(20000));
+        Payload payload(Payload::DefaultAllocator(20000));
         payload.write(data_to_append);
         // write a string to the first log stream
         return _logStream->append_data_to_plogs(dto::AppendRequest{.payload=std::move(payload)})
@@ -167,7 +167,7 @@ public:  // application lifespan
         String data_to_append(10000, '3');
         std::vector<seastar::future<std::tuple<Status, dto::AppendResponse>> > writeFutures;
         for (uint32_t i = 0; i < 2000; ++i){
-            Payload payload(std::make_shared<BinaryAllocator>(20000));
+            Payload payload(Payload::DefaultAllocator(20000));
             payload.write(data_to_append);
             writeFutures.push_back(_logStream->append_data_to_plogs(dto::AppendRequest{.payload=std::move(payload)}));
         }
@@ -237,7 +237,7 @@ public:  // application lifespan
             K2EXPECT(log::ltest, count, 2000);
             std::vector<seastar::future<std::tuple<Status, dto::AppendResponse>> > writeFutures;
             for (uint32_t i = 0; i < 2000; ++i){
-                Payload payload(std::make_shared<BinaryAllocator>(20000));
+                Payload payload(Payload::DefaultAllocator(20000));
                 payload.write(data_to_append);
                 writeFutures.push_back(_logStream->append_data_to_plogs(dto::AppendRequest{.payload=std::move(payload)}));
             }
@@ -381,7 +381,7 @@ public:  // application lifespan
 
             std::vector<seastar::future<std::tuple<Status, dto::AppendResponse>> > writeFutures;
             for (uint32_t i = 0; i < 2000; ++i){
-                Payload payload(std::make_shared<BinaryAllocator>(20000));
+                Payload payload(Payload::DefaultAllocator(20000));
                 payload.write(data_to_append);
                 writeFutures.push_back(_reload_logStream->append_data_to_plogs(dto::AppendRequest{.payload=std::move(payload)}));
             }

--- a/test/plog/LogStreamTest.cpp
+++ b/test/plog/LogStreamTest.cpp
@@ -130,7 +130,7 @@ public:  // application lifespan
             _logStream = logStream;
         }
         String data_to_append(10000, '2');
-        Payload payload([] { return Binary(20000); });
+        Payload payload(std::make_shared<BinaryAllocator>(20000));
         payload.write(data_to_append);
         // write a string to the first log stream
         return _logStream->append_data_to_plogs(dto::AppendRequest{.payload=std::move(payload)})
@@ -167,7 +167,7 @@ public:  // application lifespan
         String data_to_append(10000, '3');
         std::vector<seastar::future<std::tuple<Status, dto::AppendResponse>> > writeFutures;
         for (uint32_t i = 0; i < 2000; ++i){
-            Payload payload([] { return Binary(20000); });
+            Payload payload(std::make_shared<BinaryAllocator>(20000));
             payload.write(data_to_append);
             writeFutures.push_back(_logStream->append_data_to_plogs(dto::AppendRequest{.payload=std::move(payload)}));
         }
@@ -237,7 +237,7 @@ public:  // application lifespan
             K2EXPECT(log::ltest, count, 2000);
             std::vector<seastar::future<std::tuple<Status, dto::AppendResponse>> > writeFutures;
             for (uint32_t i = 0; i < 2000; ++i){
-                Payload payload([] { return Binary(20000); });
+                Payload payload(std::make_shared<BinaryAllocator>(20000));
                 payload.write(data_to_append);
                 writeFutures.push_back(_logStream->append_data_to_plogs(dto::AppendRequest{.payload=std::move(payload)}));
             }
@@ -381,7 +381,7 @@ public:  // application lifespan
 
             std::vector<seastar::future<std::tuple<Status, dto::AppendResponse>> > writeFutures;
             for (uint32_t i = 0; i < 2000; ++i){
-                Payload payload([] { return Binary(20000); });
+                Payload payload(std::make_shared<BinaryAllocator>(20000));
                 payload.write(data_to_append);
                 writeFutures.push_back(_reload_logStream->append_data_to_plogs(dto::AppendRequest{.payload=std::move(payload)}));
             }

--- a/test/plog/PlogClientTest.cpp
+++ b/test/plog/PlogClientTest.cpp
@@ -144,7 +144,7 @@ public:  // application lifespan
             auto& [status, resp] = response;
             K2EXPECT(log::ptest, status, Statuses::S409_Conflict);
 
-            Payload payload(std::make_shared<BinaryAllocator>(4096));
+            Payload payload(Payload::DefaultAllocator(4096));
             payload.write("1234567890");
             return _client.append(dto::PlogAppendRequest{.plogId=_plogId, .offset=0, .payload=std::move(payload)});
         })
@@ -154,7 +154,7 @@ public:  // application lifespan
             K2EXPECT(log::ptest, status, Statuses::S200_OK);
             K2EXPECT(log::ptest, return_response.newOffset, 15);
 
-            Payload payload(std::make_shared<BinaryAllocator>(4096));
+            Payload payload(Payload::DefaultAllocator(4096));
             payload.write("0987654321");
             return _client.append(dto::PlogAppendRequest{.plogId=_plogId, .offset=15, .payload=std::move(payload)});
         })
@@ -164,7 +164,7 @@ public:  // application lifespan
             K2EXPECT(log::ptest, status, Statuses::S200_OK);
             K2EXPECT(log::ptest, return_response.newOffset, 30);
 
-            Payload payload(std::make_shared<BinaryAllocator>(4096));
+            Payload payload(Payload::DefaultAllocator(4096));
             payload.write("2333333333");
             return _client.append(dto::PlogAppendRequest{.plogId=_plogId, .offset=30, .payload=std::move(payload)});
         })
@@ -174,7 +174,7 @@ public:  // application lifespan
             K2EXPECT(log::ptest, status, Statuses::S200_OK);
             K2EXPECT(log::ptest, return_response.newOffset, 45);
 
-            Payload payload(std::make_shared<BinaryAllocator>(4096));
+            Payload payload(Payload::DefaultAllocator(4096));
             payload.write("1234567890");
             return _client.append(dto::PlogAppendRequest{.plogId=_plogId, .offset=100, .payload=std::move(payload)});
         })
@@ -239,7 +239,7 @@ public:  // application lifespan
             K2EXPECT(log::ptest, status, Statuses::S409_Conflict);
             K2EXPECT(log::ptest, return_response.sealedOffset, 45);
 
-            Payload payload(std::make_shared<BinaryAllocator>(4096));
+            Payload payload(Payload::DefaultAllocator(4096));
             payload.write("1234567890");
             return _client.append(dto::PlogAppendRequest{.plogId=_plogId, .offset=45, .payload=std::move(payload)});
         })

--- a/test/plog/PlogClientTest.cpp
+++ b/test/plog/PlogClientTest.cpp
@@ -144,7 +144,7 @@ public:  // application lifespan
             auto& [status, resp] = response;
             K2EXPECT(log::ptest, status, Statuses::S409_Conflict);
 
-            Payload payload([] { return Binary(4096); });
+            Payload payload(std::make_shared<BinaryAllocator>(4096));
             payload.write("1234567890");
             return _client.append(dto::PlogAppendRequest{.plogId=_plogId, .offset=0, .payload=std::move(payload)});
         })
@@ -154,7 +154,7 @@ public:  // application lifespan
             K2EXPECT(log::ptest, status, Statuses::S200_OK);
             K2EXPECT(log::ptest, return_response.newOffset, 15);
 
-            Payload payload([] { return Binary(4096); });
+            Payload payload(std::make_shared<BinaryAllocator>(4096));
             payload.write("0987654321");
             return _client.append(dto::PlogAppendRequest{.plogId=_plogId, .offset=15, .payload=std::move(payload)});
         })
@@ -164,7 +164,7 @@ public:  // application lifespan
             K2EXPECT(log::ptest, status, Statuses::S200_OK);
             K2EXPECT(log::ptest, return_response.newOffset, 30);
 
-            Payload payload([] { return Binary(4096); });
+            Payload payload(std::make_shared<BinaryAllocator>(4096));
             payload.write("2333333333");
             return _client.append(dto::PlogAppendRequest{.plogId=_plogId, .offset=30, .payload=std::move(payload)});
         })
@@ -174,7 +174,7 @@ public:  // application lifespan
             K2EXPECT(log::ptest, status, Statuses::S200_OK);
             K2EXPECT(log::ptest, return_response.newOffset, 45);
 
-            Payload payload([] { return Binary(4096); });
+            Payload payload(std::make_shared<BinaryAllocator>(4096));
             payload.write("1234567890");
             return _client.append(dto::PlogAppendRequest{.plogId=_plogId, .offset=100, .payload=std::move(payload)});
         })
@@ -239,7 +239,7 @@ public:  // application lifespan
             K2EXPECT(log::ptest, status, Statuses::S409_Conflict);
             K2EXPECT(log::ptest, return_response.sealedOffset, 45);
 
-            Payload payload([] { return Binary(4096); });
+            Payload payload(std::make_shared<BinaryAllocator>(4096));
             payload.write("1234567890");
             return _client.append(dto::PlogAppendRequest{.plogId=_plogId, .offset=45, .payload=std::move(payload)});
         })

--- a/test/transport/PayloadTest.cpp
+++ b/test/transport/PayloadTest.cpp
@@ -85,7 +85,7 @@ data<embeddedComplex> makeData(uint32_t a, uint64_t b, char x, int ya, char yb, 
     result.z = embeddedComplex{.a=std::move(za), .b=zb, .c=zc};
     if (pdata) {
         String pp(pdata);
-        result.c = Payload([allocSize]{return Binary(allocSize);});
+        result.c = Payload(std::make_shared<BinaryAllocator>(allocSize));
         result.c.write(pp);
     }
     result.dur = dur;
@@ -113,7 +113,7 @@ SCENARIO("test empty payload serialization") {
     REQUIRE(shared.getCapacity() == 0);
     REQUIRE(shared.computeCrc32c() == 0);
 
-    Payload dst([]() { return Binary(999); });
+    Payload dst(std::make_shared<BinaryAllocator>(999));
     dst.write(src);
     REQUIRE(dst.getCurrentPosition().bufferIndex == 1);
     REQUIRE(dst.getCurrentPosition().bufferOffset == 0);
@@ -147,7 +147,7 @@ SCENARIO("test empty payload serialization") {
 }
 
 SCENARIO("test multi-buffer serialization") {
-    Payload dst([]() { return Binary(11); });
+    Payload dst(std::make_shared<BinaryAllocator>(11));
     String s(100, 'x');
     dst.write(s);
 
@@ -160,7 +160,7 @@ SCENARIO("test multi-buffer serialization") {
     REQUIRE(q == s);
 
     dst.seek(0);
-    Payload dst2([]() { return Binary(23); });
+    Payload dst2(std::make_shared<BinaryAllocator>(23));
     dst2.write(dst);
     REQUIRE(dst2.getSize() == 113); // 8 bytes for size + 105 bytes from dst
     dst2.write(s);
@@ -182,8 +182,8 @@ SCENARIO("test multi-buffer serialization") {
     REQUIRE(pb == dst);
     REQUIRE(pa == pb);
 
-    Payload p1([]() { return Binary(4096); });
-    Payload p2([]() { return Binary(20); });
+    Payload p1(std::make_shared<BinaryAllocator>(4096));
+    Payload p2(std::make_shared<BinaryAllocator>(20));
     int32_t a = 10;
     p1.write(a);
     p2.write(p1);
@@ -209,7 +209,7 @@ SCENARIO("Serialize/deserialze empty SerializeAsPayload<T>") {
     d.a = 100;
     d.b = 200;
     d.x = '!';
-    Payload dst([] { return Binary(1500); });
+    Payload dst(std::make_shared<BinaryAllocator>(1500));
     dst.write(d);
     dst.seek(0);
 
@@ -224,7 +224,7 @@ SCENARIO("Serialize/deserialze empty SerializeAsPayload<T>") {
         for (int i = 0; i < 100000; ++i) {
             bvec.push_back(blanks{});
             auto idx = uint64_t(std::rand()) % bvec.size();
-            Payload dst([] { return Binary(1500); });
+            Payload dst(std::make_shared<BinaryAllocator>(1500));
             dst.write(bvec[idx]);
             dst.seek(0);
             REQUIRE(dst.computeCrc32c() == 1383945041);
@@ -240,7 +240,7 @@ SCENARIO("Serialize/deserialze empty SerializeAsPayload<T>") {
             d.a = 1;
             d.b = 2;
             d.x = '!';
-            Payload dst([] { return Binary(1500); });
+            Payload dst(std::make_shared<BinaryAllocator>(1500));
             dst.write(d);
             data<Payload> recv;
             dst.seek(0);
@@ -262,7 +262,7 @@ SCENARIO("test empty payload serialization after some data") {
     testCases.push_back(makeData(1111, 22222, 'd', 44444, 'i', 123123456, s, 124123456, 's', s.c_str(), s, 109, Duration(21s)));
     testCases.push_back(makeData(1111, 22222, 'd', 44444, 'i', 123123456, s, 1241223456, 's', nullptr, s, 203, Duration(123456789s)));
     for (auto& d: testCases) {
-        Payload dst([] { return Binary(111); });
+        Payload dst(std::make_shared<BinaryAllocator>(111));
         dst.write(d);
         dst.seek(0);
         auto chksum = dst.computeCrc32c();
@@ -283,7 +283,7 @@ SCENARIO("test empty payload serialization after some data") {
         REQUIRE(cmplx == d.w.val);
 
         // write the parsed data back and make sure checksum remains the same
-        Payload dst2([] { return Binary(110); });
+        Payload dst2(std::make_shared<BinaryAllocator>(110));
         dst2.write(parsed);
         dst2.seek(0);
         REQUIRE(chksum == dst2.computeCrc32c());
@@ -304,12 +304,12 @@ SCENARIO("test copy from payload") {
     testCases.push_back(makeData(1111, 22222, 'd', 44444, 'i', 123123456, s, 124123456, 's', s.c_str(), s, 109, Duration(21s)));
     testCases.push_back(makeData(1111, 22222, 'd', 44444, 'i', 123123456, s, 1241223456, 's', nullptr, s, 203, Duration(123456789s)));
     for (auto& d: testCases) {
-        Payload dst([] { return Binary(111); });
+        Payload dst(std::make_shared<BinaryAllocator>(111));
         dst.write(d);
         dst.seek(0);
         auto chksum = dst.computeCrc32c();
 
-        Payload dst2([] { return Binary(111); });
+        Payload dst2(std::make_shared<BinaryAllocator>(111));
         dst2.copyFromPayload(dst, dst.getSize());
         dst2.seek(0);
 
@@ -331,7 +331,7 @@ SCENARIO("test shareAll() and shareRegion()") {
     testCases.push_back(makeData(1111, 22222, 'd', 44444, 'i', 123123456, s, 124123456, 's', s.c_str(), s, 109, Duration(21s)));
     testCases.push_back(makeData(1111, 22222, 'd', 44444, 'i', 123123456, s, 1241223456, 's', nullptr, s, 203, Duration(123456789s)));
 
-    Payload dst([] { return Binary(4096); });
+    Payload dst(std::make_shared<BinaryAllocator>(4096));
     std::vector<uint32_t> offsetCheckPoint;
     for (auto& d: testCases) {
         offsetCheckPoint.push_back(dst.getSize());
@@ -370,7 +370,7 @@ SCENARIO("test shareAll() and shareRegion()") {
 }
 
 SCENARIO("test getSerializedSizeOf method") {
-    Payload src([] { return Binary(32); } );
+    Payload src(std::make_shared<BinaryAllocator>(32));
     char a = 'a';
     String b = "test getSerializedSizeOf method";
     std::decimal::decimal64 c(323.435);
@@ -400,7 +400,7 @@ SCENARIO("test getSerializedSizeOf method") {
             {2, {2, 3}},
             {3, {3, 4, 5}},
     };
-    Payload j([] { return Binary(32); });
+    Payload j(std::make_shared<BinaryAllocator>(32));
     j.write(b);
 
     src.write(a);

--- a/test/transport/PayloadTest.cpp
+++ b/test/transport/PayloadTest.cpp
@@ -85,7 +85,7 @@ data<embeddedComplex> makeData(uint32_t a, uint64_t b, char x, int ya, char yb, 
     result.z = embeddedComplex{.a=std::move(za), .b=zb, .c=zc};
     if (pdata) {
         String pp(pdata);
-        result.c = Payload(std::make_shared<BinaryAllocator>(allocSize));
+        result.c = Payload(Payload::DefaultAllocator(allocSize));
         result.c.write(pp);
     }
     result.dur = dur;
@@ -113,7 +113,7 @@ SCENARIO("test empty payload serialization") {
     REQUIRE(shared.getCapacity() == 0);
     REQUIRE(shared.computeCrc32c() == 0);
 
-    Payload dst(std::make_shared<BinaryAllocator>(999));
+    Payload dst(Payload::DefaultAllocator(999));
     dst.write(src);
     REQUIRE(dst.getCurrentPosition().bufferIndex == 1);
     REQUIRE(dst.getCurrentPosition().bufferOffset == 0);
@@ -147,7 +147,7 @@ SCENARIO("test empty payload serialization") {
 }
 
 SCENARIO("test multi-buffer serialization") {
-    Payload dst(std::make_shared<BinaryAllocator>(11));
+    Payload dst(Payload::DefaultAllocator(11));
     String s(100, 'x');
     dst.write(s);
 
@@ -160,7 +160,7 @@ SCENARIO("test multi-buffer serialization") {
     REQUIRE(q == s);
 
     dst.seek(0);
-    Payload dst2(std::make_shared<BinaryAllocator>(23));
+    Payload dst2(Payload::DefaultAllocator(23));
     dst2.write(dst);
     REQUIRE(dst2.getSize() == 113); // 8 bytes for size + 105 bytes from dst
     dst2.write(s);
@@ -182,8 +182,8 @@ SCENARIO("test multi-buffer serialization") {
     REQUIRE(pb == dst);
     REQUIRE(pa == pb);
 
-    Payload p1(std::make_shared<BinaryAllocator>(4096));
-    Payload p2(std::make_shared<BinaryAllocator>(20));
+    Payload p1(Payload::DefaultAllocator(4096));
+    Payload p2(Payload::DefaultAllocator(20));
     int32_t a = 10;
     p1.write(a);
     p2.write(p1);
@@ -209,7 +209,7 @@ SCENARIO("Serialize/deserialze empty SerializeAsPayload<T>") {
     d.a = 100;
     d.b = 200;
     d.x = '!';
-    Payload dst(std::make_shared<BinaryAllocator>(1500));
+    Payload dst(Payload::DefaultAllocator(1500));
     dst.write(d);
     dst.seek(0);
 
@@ -224,7 +224,7 @@ SCENARIO("Serialize/deserialze empty SerializeAsPayload<T>") {
         for (int i = 0; i < 100000; ++i) {
             bvec.push_back(blanks{});
             auto idx = uint64_t(std::rand()) % bvec.size();
-            Payload dst(std::make_shared<BinaryAllocator>(1500));
+            Payload dst(Payload::DefaultAllocator(1500));
             dst.write(bvec[idx]);
             dst.seek(0);
             REQUIRE(dst.computeCrc32c() == 1383945041);
@@ -240,7 +240,7 @@ SCENARIO("Serialize/deserialze empty SerializeAsPayload<T>") {
             d.a = 1;
             d.b = 2;
             d.x = '!';
-            Payload dst(std::make_shared<BinaryAllocator>(1500));
+            Payload dst(Payload::DefaultAllocator(1500));
             dst.write(d);
             data<Payload> recv;
             dst.seek(0);
@@ -262,7 +262,7 @@ SCENARIO("test empty payload serialization after some data") {
     testCases.push_back(makeData(1111, 22222, 'd', 44444, 'i', 123123456, s, 124123456, 's', s.c_str(), s, 109, Duration(21s)));
     testCases.push_back(makeData(1111, 22222, 'd', 44444, 'i', 123123456, s, 1241223456, 's', nullptr, s, 203, Duration(123456789s)));
     for (auto& d: testCases) {
-        Payload dst(std::make_shared<BinaryAllocator>(111));
+        Payload dst(Payload::DefaultAllocator(111));
         dst.write(d);
         dst.seek(0);
         auto chksum = dst.computeCrc32c();
@@ -283,7 +283,7 @@ SCENARIO("test empty payload serialization after some data") {
         REQUIRE(cmplx == d.w.val);
 
         // write the parsed data back and make sure checksum remains the same
-        Payload dst2(std::make_shared<BinaryAllocator>(110));
+        Payload dst2(Payload::DefaultAllocator(110));
         dst2.write(parsed);
         dst2.seek(0);
         REQUIRE(chksum == dst2.computeCrc32c());
@@ -304,12 +304,12 @@ SCENARIO("test copy from payload") {
     testCases.push_back(makeData(1111, 22222, 'd', 44444, 'i', 123123456, s, 124123456, 's', s.c_str(), s, 109, Duration(21s)));
     testCases.push_back(makeData(1111, 22222, 'd', 44444, 'i', 123123456, s, 1241223456, 's', nullptr, s, 203, Duration(123456789s)));
     for (auto& d: testCases) {
-        Payload dst(std::make_shared<BinaryAllocator>(111));
+        Payload dst(Payload::DefaultAllocator(111));
         dst.write(d);
         dst.seek(0);
         auto chksum = dst.computeCrc32c();
 
-        Payload dst2(std::make_shared<BinaryAllocator>(111));
+        Payload dst2(Payload::DefaultAllocator(111));
         dst2.copyFromPayload(dst, dst.getSize());
         dst2.seek(0);
 
@@ -331,7 +331,7 @@ SCENARIO("test shareAll() and shareRegion()") {
     testCases.push_back(makeData(1111, 22222, 'd', 44444, 'i', 123123456, s, 124123456, 's', s.c_str(), s, 109, Duration(21s)));
     testCases.push_back(makeData(1111, 22222, 'd', 44444, 'i', 123123456, s, 1241223456, 's', nullptr, s, 203, Duration(123456789s)));
 
-    Payload dst(std::make_shared<BinaryAllocator>(4096));
+    Payload dst(Payload::DefaultAllocator(4096));
     std::vector<uint32_t> offsetCheckPoint;
     for (auto& d: testCases) {
         offsetCheckPoint.push_back(dst.getSize());
@@ -370,7 +370,7 @@ SCENARIO("test shareAll() and shareRegion()") {
 }
 
 SCENARIO("test getSerializedSizeOf method") {
-    Payload src(std::make_shared<BinaryAllocator>(32));
+    Payload src(Payload::DefaultAllocator(32));
     char a = 'a';
     String b = "test getSerializedSizeOf method";
     std::decimal::decimal64 c(323.435);
@@ -400,7 +400,7 @@ SCENARIO("test getSerializedSizeOf method") {
             {2, {2, 3}},
             {3, {3, 4, 5}},
     };
-    Payload j(std::make_shared<BinaryAllocator>(32));
+    Payload j(Payload::DefaultAllocator(32));
     j.write(b);
 
     src.write(a);


### PR DESCRIPTION
Change to use a BinaryAllocator to replace the original BinaryAllocatorFunctor due to the following reasons:
1) holds a default block size, which the function could not have such a state
2) provide a method to allocate by a specific size instead of the default block size

All unit tests and integration tests passed.

root@b0d49a77c3ce:/build# cd build/test && ctest
Test project /build/build/test
    Start 1: plogmock
1/9 Test #1: plogmock .........................   Passed    0.38 sec
    Start 2: persistent_volume
2/9 Test #2: persistent_volume ................   Passed    3.09 sec
    Start 3: transport
3/9 Test #3: transport ........................   Passed    0.09 sec
    Start 4: readcache
4/9 Test #4: readcache ........................   Passed    0.03 sec
    Start 5: skv_record
5/9 Test #5: skv_record .......................   Passed    0.05 sec
    Start 6: key_encoding
6/9 Test #6: key_encoding .....................   Passed    0.04 sec
    Start 7: skv_ser
7/9 Test #7: skv_ser ..........................   Passed    0.04 sec
    Start 8: expression
8/9 Test #8: expression .......................   Passed    0.05 sec
    Start 9: transport
9/9 Test #9: transport ........................   Passed    0.04 sec

100% tests passed, 0 tests failed out of 9

Total Test time (real) =   3.96 sec

