### PR TITLE
YCSB update operation issue

### DIFF
--- a/src/k2/cmd/ycsb/data.h
+++ b/src/k2/cmd/ycsb/data.h
@@ -166,7 +166,7 @@ seastar::future<WriteResult> writeRow(YCSBData& row, K2TxnHandle& txn, bool eras
 
 // function to update the partial fields for a YCSB Data row
 seastar::future<PartialUpdateResult>
-partialUpdateRow(uint32_t keyid, std::vector<String> fieldValues, std::vector<uint32_t> fieldsToUpdate, K2TxnHandle& txn, bool isonehot=false) {
+partialUpdateRow(uint32_t keyid, std::vector<String> fieldValues, std::vector<uint32_t> fieldsToUpdate, K2TxnHandle& txn, uint32_t field_length, bool isonehot=false) {
 
     dto::SKVRecord skv_record(YCSBData::collectionName, YCSBData::schema); // create SKV record
 
@@ -174,7 +174,7 @@ partialUpdateRow(uint32_t keyid, std::vector<String> fieldValues, std::vector<ui
 
     for(uint32_t field=0; field<YCSBData::ycsb_schema.fields.size(); field++){
         if(field==0) { // 0 is the key and cannot be updated
-            skv_record.serializeNext<String>(YCSBData::idToKey(keyid,YCSBData::ycsb_schema.fields.size())); // add key
+            skv_record.serializeNext<String>(YCSBData::idToKey(keyid,field_length)); // add key
         } else if(cur==fieldsToUpdate.size() || fieldsToUpdate[cur]!=field) { // fields to update are in order
             skv_record.serializeNull();
         } else {

--- a/src/k2/cmd/ycsb/data.h
+++ b/src/k2/cmd/ycsb/data.h
@@ -145,7 +145,7 @@ private:
 };
 
 // function to write the given YCSB Data row
-seastar::future<WriteResult> writeRow(YCSBData& row, K2TxnHandle& txn, bool erase = false, ExistencePrecondition precondition = ExistencePrecondition::None)
+seastar::future<WriteResult> writeRow(YCSBData& row, K2TxnHandle& txn, bool erase = false, ExistencePrecondition precondition = ExistencePrecondition::None, bool isonehot=false)
 {
     dto::SKVRecord skv_record(YCSBData::collectionName, YCSBData::schema); // create SKV record
 
@@ -153,7 +153,8 @@ seastar::future<WriteResult> writeRow(YCSBData& row, K2TxnHandle& txn, bool eras
         skv_record.serializeNext<String>(field); // add fields to SKV record
     }
 
-    return txn.write<dto::SKVRecord>(skv_record, erase, precondition).then([] (WriteResult&& result) {
+
+    return txn.write<dto::SKVRecord>(skv_record, erase, precondition, isonehot).then([] (WriteResult&& result) {
         if (!result.status.is2xxOK() && result.status.code!=412 && result.status.code!=404) { // k2::Statuses::S412_Precondition_Failed for write with erase=false and key already exists and k2::Statuses::S404_Not_Found for write with erase=true and key does not exist
             K2LOG_D(log::ycsb, "writeRow failed and is retryable: {}", result.status);
             return seastar::make_exception_future<WriteResult>(std::runtime_error("writeRow failed!"));
@@ -165,7 +166,7 @@ seastar::future<WriteResult> writeRow(YCSBData& row, K2TxnHandle& txn, bool eras
 
 // function to update the partial fields for a YCSB Data row
 seastar::future<PartialUpdateResult>
-partialUpdateRow(uint32_t keyid, std::vector<String> fieldValues, std::vector<uint32_t> fieldsToUpdate, K2TxnHandle& txn) {
+partialUpdateRow(uint32_t keyid, std::vector<String> fieldValues, std::vector<uint32_t> fieldsToUpdate, K2TxnHandle& txn, bool isonehot=false) {
 
     dto::SKVRecord skv_record(YCSBData::collectionName, YCSBData::schema); // create SKV record
 
@@ -182,8 +183,9 @@ partialUpdateRow(uint32_t keyid, std::vector<String> fieldValues, std::vector<ui
         }
     }
 
-    return txn.partialUpdate<dto::SKVRecord>(skv_record, std::move(fieldsToUpdate)).then([] (PartialUpdateResult&& result) {
-        if (!result.status.is2xxOK() && result.status.code!=412 && result.status.code!=404) { // 412 for precondition of exists not satisfied and 404 for key not found
+
+    return txn.partialUpdate<dto::SKVRecord>(skv_record, std::move(fieldsToUpdate), dto::Key(), isonehot).then([] (PartialUpdateResult&& result) {
+        if (!result.status.is2xxOK() && result.status.code!=412 && result.status.code!=404) { // 412 for precondition of Exists not satisfied and 404 for key not found
             K2LOG_D(log::ycsb, "partialUpdateRow failed: {}", result.status);
             return seastar::make_exception_future<PartialUpdateResult>(std::runtime_error("partialUpdateRow failed!"));
         }

--- a/src/k2/cmd/ycsb/transactions.h
+++ b/src/k2/cmd/ycsb/transactions.h
@@ -220,7 +220,7 @@ private:
         }
 
         _onehot = _ops_per_txn()==1?_isonehot():false; // flag for one-hot transactions
-        return partialUpdateRow(_keyid,std::move(fieldValues),std::move(fieldsToUpdate),_txn, _onehot).discard_result();
+        return partialUpdateRow(_keyid,std::move(fieldValues),std::move(fieldsToUpdate),_txn, _field_length(), _onehot).discard_result();
     }
 
     seastar::future<> scanOperation(){
@@ -231,7 +231,7 @@ private:
             CHECK_READ_STATUS(response);
             // make Query request and set query rules
             _query_scan = std::move(response.query);
-            _query_scan.startScanRecord.serializeNext<String>(YCSBData::idToKey(_keyid,_num_fields()));
+            _query_scan.startScanRecord.serializeNext<String>(YCSBData::idToKey(_keyid,_field_length()));
             _query_scan.setLimit(_scanLengthDist->getValue()); // get specified number of entries (got from scanLength Distribution) starting from given key
             _query_scan.setReverseDirection(false);
 

--- a/src/k2/cmd/ycsb/transactions.h
+++ b/src/k2/cmd/ycsb/transactions.h
@@ -90,7 +90,7 @@ public:
 
     YCSBTxn(RandomContext& random, K23SIClient& client,
              std::shared_ptr<RandomGenerator> requestDist, std::shared_ptr<RandomGenerator> scanLengthDist) :
-                        _random(random), _client(client), _failed(false), _requestDist(requestDist), _scanLengthDist(scanLengthDist) {}
+                        _random(random), _client(client), _failed(false), _requestDist(requestDist), _scanLengthDist(scanLengthDist), _onehot(false) {}
 
      seastar::future<bool> attempt() {
         K2TxnOptions options{};
@@ -164,6 +164,9 @@ private:
                 fut.ignore_ready_future();
                 K2LOG_D(log::ycsb, "Txn finished");
 
+                if(_onehot) // one hot transaction and succeeded
+                    return seastar::make_ready_future<EndResult>(EndResult(Statuses::S200_OK("one hot transaction ended successfully")));
+
                 return _txn.end(true);
             }).then_wrapped([this] (auto&& fut) {
                 if (fut.failed()) {
@@ -216,7 +219,8 @@ private:
             cur++;
         }
 
-        return partialUpdateRow(_keyid,std::move(fieldValues),std::move(fieldsToUpdate),_txn).discard_result();
+        _onehot = _ops_per_txn()==1?_isonehot():false; // flag for one-hot transactions
+        return partialUpdateRow(_keyid,std::move(fieldValues),std::move(fieldsToUpdate),_txn, _onehot).discard_result();
     }
 
     seastar::future<> scanOperation(){
@@ -269,7 +273,8 @@ private:
         if(_requestDistName()!="latest") {
             K2LOG_D(log::ycsb, "Insert operation started for keyid {}", _keyid);
             YCSBData row(_keyid, _random); // generate row
-            return writeRow(row, _txn).discard_result();
+            _onehot = _ops_per_txn()==1?_isonehot():false; // flag for one-hot transactions
+            return writeRow(row, _txn, false, ExistencePrecondition::None, _onehot).discard_result();
         }
 
         _keyid = _requestDist->getMaxValue()+1;
@@ -277,7 +282,9 @@ private:
 
         //handle latest distribution separately to identify insert fails and increment latest known record max key value
         K2LOG_D(log::ycsb, "Insert operation started for keyid {}", _keyid);
-        return writeRow(row, _txn, false, ExistencePrecondition::NotExists) // if record with given key already exists must return error so we set precondition to Exists
+
+        _onehot = _ops_per_txn()==1?_isonehot():false; // flag for one-hot transactions
+        return writeRow(row, _txn, false, ExistencePrecondition::NotExists, _onehot) // if record with given key already exists must return error so we set precondition to NotExists
             .then_wrapped([this] (auto&& fut) {
                 if (fut.failed()) {
                     fut.ignore_ready_future();
@@ -301,7 +308,8 @@ private:
     seastar::future<> deleteOperation(){
         K2LOG_D(log::ycsb, "Delete operation started for keyid {}", _keyid);
         YCSBData row(_keyid); // generate row
-        return writeRow(row, _txn, true).discard_result();
+        _onehot = _ops_per_txn()==1?_isonehot():false; // flag for one-hot transactions
+        return writeRow(row, _txn, true, ExistencePrecondition::None, _onehot).discard_result();
     }
 
     Query _query_scan;
@@ -317,6 +325,7 @@ private:
     std::shared_ptr<RandomGenerator> _requestDist; // Request distribution for selecting keys
     std::shared_ptr<RandomGenerator> _scanLengthDist; // Request distribution for selecting length of scan
     uint64_t _insertMissesLatest{0}; // number of inserts missed when request distribution is Latest distribution
+    bool _onehot; // set to true if one hot transaction
 
 private:
     ConfigVar<uint64_t> _ops_per_txn{"ops_per_txn"};
@@ -324,4 +333,5 @@ private:
     ConfigVar<uint32_t> _num_fields{"num_fields"};
     ConfigVar<uint32_t> _max_fields_update{"max_fields_update"};
     ConfigVar<String> _requestDistName{"request_dist"};
+    ConfigVar<bool> _isonehot{"isonehot"};
 };

--- a/src/k2/cmd/ycsb/ycsb_client.cpp
+++ b/src/k2/cmd/ycsb/ycsb_client.cpp
@@ -178,7 +178,7 @@ private:
         int id = seastar::this_shard_id();
         int share = _num_keys / cpus; // number of records loaded per cpu, the last one can have more than share loads
 
-        auto f = seastar::sleep(5s); // sleep for collection to be loaded first
+        auto f = seastar::make_ready_future<>();
         if (id == 0) { // only shard 0 loads the collection
             f = f.then ([this] {
                 K2LOG_I(log::ycsb, "Creating collection");

--- a/src/k2/cmd/ycsb/ycsb_client.cpp
+++ b/src/k2/cmd/ycsb/ycsb_client.cpp
@@ -446,7 +446,8 @@ int main(int argc, char** argv) {;
         ("delete_proportion",bpo::value<double>()->default_value(0), "Delete Proportion")
         ("max_scan_length",bpo::value<uint32_t>()->default_value(10), "Maximum scan length")
         ("max_fields_update",bpo::value<uint32_t>()->default_value(1), "Maximum number of fields to update")
-        ("ops_per_txn",bpo::value<uint64_t>()->default_value(1), "The number of operations per transaction");
+        ("ops_per_txn",bpo::value<uint64_t>()->default_value(1), "The number of operations per transaction")
+        ("isonehot",bpo::value<bool>()->default_value(true),"Whether to use one hot transactions (for transactions with one write/update) or not");
 
     app.addApplet<k2::TSO_ClientLib>();
     app.addApplet<Client>();

--- a/src/k2/dto/K23SI.h
+++ b/src/k2/dto/K23SI.h
@@ -214,17 +214,18 @@ struct K23SIWriteRequest {
     Key key; // the key for the write
     SKVRecord::Storage value; // the value of the write
     std::vector<uint32_t> fieldsForPartialUpdate; // if size() > 0 then this is a partial update
+    bool isonehot = false; // flag for one hot transactions
 
     K23SIWriteRequest() = default;
     K23SIWriteRequest(PVID _pvid, String cname, K23SI_MTR _mtr, Key _trh, String _trhCollection, bool _isDelete,
                       bool _designateTRH, ExistencePrecondition _precondition, uint64_t id, Key _key, SKVRecord::Storage _value,
-                      std::vector<uint32_t> _fields) :
+                      std::vector<uint32_t> _fields, bool _isonehot=false) :
         pvid(std::move(_pvid)), collectionName(std::move(cname)), mtr(std::move(_mtr)), trh(std::move(_trh)), trhCollection(std::move(_trhCollection)),
         isDelete(_isDelete), designateTRH(_designateTRH), precondition(_precondition), request_id(id),
-        key(std::move(_key)), value(std::move(_value)), fieldsForPartialUpdate(std::move(_fields)) {}
+        key(std::move(_key)), value(std::move(_value)), fieldsForPartialUpdate(std::move(_fields)), isonehot(_isonehot) {}
 
-    K2_PAYLOAD_FIELDS(pvid, collectionName, mtr, trh, trhCollection, isDelete, designateTRH, precondition, request_id, key, value, fieldsForPartialUpdate);
-    K2_DEF_FMT(K23SIWriteRequest, pvid, collectionName, mtr, trh, trhCollection, isDelete, designateTRH, precondition, request_id, key, value, fieldsForPartialUpdate);
+    K2_PAYLOAD_FIELDS(pvid, collectionName, mtr, trh, trhCollection, isDelete, designateTRH, precondition, request_id, key, value, fieldsForPartialUpdate, isonehot);
+    K2_DEF_FMT(K23SIWriteRequest, pvid, collectionName, mtr, trh, trhCollection, isDelete, designateTRH, precondition, request_id, key, value, fieldsForPartialUpdate, isonehot);
 };
 
 struct K23SIWriteResponse {

--- a/src/k2/module/k23si/Module.cpp
+++ b/src/k2/module/k23si/Module.cpp
@@ -1182,7 +1182,7 @@ K23SIPartitionModule::_processWrite(dto::K23SIWriteRequest&& request, FastDeadli
     };
 
     bool isonehot = request.isonehot;
-    auto collection = request.collection;
+    auto collection = request.collectionName;
 
     // all checks passed - we're ready to place this WI as the latest version
     auto status = _createWI(std::move(request), vset);

--- a/src/k2/module/k23si/Module.cpp
+++ b/src/k2/module/k23si/Module.cpp
@@ -680,7 +680,7 @@ K23SIPartitionModule::handleQuery(dto::K23SIQueryRequest&& request, dto::K23SIQu
 }
 
 seastar::future<std::tuple<Status, dto::K23SIReadResponse>>
-K23SIPartitionModule::handleRead(dto::K23SIReadRequest&& request, FastDeadline deadline) {
+K23SIPartitionModule::handleRead(dto::K23SIReadRequest&& request, FastDeadline deadline, int count) {
     K2LOG_D(log::skvsvr, "Partition: {}, received read {}", _partition, request);
 
     Status validateStatus = _validateReadRequest(request);
@@ -710,13 +710,18 @@ K23SIPartitionModule::handleRead(dto::K23SIReadRequest&& request, FastDeadline d
         return _makeReadOK(rec);
     }
 
+    if (count > 20) {
+        return RPCResponse(dto::K23SIStatus::ServiceUnavailable("Consecutive pushes, client should retry"),
+                           dto::K23SIReadResponse{});
+    }
+
     // record is still pending and isn't from same transaction.
     return _doPush(request.key, versions.WI->data.timestamp, request.mtr, deadline)
-        .then([this, request=std::move(request), deadline](auto&& retryChallenger) mutable {
+        .then([this, request=std::move(request), deadline, count](auto&& retryChallenger) mutable {
             if (!retryChallenger.is2xxOK()) {
                 return RPCResponse(dto::K23SIStatus::AbortConflict("incumbent txn won in read push"), dto::K23SIReadResponse{});
             }
-            return handleRead(std::move(request), deadline);
+            return handleRead(std::move(request), deadline, count+1);
         });
 }
 
@@ -1081,7 +1086,7 @@ K23SIPartitionModule::handleWrite(dto::K23SIWriteRequest&& request, FastDeadline
 }
 
 seastar::future<std::tuple<Status, dto::K23SIWriteResponse>>
-K23SIPartitionModule::_processWrite(dto::K23SIWriteRequest&& request, FastDeadline deadline) {
+K23SIPartitionModule::_processWrite(dto::K23SIWriteRequest&& request, FastDeadline deadline, int count) {
     K2LOG_D(log::skvsvr, "processing write: {}", request);
     auto& vset = _indexer[request.key];
     Status validateStatus = _validateWriteRequest(request, vset);
@@ -1098,11 +1103,16 @@ K23SIPartitionModule::_processWrite(dto::K23SIWriteRequest&& request, FastDeadli
 
     // check to see if we should push or is this a write from same txn
     if (vset.WI.has_value() && vset.WI->data.timestamp != request.mtr.timestamp) {
+        if (count > 20) {
+            return RPCResponse(dto::K23SIStatus::ServiceUnavailable("Consecutive pushes, client should retry"),
+                               dto::K23SIWriteResponse{});
+        }
+
         // this is a write request finding a WI from a different transaction. Do a push with the remaining
         // deadline time.
         K2LOG_D(log::skvsvr, "different WI found for key {}", request.key);
         return _doPush(request.key, vset.WI->data.timestamp, request.mtr, deadline)
-            .then([this, request = std::move(request), deadline](auto&& retryChallenger) mutable {
+            .then([this, request = std::move(request), deadline, count](auto&& retryChallenger) mutable {
                 if (!retryChallenger.is2xxOK()) {
                     // challenger must fail. Flush in case a TR was created during this call to handle write
                     K2LOG_D(log::skvsvr, "write push challenger lost for key {}", request.key);
@@ -1110,7 +1120,7 @@ K23SIPartitionModule::_processWrite(dto::K23SIWriteRequest&& request, FastDeadli
                 }
 
                 K2LOG_D(log::skvsvr, "write push retry for key {}", request.key);
-                return _processWrite(std::move(request), deadline);
+                return _processWrite(std::move(request), deadline, count + 1);
             });
     }
 

--- a/src/k2/module/k23si/Module.h
+++ b/src/k2/module/k23si/Module.h
@@ -90,7 +90,7 @@ public:
     // on behalf of an incoming read (recursively). We only perform the recursive attempt
     // to read if we were allowed to retry by the PUSH operation
     seastar::future<std::tuple<Status, dto::K23SIReadResponse>>
-    handleRead(dto::K23SIReadRequest&& request, FastDeadline deadline);
+    handleRead(dto::K23SIReadRequest&& request, FastDeadline deadline, int count = 1);
 
     seastar::future<std::tuple<Status, dto::K23SIWriteResponse>>
     handleWrite(dto::K23SIWriteRequest&& request, FastDeadline deadline);
@@ -236,7 +236,7 @@ private: // methods
 
     // helper used to process the write part of a write request
     seastar::future<std::tuple<Status, dto::K23SIWriteResponse>>
-    _processWrite(dto::K23SIWriteRequest&& request, FastDeadline deadline);
+    _processWrite(dto::K23SIWriteRequest&& request, FastDeadline deadline, int count = 1);
 
     void _unregisterVerbs();
 

--- a/src/k2/module/k23si/client/k23si_client.cpp
+++ b/src/k2/module/k23si/client/k23si_client.cpp
@@ -120,6 +120,7 @@ seastar::future<ReadResult<dto::SKVRecord>> K2TxnHandle::read(dto::Key key, Stri
 
     _client->read_ops++;
     _ongoing_ops++;
+    _total_ops++;
 
     return _cpo_client->partitionRequest
         <dto::K23SIReadRequest, dto::K23SIReadResponse, dto::Verbs::K23SI_READ>
@@ -156,7 +157,7 @@ seastar::future<ReadResult<dto::SKVRecord>> K2TxnHandle::read(dto::Key key, Stri
 
 
 std::unique_ptr<dto::K23SIWriteRequest> K2TxnHandle::_makeWriteRequest(dto::SKVRecord& record, bool erase,
-                                                                    dto::ExistencePrecondition precondition) {
+                                                                    dto::ExistencePrecondition precondition, bool isonehot=false) {
     for (const String& key : record.partitionKeys) {
         if (key == "") {
             throw K23SIClientException("Partition key field not set for write request");
@@ -187,12 +188,13 @@ std::unique_ptr<dto::K23SIWriteRequest> K2TxnHandle::_makeWriteRequest(dto::SKVR
         _client->write_ops,
         key,
         record.storage.share(),
-        std::vector<uint32_t>()
+        std::vector<uint32_t>(),
+        isonehot
     );
 }
 
 std::unique_ptr<dto::K23SIWriteRequest> K2TxnHandle::_makePartialUpdateRequest(dto::SKVRecord& record,
-                    std::vector<uint32_t> fieldsForPartialUpdate, dto::Key&& key) {
+                    std::vector<uint32_t> fieldsForPartialUpdate, dto::Key&& key, bool isonehot=false) {
         bool isTRH = !_trh_key.has_value();
         if (isTRH) {
             _trh_key = key;
@@ -211,7 +213,8 @@ std::unique_ptr<dto::K23SIWriteRequest> K2TxnHandle::_makePartialUpdateRequest(d
             _client->write_ops,
             std::move(key),
             record.storage.share(),
-            fieldsForPartialUpdate
+            fieldsForPartialUpdate,
+            isonehot
         });
     }
 
@@ -277,8 +280,8 @@ seastar::future<EndResult> K2TxnHandle::end(bool shouldCommit) {
             return _heartbeat_timer.stop().then([this, s=std::move(status)] () {
                 // TODO get min transaction time from TSO client
                 auto time_spent = Clock::now() - _start_time;
-                if (time_spent < 50us) {
-                    auto sleep = 50us - time_spent;
+                if (time_spent < 5us) {
+                    auto sleep = 5us - time_spent;
                     return seastar::sleep(sleep).then([s=std::move(s)] () {
                         return seastar::make_ready_future<EndResult>(EndResult(std::move(s)));
                     });
@@ -554,6 +557,7 @@ seastar::future<QueryResult> K2TxnHandle::query(Query& query) {
 
     _client->query_ops++;
     _ongoing_ops++;
+    _total_ops++;
 
     return _cpo_client->partitionRequest
         <dto::K23SIQueryRequest, dto::K23SIQueryResponse, dto::Verbs::K23SI_QUERY>

--- a/src/k2/transport/Payload.cpp
+++ b/src/k2/transport/Payload.cpp
@@ -435,7 +435,9 @@ Payload Payload::shareRegion(size_t startOffset, size_t nbytes){
 }
 
 Payload Payload::copy(BinaryAllocatorFunctor allocator) {
-    Payload copied(allocator);
+    (void) allocator;
+    auto myalloc = ([size=getSize()] () { return Binary(size); });
+    Payload copied(myalloc);
 
     // copy exactly the data we need
     size_t toCopy = _size;

--- a/src/k2/tso/client/tso_clientlib.cpp
+++ b/src/k2/tso/client/tso_clientlib.cpp
@@ -43,7 +43,22 @@ seastar::future<> TSO_ClientLib::start()
 
     _tSOServerURLs.emplace_back(TSOServerURL());
     // for now we use the first server URL only, in the future, allow to check other server in case first one is not available
-    return _discoverServiceNodes(_tSOServerURLs[0]);
+    std::uniform_int_distribution<int> d(0, 100);
+    std::random_device rd1;
+
+    int sleep = seastar::this_shard_id() == 0 ? 0 : d(rd1);
+    return seastar::sleep(100ms*sleep)
+    .then([this] () {
+        return _discoverServiceNodes(_tSOServerURLs[0])
+        .then([this] () {
+            K2LOG_I(log::tsoclient, "Getting bootstrap timestamp");
+            return _getTimestampBatch(1)
+            .then([this] (auto&& batch) {
+                K2LOG_I(log::tsoclient, "Got bootstrap timestamp");
+                (void) batch;
+            });
+        });
+    });
 }
 
 seastar::future<> TSO_ClientLib::gracefulStop() {
@@ -477,7 +492,7 @@ seastar::future<TimestampBatch> TSO_ClientLib::_getTimestampBatch(uint16_t batch
 {
     auto retryStrategy = k2::ExponentialBackoffStrategy();
     //TODO: need to find out if the TSO is local or remote and get the timeout config accordingly
-    retryStrategy.withRetries(3).withStartTimeout(10ms).withRate(5);
+    retryStrategy.withRetries(5).withStartTimeout(1s).withRate(5);
 
     return seastar::do_with(std::move(retryStrategy), TimestampBatch(), [this, batchSize]
         (ExponentialBackoffStrategy& rs, TimestampBatch& batch) mutable


### PR DESCRIPTION
Resolved the issue of WI =0 in metrics.

Caused due to incorrect key formed while performing partial updates. 

Used _num_fields instead of _field_length.