### PR TITLE
fix indexer reverse iterator deference issue

### DIFF
--- a/src/k2/module/k23si/Module.cpp
+++ b/src/k2/module/k23si/Module.cpp
@@ -462,9 +462,7 @@ IndexerIterator K23SIPartitionModule::_initializeScan(const dto::Key& start, boo
         } else if (key_it->first == start && exclusiveKey) {
             _scanAdvance(key_it, reverse, start.schemaName);
         } else if (key_it->first > start) {
-            while (key_it->first > start) {
-                _scanAdvance(key_it, reverse, start.schemaName);
-            }
+            _scanAdvance(key_it, reverse, start.schemaName);
         }
     }
 


### PR DESCRIPTION
Fixed the reverse iterator deference issue when key_it->first was called by indexer_end().

Didn't see other obvious issues after test and debug the reverse scan logic.

Unit tests and integration tests all passed.