### PR TITLE
Update operation issue due to _field_length in YCSB

### DIFF
--- a/src/k2/cmd/ycsb/data.h
+++ b/src/k2/cmd/ycsb/data.h
@@ -165,7 +165,7 @@ seastar::future<WriteResult> writeRow(YCSBData& row, K2TxnHandle& txn, bool eras
 
 // function to update the partial fields for a YCSB Data row
 seastar::future<PartialUpdateResult>
-partialUpdateRow(uint32_t keyid, std::vector<String> fieldValues, std::vector<uint32_t> fieldsToUpdate, K2TxnHandle& txn) {
+partialUpdateRow(uint32_t keyid, std::vector<String> fieldValues, std::vector<uint32_t> fieldsToUpdate, K2TxnHandle& txn, uint32_t field_length) {
 
     dto::SKVRecord skv_record(YCSBData::collectionName, YCSBData::schema); // create SKV record
 
@@ -173,7 +173,7 @@ partialUpdateRow(uint32_t keyid, std::vector<String> fieldValues, std::vector<ui
 
     for(uint32_t field=0; field<YCSBData::ycsb_schema.fields.size(); field++){
         if(field==0) { // 0 is the key and cannot be updated
-            skv_record.serializeNext<String>(YCSBData::idToKey(keyid,YCSBData::ycsb_schema.fields.size())); // add key
+            skv_record.serializeNext<String>(YCSBData::idToKey(keyid,field_length)); // add key
         } else if(cur==fieldsToUpdate.size() || fieldsToUpdate[cur]!=field) { // fields to update are in order
             skv_record.serializeNull();
         } else {

--- a/src/k2/cmd/ycsb/transactions.h
+++ b/src/k2/cmd/ycsb/transactions.h
@@ -216,7 +216,7 @@ private:
             cur++;
         }
 
-        return partialUpdateRow(_keyid,std::move(fieldValues),std::move(fieldsToUpdate),_txn).discard_result();
+        return partialUpdateRow(_keyid,std::move(fieldValues),std::move(fieldsToUpdate),_txn,_field_length()).discard_result();
     }
 
     seastar::future<> scanOperation(){
@@ -227,7 +227,7 @@ private:
             CHECK_READ_STATUS(response);
             // make Query request and set query rules
             _query_scan = std::move(response.query);
-            _query_scan.startScanRecord.serializeNext<String>(YCSBData::idToKey(_keyid,_num_fields()));
+            _query_scan.startScanRecord.serializeNext<String>(YCSBData::idToKey(_keyid,_field_length()));
             _query_scan.setLimit(_scanLengthDist->getValue()); // get specified number of entries (got from scanLength Distribution) starting from given key
             _query_scan.setReverseDirection(false);
 


### PR DESCRIPTION
Resolved the issue of WI=0 in metrics.

Caused due to incorrect key formed while performing partial updates.

Used _num_fields instead of _field_length while creating keys.