### PR TITLE
Health monitor

### DIFF
--- a/src/k2/cmd/controlPlaneOracle/cpo_main.cpp
+++ b/src/k2/cmd/controlPlaneOracle/cpo_main.cpp
@@ -31,11 +31,12 @@ int main(int argc, char** argv) {
     app.addOptions()
         ("nodepool_endpoints", bpo::value<std::vector<k2::String>>()->multitoken()->default_value(std::vector<k2::String>()), "A list (space-delimited) of nodepool endpoints")
         ("tso_endpoints", bpo::value<std::vector<k2::String>>()->multitoken()->default_value(std::vector<k2::String>()), "A list (space-delimited) of TSO endpoints")
-        ("k23si_persistence_endpoints", bpo::value<std::vector<k2::String>>()->multitoken()->default_value(std::vector<k2::String>()), "A list (space-delimited) of persistence endpoints")
+        ("persistence_endpoints", bpo::value<std::vector<k2::String>>()->multitoken()->default_value(std::vector<k2::String>()), "A list (space-delimited) of persistence endpoints")
         ("heartbeat_interval", bpo::value<k2::ParseableDuration>(), "The interval the health monitor uses to send heartbeats")
         ("heartbeat_batch_wait", bpo::value<k2::ParseableDuration>(), "How long the heartbeat monitor waits between batches (only for the start-up set of heartbeats")
         ("heartbeat_batch_size", bpo::value<uint32_t>()->default_value(100), "How many heartbeats the monitor sends before waiting (only for the start-up set of heartbeats")
         ("heartbeat_lost_threshold", bpo::value<uint32_t>()->default_value(3), "How many lost heartbeats are required before the monitor considers a target dead")
+        ("txn_heartbeat_deadline", bpo::value<k2::ParseableDuration>(), "The interval clients must use to heartbeat active transactions")
         ("assignment_timeout", bpo::value<k2::ParseableDuration>(), "Timeout for K2 partition assignment")
         ("data_dir", bpo::value<k2::String>(), "The directory where we can keep data");
     app.addApplet<k2::CPOService>([]() mutable -> seastar::distributed<k2::CPOService>& {

--- a/src/k2/cmd/controlPlaneOracle/cpo_main.cpp
+++ b/src/k2/cmd/controlPlaneOracle/cpo_main.cpp
@@ -36,6 +36,7 @@ int main(int argc, char** argv) {
         ("heartbeat_batch_wait", bpo::value<k2::ParseableDuration>(), "How long the heartbeat monitor waits between batches (only for the start-up set of heartbeats")
         ("heartbeat_batch_size", bpo::value<uint32_t>()->default_value(100), "How many heartbeats the monitor sends before waiting (only for the start-up set of heartbeats")
         ("heartbeat_lost_threshold", bpo::value<uint32_t>()->default_value(3), "How many lost heartbeats are required before the monitor considers a target dead")
+        ("heartbeat_monitor_shard_id", bpo::value<uint32_t>()->default_value(1), "Which shard the heartbeat monitor should run on")
         ("txn_heartbeat_deadline", bpo::value<k2::ParseableDuration>(), "The interval clients must use to heartbeat active transactions")
         ("assignment_timeout", bpo::value<k2::ParseableDuration>(), "Timeout for K2 partition assignment")
         ("data_dir", bpo::value<k2::String>(), "The directory where we can keep data");

--- a/src/k2/cmd/controlPlaneOracle/cpo_main.cpp
+++ b/src/k2/cmd/controlPlaneOracle/cpo_main.cpp
@@ -24,16 +24,24 @@ Copyright(c) 2020 Futurewei Cloud
 #include <k2/appbase/Appbase.h>
 #include <k2/infrastructure/APIServer.h>
 #include <k2/cpo/service/CPOService.h>
+#include <k2/cpo/service/HealthMonitor.h>
 
 int main(int argc, char** argv) {
     k2::App app("CPOService");
     app.addOptions()
+        ("nodepool_endpoints", bpo::value<std::vector<k2::String>>()->multitoken()->default_value(std::vector<k2::String>()), "A list (space-delimited) of nodepool endpoints")
+        ("tso_endpoints", bpo::value<std::vector<k2::String>>()->multitoken()->default_value(std::vector<k2::String>()), "A list (space-delimited) of TSO endpoints")
+        ("k23si_persistence_endpoints", bpo::value<std::vector<k2::String>>()->multitoken()->default_value(std::vector<k2::String>()), "A list (space-delimited) of persistence endpoints")
+        ("heartbeat_interval", bpo::value<k2::ParseableDuration>(), "The interval the health monitor uses to send heartbeats")
+        ("heartbeat_batch_wait", bpo::value<k2::ParseableDuration>(), "How long the heartbeat monitor waits between batches (only for the start-up set of heartbeats")
+        ("heartbeat_batch_size", bpo::value<uint32_t>()->default_value(100), "How many heartbeats the monitor sends before waiting (only for the start-up set of heartbeats")
+        ("heartbeat_lost_threshold", bpo::value<uint32_t>()->default_value(3), "How many lost heartbeats are required before the monitor considers a target dead")
         ("assignment_timeout", bpo::value<k2::ParseableDuration>(), "Timeout for K2 partition assignment")
-        ("heartbeat_deadline", bpo::value<k2::ParseableDuration>(), "K2 Txn heartbeat deadline")
         ("data_dir", bpo::value<k2::String>(), "The directory where we can keep data");
     app.addApplet<k2::CPOService>([]() mutable -> seastar::distributed<k2::CPOService>& {
         return k2::AppBase().getDist<k2::CPOService>();
     });
+    app.addApplet<k2::HealthMonitor>();
     app.addApplet<k2::APIServer>();
     return app.start(argc, argv);
 }

--- a/src/k2/cmd/nodepool/nodepool_main.cpp
+++ b/src/k2/cmd/nodepool/nodepool_main.cpp
@@ -27,6 +27,7 @@ Copyright(c) 2020 Futurewei Cloud
 #include <k2/infrastructure/APIServer.h>
 #include <k2/nodePoolMonitor/NodePoolMonitor.h>
 #include <k2/tso/client/tso_clientlib.h>
+#include <k2/cpo/client/Heartbeat.h>
 
 int main(int argc, char** argv) {
     k2::App app("NodePoolService");
@@ -41,6 +42,7 @@ int main(int argc, char** argv) {
         ("k23si_query_push_limit", bpo::value<uint32_t>(), "Min records in response needed to avoid a push during query processing")
         ("k23si_persistence_endpoints", bpo::value<std::vector<k2::String>>()->multitoken()->default_value(std::vector<k2::String>()), "A space-delimited list of k2 persistence endpoints, each core will pick one endpoint");
 
+    app.addApplet<k2::HeartbeatResponder>();
     app.addApplet<k2::APIServer>();
     app.addApplet<k2::TSO_ClientLib>();
     app.addApplet<k2::CollectionMetadataCache>();

--- a/src/k2/cmd/persistence/CMakeLists.txt
+++ b/src/k2/cmd/persistence/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_executable (persistence persistence_main.cpp)
 
-target_link_libraries (persistence PRIVATE appbase common transport Seastar::seastar persistence_service)
+target_link_libraries (persistence PRIVATE cpo_client appbase common transport Seastar::seastar persistence_service)
 
 install (TARGETS persistence DESTINATION bin)

--- a/src/k2/cmd/persistence/persistence_main.cpp
+++ b/src/k2/cmd/persistence/persistence_main.cpp
@@ -23,9 +23,11 @@ Copyright(c) 2020 Futurewei Cloud
 
 #include <k2/appbase/Appbase.h>
 #include <k2/persistence/service/PersistenceService.h>
+#include <k2/cpo/client/Heartbeat.h>
 
 int main(int argc, char** argv) {
     k2::App app("PersistenceService");
+    app.addApplet<k2::HeartbeatResponder>();
     // pass the ss::distributed container to the PersistenceService constructor
     app.addApplet<k2::PersistenceService>();
     return app.start(argc, argv);

--- a/src/k2/cmd/tso/CMakeLists.txt
+++ b/src/k2/cmd/tso/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_executable (tso tso_main.cpp)
 
-target_link_libraries (tso PRIVATE tso_service appbase common transport Seastar::seastar)
+target_link_libraries (tso PRIVATE tso_service cpo_client appbase common transport Seastar::seastar)
 
 install (TARGETS tso DESTINATION bin)

--- a/src/k2/cmd/tso/tso_main.cpp
+++ b/src/k2/cmd/tso/tso_main.cpp
@@ -22,11 +22,13 @@ Copyright(c) 2020 Futurewei Cloud
 */
 
 #include <k2/tso/service/TSOService.h>
+#include <k2/cpo/client/Heartbeat.h>
 
 int main(int argc, char** argv)
 {
     k2::App app("TSOService");
 
+    app.addApplet<k2::HeartbeatResponder>();
     app.addApplet<k2::TSOService>();
 
     return app.start(argc, argv);

--- a/src/k2/common/Timer.h
+++ b/src/k2/common/Timer.h
@@ -50,7 +50,9 @@ public:
 
     seastar::future<> stop() {
         _timer.cancel();
-        return std::move(_timerDone);
+        auto stop_fut = std::move(_timerDone);
+        _timerDone = seastar::make_ready_future();
+        return stop_fut;
     };
 
     void arm(Duration when) {

--- a/src/k2/cpo/client/Heartbeat.cpp
+++ b/src/k2/cpo/client/Heartbeat.cpp
@@ -62,7 +62,7 @@ HeartbeatResponder::_handleHeartbeat(dto::HeartbeatRequest&& request) {
     } else if (_lastSeq != request.lastToken) {
         // Monitor did not get our response
         ++_missedHBs;
-        K2LOG_I(log::cpoclient, "CPO did not get last response (token mismatch)");
+        K2LOG_D(log::cpoclient, "CPO did not get last response (token mismatch)");
         status = Statuses::S403_Forbidden("Heartbeat request token does not match");
     }
 

--- a/src/k2/cpo/client/Heartbeat.cpp
+++ b/src/k2/cpo/client/Heartbeat.cpp
@@ -1,0 +1,136 @@
+/*
+MIT License
+
+Copyright(c) 2021 Futurewei Cloud
+
+    Permission is hereby granted,
+    free of charge, to any person obtaining a copy of this software and associated documentation files(the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and / or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions :
+
+    The above copyright notice and this permission notice shall be included in all copies
+    or
+    substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS",
+    WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+    DAMAGES OR OTHER
+    LIABILITY,
+    WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+*/
+
+#include "Heartbeat.h"
+
+#include <k2/cpo/client/CPOClient.h>
+#include <k2/dto/MessageVerbs.h>
+#include <k2/transport/TCPRPCProtocol.h>
+#include <k2/transport/RRDMARPCProtocol.h>
+
+namespace k2 {
+
+void HeartbeatResponder::_registerMetrics() {
+    _metric_groups.clear();
+    std::vector<sm::label_instance> labels;
+    labels.push_back(sm::label_instance("total_cores", seastar::smp::count));
+
+    _metric_groups.add_group("HeartbeatResponder", {
+        sm::make_counter("heartbeats", _heartbeats, sm::description("Number of heartbeat requests"), labels),
+    });
+}
+
+seastar::future<std::tuple<Status, dto::HeartbeatResponse>>
+HeartbeatResponder::_handleHeartbeat(dto::HeartbeatRequest&& request) {
+    K2LOG_V(log::cpoclient, "HB Request {}", request);
+    _heartbeats++;
+
+    if (!_up) {
+        // First heartbeat we have seen, initialize the HB config
+        _HBInterval = request.interval;
+        _HBDeadThreshold = request.deadThreshold;
+        _up = true;
+    } else if (_lastSeq != request.lastToken) {
+        // Monitor did not get our response
+        ++_missedHBs;
+        K2LOG_I(log::cpoclient, "CPO did not get last response (token mismatch)");
+    }
+
+    if (_missedHBs >= _HBDeadThreshold - 1) {
+        if (_up) {
+            K2LOG_W(log::cpoclient, "Too many heartbeats missed, this node is considered down");
+            _up = false;
+        }
+        K2LOG_W(log::cpoclient, "This node is already considered down");
+        return RPCResponse(Statuses::S410_Gone("This target is down due to lack of heartbeats"),
+                                                dto::HeartbeatResponse{});
+    }
+
+    return _nextHeartbeatExpire.stop()
+    .then([this] () {
+        _lastSeq++;
+        _missedHBs = 0;
+        dto::HeartbeatResponse response {
+            _ID,
+            _metadata,
+            _eps,
+            _lastSeq
+        };
+
+        _nextHeartbeatExpire.arm(_HBInterval + (_HBInterval / 2));
+        return RPCResponse(Statuses::S200_OK("Heartbeat success"), std::move(response));
+    });
+}
+
+seastar::future<> HeartbeatResponder::gracefulStop() {
+    RPC().registerMessageObserver(dto::Verbs::CPO_HEARTBEAT, nullptr);
+
+    return _nextHeartbeatExpire.stop();
+}
+
+seastar::future<> HeartbeatResponder::start() {
+    auto tcp_ep = k2::RPC().getServerEndpoint(k2::TCPRPCProtocol::proto);
+    if (tcp_ep) {
+        _ID = tcp_ep->url;
+        _eps.push_back(tcp_ep->url);
+    }
+    auto rdma_ep = k2::RPC().getServerEndpoint(k2::RRDMARPCProtocol::proto);
+    if (rdma_ep) {
+        _eps.push_back(tcp_ep->url);
+    }
+
+    _registerMetrics();
+
+    _nextHeartbeatExpire.setCallback([this] () {
+        ++_missedHBs;
+        K2LOG_I(log::cpoclient, "Heartbeat from CPO monitor was missed");
+        if (_missedHBs >= _HBDeadThreshold - 1) {
+            K2LOG_W(log::cpoclient, "Too many heartbeats missed, this node is considered down");
+            _up = false;
+        }
+
+        if (_up) {
+            _nextHeartbeatExpire.arm(_HBInterval);
+        }
+    });
+
+    RPC().registerRPCObserver<dto::HeartbeatRequest, dto::HeartbeatResponse>
+    (dto::Verbs::CPO_HEARTBEAT, [this](dto::HeartbeatRequest&& request) {
+        return _handleHeartbeat(std::move(request));
+    });
+
+    return seastar::make_ready_future<>();
+}
+
+// Used by other applets to know if they should soft-down themselves
+bool HeartbeatResponder::isUp() {
+    return _up;
+}
+
+// Used by other applets to set role-specific metadata,
+// which is passed on to the monitor in the HB response
+void HeartbeatResponder::setRoleMetadata(String metadata) {
+    _metadata = metadata;
+}
+
+} // namespace k2

--- a/src/k2/cpo/client/Heartbeat.cpp
+++ b/src/k2/cpo/client/Heartbeat.cpp
@@ -103,7 +103,7 @@ seastar::future<> HeartbeatResponder::start() {
 
     _nextHeartbeatExpire.setCallback([this] () {
         ++_missedHBs;
-        K2LOG_I(log::cpoclient, "Heartbeat from CPO monitor was missed");
+        K2LOG_D(log::cpoclient, "Heartbeat from CPO monitor was missed");
         if (_missedHBs >= _HBDeadThreshold - 1) {
             K2LOG_W(log::cpoclient, "Too many heartbeats missed, this node is considered down");
             _up = false;

--- a/src/k2/cpo/client/Heartbeat.h
+++ b/src/k2/cpo/client/Heartbeat.h
@@ -40,7 +40,7 @@ private:
     SingleTimer _nextHeartbeatExpire;
     Duration _HBInterval;      // Will be obtained from the heartbeat requests
     uint32_t _HBDeadThreshold; // Will be obtained from the heartbeat requests
-    uint32_t _missedHBs;
+    uint32_t _missedHBs{0};
     uint64_t _lastSeq{0};
     bool _running{false};
     bool _up{false};

--- a/src/k2/cpo/client/Heartbeat.h
+++ b/src/k2/cpo/client/Heartbeat.h
@@ -53,7 +53,8 @@ private:
     // For metrics
     void _registerMetrics();
     sm::metric_groups _metric_groups;
-    uint64_t _heartbeats{0};
+    k2::ExponentialHistogram _heartbeatInterarrival;
+    k2::TimePoint _lastHeartbeatTime;
 
     seastar::future<std::tuple<Status, dto::HeartbeatResponse>>
     _handleHeartbeat(dto::HeartbeatRequest&& request);

--- a/src/k2/cpo/client/Heartbeat.h
+++ b/src/k2/cpo/client/Heartbeat.h
@@ -34,24 +34,21 @@ Copyright(c) 2021 Futurewei Cloud
 #include <k2/common/Timer.h>
 
 namespace k2 {
-/*
-    auto tcp_ep = k2::RPC().getServerEndpoint(k2::TCPRPCProtocol::proto);
-    if (tcp_ep) {
-        partition.endpoints.insert(tcp_ep->url);
-    }
-    auto rdma_ep = k2::RPC().getServerEndpoint(k2::RRDMARPCProtocol::proto);
-    if (rdma_ep) {
-        partition.endpoints.insert(rdma_ep->url);
-    }
-*/
+
 class HeartbeatResponder {
 private:
-    SingleTimer _nextHeartbeat;
+    SingleTimer _nextHeartbeatExpire;
     Duration _HBInterval;      // Will be obtained from the heartbeat requests
     uint32_t _HBDeadThreshold; // Will be obtained from the heartbeat requests
     uint32_t _missedHBs;
+    uint64_t _lastSeq{0};
     bool _running{false};
     bool _up{false};
+
+    // Returned in heartbeat response
+    String _ID;
+    std::vector<String> _eps;
+    String _metadata;
 
     // For metrics
     void _registerMetrics();

--- a/src/k2/cpo/service/CPOService.cpp
+++ b/src/k2/cpo/service/CPOService.cpp
@@ -63,8 +63,8 @@ seastar::future<> CPOService::gracefulStop() {
 seastar::future<> CPOService::start() {
     APIServer& api_server = AppBase().getDist<APIServer>().local();
 
-    if (seastar::smp::count < 2) {
-        K2LOG_W(log::cposvr, "CPO requires 2 cores to enable health monitoring, but only 1 is available. Health monitoring is disabled");
+    if (_heartbeatMonitorShardId() >= seastar::smp::count) {
+        K2LOG_W(log::cposvr, "Specified shard ID for heartbeat monitoring is unavailable. Health monitoring is disabled");
     }
 
     K2LOG_I(log::cposvr, "Registering message handlers");

--- a/src/k2/cpo/service/CPOService.cpp
+++ b/src/k2/cpo/service/CPOService.cpp
@@ -63,6 +63,10 @@ seastar::future<> CPOService::gracefulStop() {
 seastar::future<> CPOService::start() {
     APIServer& api_server = AppBase().getDist<APIServer>().local();
 
+    if (seastar::smp::count < 2) {
+        K2LOG_W(log::cposvr, "CPO requires 2 cores to enable health monitoring, but only 1 is available. Health monitoring is disabled");
+    }
+
     K2LOG_I(log::cposvr, "Registering message handlers");
     RPC().registerRPCObserver<dto::CollectionCreateRequest, dto::CollectionCreateResponse>(dto::Verbs::CPO_COLLECTION_CREATE, [this](dto::CollectionCreateRequest&& request) {
         return _dist().invoke_on(0, &CPOService::handleCreate, std::move(request));

--- a/src/k2/cpo/service/CPOService.h
+++ b/src/k2/cpo/service/CPOService.h
@@ -43,6 +43,7 @@ private:
     typedef std::function<seastar::distributed<CPOService>&()> DistGetter;
     DistGetter _dist;
     ConfigVar<String> _dataDir{"data_dir"};
+    ConfigVar<uint32_t> _heartbeatMonitorShardId{"heartbeat_monitor_shard_id"};
     String _getCollectionPath(String name);
     String _getPersistenceClusterPath(String clusterName);
     String _getSchemasPath(String collectionName);

--- a/src/k2/cpo/service/CPOService.h
+++ b/src/k2/cpo/service/CPOService.h
@@ -49,7 +49,7 @@ private:
     void _assignCollection(dto::Collection& collection);
     seastar::future<bool> _offloadCollection(dto::Collection& collection);
     ConfigDuration _assignTimeout{"assignment_timeout", 10ms};
-    ConfigDuration _collectionHeartbeatDeadline{"heartbeat_deadline", 100ms};
+    ConfigDuration _collectionHeartbeatDeadline{"txn_heartbeat_deadline", 100ms};
     std::unordered_map<String, seastar::future<>> _assignments;
     std::unordered_map<String, std::vector<dto::PartitionMetdataRecord>> _metadataRecords;
     std::tuple<Status, dto::Collection> _getCollection(String name);

--- a/src/k2/cpo/service/HealthMonitor.cpp
+++ b/src/k2/cpo/service/HealthMonitor.cpp
@@ -1,0 +1,209 @@
+/*
+MIT License
+
+Copyright(c) 2021 Futurewei Cloud
+
+    Permission is hereby granted,
+    free of charge, to any person obtaining a copy of this software and associated documentation files(the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and / or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions :
+
+    The above copyright notice and this permission notice shall be included in all copies
+    or
+    substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS",
+    WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+    DAMAGES OR OTHER
+    LIABILITY,
+    WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+*/
+
+#include "HealthMonitor.h"
+
+#include <k2/dto/MessageVerbs.h>
+
+namespace k2 {
+
+void HealthMonitor::addHBControl(RPCServer&& server, TimePoint nextHB) {
+    auto control = seastar::make_lw_shared<HeartbeatControl>();
+    control->target = std::move(server);
+    control->endpoint = RPC().getTXEndpoint(control->target.ID);
+    control->nextHeartbeat = nextHB;
+
+    _heartbeats.push_back(std::move(control));
+}
+
+void HealthMonitor::checkHBs() {
+    if (!_running) {
+        return;
+    }
+
+    auto now = CachedSteadyClock::now(true);
+    Duration nextArm = _interval();
+
+    auto it = _heartbeats.begin();
+    while (it != _heartbeats.end()) {
+        // List is kept in sorted order, if we reach one that is not expired then we are done,
+        // arm the timer and exit
+        if ((*it)->nextHeartbeat > now) {
+            nextArm = (*it)->nextHeartbeat - now;
+            break;
+        }
+
+        // If the last heartbeat has not been responded to yet, count it as missed and potentially the target
+        // as dead.
+        if ((*it)->heartbeatInFlight) {
+            K2LOG_D(log::cposvr, "missed HB for {}", *it);
+            (*it)->unackedHeartbeats++;
+            if ((*it)->unackedHeartbeats >= _deadThreshold()) {
+                K2LOG_I(log::cposvr, "HB target is dead: {}", **it);
+                _deadHeartbeats.push_back(std::move(*it));
+                it = _heartbeats.erase(it);
+                continue;
+            }
+        }
+
+        // Normal case. Send a new heartbeat request to target.
+
+        dto::HeartbeatRequest request{.lastToken = (*it)->lastToken, .interval = _interval(),
+                                        .deadThreshold = _deadThreshold()};
+
+        (*it)->heartbeatInFlight = true;
+        (*it)->nextHeartbeat = now + _interval();
+
+        (*it)->heartbeatRequest = RPC()
+        .callRPC<dto::HeartbeatRequest, dto::HeartbeatResponse>(dto::Verbs::CPO_HEARTBEAT, request,
+                                                                *((*it)->endpoint), _interval())
+        .then([this, hb_ptr=*it, it] (auto&& result) {
+            auto& [status, response] = result;
+            K2LOG_V(log::cposvr, "Heartbeat response for {}", *hb_ptr);
+
+            if (!status.is2xxOK()) {
+                // Missed HB will be counted the next time this target reaches the head of the list
+                return seastar::make_ready_future<>();
+            }
+            if (hb_ptr->unackedHeartbeats >= _deadThreshold()) {
+                // This target has already been determined dead (and iterator is not valid anymore)
+                K2LOG_I(log::cposvr, "HB response after target determined dead for {}", *hb_ptr);
+                return seastar::make_ready_future<>();
+            }
+
+            hb_ptr->target.roleMetadata = std::move(response.roleMetadata);
+            hb_ptr->target.endpoints = std::move(response.endpoints);
+
+            hb_ptr->heartbeatInFlight = false;
+            hb_ptr->unackedHeartbeats = 0;
+            auto now = CachedSteadyClock::now(true);
+            hb_ptr->nextHeartbeat = now + _interval();
+            hb_ptr->lastToken = response.echoToken;
+
+            _heartbeats.erase(it);
+            _heartbeats.push_back(hb_ptr);
+
+            return seastar::make_ready_future<>();
+        })
+        .handle_exception([hb_ptr=*it] (auto exc){
+            K2LOG_W_EXC(log::cposvr, exc, "caught exception in heartbeat RPC for target {}", *hb_ptr);
+            return seastar::make_ready_future();
+        });
+    }
+
+    _nextHeartbeat.arm(nextArm);
+}
+
+seastar::future<> HealthMonitor::gracefulStop() {
+     if (seastar::this_shard_id() != 1) {
+        // Health monitor only runs on core 1
+        return seastar::make_ready_future<>();
+    }
+
+    _running = false;
+    seastar::future<> timer = _nextHeartbeat.stop();
+
+    return seastar::do_with(std::vector<seastar::future<>>{}, [this, timer=std::move(timer)]
+                                                              (std::vector<seastar::future<>>& futs) mutable {
+        futs.reserve(_heartbeats.size() + _deadHeartbeats.size() + 1);
+
+        futs.push_back(std::move(timer));
+
+        for (auto hb : _heartbeats) {
+            futs.push_back(std::move(hb->heartbeatRequest));
+        }
+
+        // Need to wait for dead heartbeats too because the RPC request could still be waiting for a timeout
+        for (auto hb : _deadHeartbeats) {
+            futs.push_back(std::move(hb->heartbeatRequest));
+        }
+
+        return seastar::when_all_succeed(futs.begin(), futs.end()).discard_result();
+    });
+}
+
+seastar::future<> HealthMonitor::start() {
+    if (seastar::this_shard_id() != 1) {
+        // Health monitor only runs on core 1
+        return seastar::make_ready_future<>();
+    }
+
+    K2LOG_D(log::cposvr, "HealthMonitor start()");
+    _running = true;
+
+    auto now = CachedSteadyClock::now(true);
+    uint32_t count = 0;
+    Duration delay = 0s;
+
+    for(const String& ep_url : _nodepoolEndpoints()) {
+        RPCServer server;
+        server.ID = ep_url;
+        server.role = "Nodepool";
+
+        addHBControl(std::move(server), now + delay);
+
+        ++count;
+        if (count == _batchSize()) {
+            delay += _batchWait();
+            count = 0;
+        }
+    }
+
+    for(const String& ep_url : _TSOEndpoints()) {
+        RPCServer server;
+        server.ID = ep_url;
+        server.role = "TSO";
+
+        addHBControl(std::move(server), now + delay);
+
+        ++count;
+        if (count == _batchSize()) {
+            delay += _batchWait();
+            count = 0;
+        }
+    }
+
+    for(const String& ep_url : _persistEndpoints()) {
+        RPCServer server;
+        server.ID = ep_url;
+        server.role = "Persistence";
+
+        addHBControl(std::move(server), now + delay);
+
+        ++count;
+        if (count == _batchSize()) {
+            delay += _batchWait();
+            count = 0;
+        }
+    }
+
+    _nextHeartbeat.setCallback([this] {
+        K2LOG_D(log::cposvr, "Heartbeat timer fired");
+        checkHBs();
+    });
+    _nextHeartbeat.arm(0s);
+
+    return seastar::make_ready_future<>();
+}
+
+} // ns k2

--- a/src/k2/cpo/service/HealthMonitor.h
+++ b/src/k2/cpo/service/HealthMonitor.h
@@ -31,6 +31,7 @@ Copyright(c) 2021 Futurewei Cloud
 #include <k2/cpo/service/CPOService.h>
 #include <k2/dto/ControlPlaneOracle.h>
 #include <k2/dto/LogStream.h>
+#include <k2/transport/Prometheus.h>
 #include <k2/transport/Status.h>
 #include <k2/common/Timer.h>
 
@@ -73,12 +74,12 @@ private:
     ConfigVar<Duration> _batchWait{"heartbeat_batch_wait", 0s};
     ConfigVar<uint32_t> _batchSize{"heartbeat_batch_size", 100};
     ConfigVar<uint32_t> _deadThreshold{"heartbeat_lost_threshold", 3};
+    ConfigVar<uint32_t> _heartbeatMonitorShardId{"heartbeat_monitor_shard_id", 1};
 
     SingleTimer _nextHeartbeat;
     bool _running{false};
 
     std::list<seastar::lw_shared_ptr<HeartbeatControl>> _heartbeats;
-    std::list<seastar::lw_shared_ptr<HeartbeatControl>> _deadHeartbeats;
 
     // For metrics
     void _registerMetrics();
@@ -86,13 +87,13 @@ private:
     uint32_t _nodepoolDown{0};
     uint32_t _TSODown{0};
     uint32_t _persistDown{0};
-    uint64_t _heartbeatsSent{0};
     uint64_t _heartbeatsLost{0};
     uint64_t _downEvents{0};
+    k2::ExponentialHistogram _heartbeatLatency;
 
-    String _nodepoolRole{"Nodepool"};
-    String _tsoRole{"TSO"};
-    String _persistRole{"Persistence"};
+    const String _nodepoolRole{"Nodepool"};
+    const String _tsoRole{"TSO"};
+    const String _persistRole{"Persistence"};
 
     void _addHBControl(RPCServer&& server, TimePoint nextHB);
     void _checkHBs();

--- a/src/k2/cpo/service/HealthMonitor.h
+++ b/src/k2/cpo/service/HealthMonitor.h
@@ -36,6 +36,9 @@ Copyright(c) 2021 Futurewei Cloud
 
 namespace k2 {
 
+// Represents the target of a heartbeat request, which can be anything that responds to a
+// Chogori platform RPC request. The data here is informational only and is does not affect the
+// heartbeat monitor operation but can be used by other CPO components or for logging purposes
 class RPCServer {
 public:
     String ID;
@@ -45,6 +48,8 @@ public:
     K2_DEF_FMT(RPCServer, ID, role, roleMetadata, endpoints);
 };
 
+// The data needed for a single target (one-to-one with an RPCServer above) for the heartbeat monitor to
+// operate on
 class HeartbeatControl {
 public:
     TimePoint nextHeartbeat;
@@ -64,10 +69,10 @@ private:
     ConfigVar<std::vector<String>> _nodepoolEndpoints{"nodepool_endpoints"};
     ConfigVar<std::vector<String>> _TSOEndpoints{"tso_endpoints"};
     ConfigVar<std::vector<String>> _persistEndpoints{"k23si_persistence_endpoints"};
-    ConfigVar<Duration> _interval{"heartbeat_interval", 100ms};
+    ConfigVar<Duration> _interval{"heartbeat_interval", 500ms};
     ConfigVar<Duration> _batchWait{"heartbeat_batch_wait", 0s};
-    ConfigVar<uint32_t> _batchSize{"heartbeat_batch_size"};
-    ConfigVar<uint32_t> _deadThreshold{"heartbeat_lost_threshold"};
+    ConfigVar<uint32_t> _batchSize{"heartbeat_batch_size", 100};
+    ConfigVar<uint32_t> _deadThreshold{"heartbeat_lost_threshold", 3};
 
     SingleTimer _nextHeartbeat;
     bool _running{false};
@@ -85,8 +90,12 @@ private:
     uint64_t _heartbeatsLost{0};
     uint64_t _downEvents{0};
 
-    void addHBControl(RPCServer&& server, TimePoint nextHB);
-    void checkHBs();
+    String _nodepoolRole{"Nodepool"};
+    String _tsoRole{"TSO"};
+    String _persistRole{"Persistence"};
+
+    void _addHBControl(RPCServer&& server, TimePoint nextHB);
+    void _checkHBs();
 
 public:
     // required for seastar::distributed interface

--- a/src/k2/dto/ControlPlaneOracle.h
+++ b/src/k2/dto/ControlPlaneOracle.h
@@ -27,6 +27,7 @@ Copyright(c) 2020 Futurewei Cloud
 
 #include "Collection.h"
 #include "FieldTypes.h"
+#include "Timestamp.h"
 
 #include "Log.h"
 // This file contains DTOs for K2 ControlPlaneOracle
@@ -153,5 +154,32 @@ struct GetSchemasResponse {
     K2_DEF_FMT(GetSchemasResponse, schemas);
 };
 
+struct HeartbeatRequest {
+    // The target uses this to determine if its responses are succeeding or if it needs to die.
+    uint64_t lastToken;
+
+    // Time between heartbeats and how many lost heartbeats are needed to consider a target dead.
+    // This is needed as part of the request so that targets can monitor if they should soft shutdown and
+    // so that this information can be controlled by the CPO rather than part of the target config.
+    Duration interval;
+    uint32_t deadThreshold;
+
+    K2_PAYLOAD_FIELDS(lastToken, interval, deadThreshold);
+    K2_DEF_FMT(HeartbeatRequest, lastToken, interval, deadThreshold);
+};
+
+struct HeartbeatResponse {
+    // The instance ID, unique in the cluster at a given moment in time
+    String ID;
+    // Role specific metadata, such as collection assignment status for a nodepool.
+    // This is only used for logging and debugging.
+    String roleMetadata;
+    // Available endpoints that this instance can be reached at
+    std::vector<String> endpoints;
+    // The target uses this to determine if its responses are succeeding or if it needs to die.
+    uint64_t echoToken;
+    K2_PAYLOAD_FIELDS(ID, roleMetadata, endpoints, echoToken);
+    K2_DEF_FMT(HeartbeatResponse, ID, roleMetadata, endpoints, echoToken);
+};
 
 }  // namespace k2::dto

--- a/src/k2/dto/MessageVerbs.h
+++ b/src/k2/dto/MessageVerbs.h
@@ -45,6 +45,8 @@ enum Verbs : k2::Verb {
     CPO_SCHEMAS_GET,
     CPO_COLLECTION_DROP,
 
+    CPO_HEARTBEAT,
+
     /************ Assignment *****************/
     // K2Assignment: CPO asks K2 to assign a partition
     K2_ASSIGNMENT_CREATE = 25,

--- a/test/integration/heartbeat_monitor.py
+++ b/test/integration/heartbeat_monitor.py
@@ -42,7 +42,7 @@ class TestHeartbeatFailure(unittest.TestCase):
         url = "http://127.0.0.1:" + args.prometheus_port + "/metrics"
         r = requests.get(url)
         for line in r.text.splitlines():
-            if "HealthMonitor_heartbeats_sent" in line:
+            if "HealthMonitor_heartbeat_latency_count" in line:
                 count = 0
                 try:
                     count = int(float(line.split()[1]))
@@ -73,7 +73,7 @@ class TestHeartbeatFailure(unittest.TestCase):
         url = "http://127.0.0.1:" + args.prometheus_port + "/metrics"
         r = requests.get(url)
         for line in r.text.splitlines():
-            if "HealthMonitor_heartbeats_sent" in line:
+            if "HealthMonitor_heartbeat_latency_count" in line:
                 count = 0
                 try:
                     count = int(float(line.split()[1]))

--- a/test/integration/heartbeat_monitor.py
+++ b/test/integration/heartbeat_monitor.py
@@ -98,7 +98,6 @@ class TestHeartbeatFailure(unittest.TestCase):
                 self.assertTrue(count > 0)
                 print("nodepool_total: ", count)
 
-
-del sys.argv[1:]
+# Needed because unittest will throw an exception if it sees any command line arguments it doesn't understand
 del sys.argv[1:]
 unittest.main()

--- a/test/integration/heartbeat_monitor.py
+++ b/test/integration/heartbeat_monitor.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+
+'''
+MIT License
+
+Copyright (c) 2021 Futurewei Cloud
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+'''
+
+import argparse, unittest, sys, os, signal, time
+import requests, json
+from urllib.parse import urlparse
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--nodepool_pid", help="Nodepool PID")
+parser.add_argument("--prometheus_port", help="CPO prometheus port")
+args = parser.parse_args()
+
+#CPOService_HealthMonitor_heartbeats_sent{shard="1",total_cores="2"} 40
+#CPOService_HealthMonitor_nodepool_down{shard="1",total_cores="2"} 0.000000
+#CPOService_HealthMonitor_nodepool_total{shard="1",total_cores="2"} 1.000000
+
+class TestHeartbeatFailure(unittest.TestCase):
+    def test_heartbeatFailure(self):
+        url = "http://127.0.0.1:" + args.prometheus_port + "/metrics"
+        r = requests.get(url)
+        for line in r.text.splitlines():
+            if "HealthMonitor_heartbeats_sent" in line:
+                count = 0
+                try:
+                    count = int(float(line.split()[1]))
+                except:
+                    continue
+                self.assertTrue(count > 0)
+                print("Heartbeats_sent: ", count)
+            if "HealthMonitor_nodepool_down" in line:
+                count = 0
+                try:
+                    count = int(float(line.split()[1]))
+                except:
+                    continue
+                self.assertTrue(count == 0)
+                print("nodepool_down: ", count)
+            if "HealthMonitor_nodepool_total" in line:
+                count = 0
+                try:
+                    count = int(float(line.split()[1]))
+                except:
+                    continue
+                self.assertTrue(count > 0)
+                print("nodepool_total: ", count)
+
+        os.kill(int(args.nodepool_pid), signal.SIGKILL)
+        time.sleep(2)
+            
+        url = "http://127.0.0.1:" + args.prometheus_port + "/metrics"
+        r = requests.get(url)
+        for line in r.text.splitlines():
+            if "HealthMonitor_heartbeats_sent" in line:
+                count = 0
+                try:
+                    count = int(float(line.split()[1]))
+                except:
+                    continue
+                self.assertTrue(count > 0)
+                print("Heartbeats_sent: ", count)
+            if "HealthMonitor_nodepool_down" in line:
+                count = 0
+                try:
+                    count = int(float(line.split()[1]))
+                except:
+                    continue
+                self.assertTrue(count == 1)
+                print("nodepool_down: ", count)
+            if "HealthMonitor_nodepool_total" in line:
+                count = 0
+                try:
+                    count = int(float(line.split()[1]))
+                except:
+                    continue
+                self.assertTrue(count > 0)
+                print("nodepool_total: ", count)
+
+
+del sys.argv[1:]
+del sys.argv[1:]
+unittest.main()

--- a/test/integration/run.sh
+++ b/test/integration/run.sh
@@ -4,7 +4,7 @@ cd ${topname}
 
 set -e
 
-for test in test_collection.sh test_k23si.sh test_3si_txn.sh test_schema_create.sh test_skv_client.sh test_query.sh; do
+for test in test_collection.sh test_k23si.sh test_3si_txn.sh test_schema_create.sh test_skv_client.sh test_query.sh test_heartbeat_monitor.sh; do
     echo ">>> Running integration test: ${test}";
     ./${test};
     echo ">>> Done running test ${test}";

--- a/test/integration/test_3si_txn.sh
+++ b/test/integration/test_3si_txn.sh
@@ -22,8 +22,6 @@ persistence_child_pid=$!
 ./build/src/k2/cmd/tso/tso -c2 --tcp_endpoints ${TSO} 13001 --enable_tx_checksum true --reactor-backend epoll --prometheus_port 63003 &
 tso_child_pid=$!
 
-sleep 2
-
 # start CPO on 2 cores
 ./build/src/k2/cmd/controlPlaneOracle/cpo_main -c2 --tcp_endpoints ${CPO} --data_dir ${CPODIR} --txn_heartbeat_deadline=10s --enable_tx_checksum true --reactor-backend epoll --prometheus_port 63000 --assignment_timeout=1s --nodepool_endpoints ${EPS} --tso_endpoints ${TSO} --persistence_endpoints ${PERSISTENCE} &
 cpo_child_pid=$!

--- a/test/integration/test_3si_txn.sh
+++ b/test/integration/test_3si_txn.sh
@@ -10,10 +10,6 @@ PERSISTENCE=tcp+k2rpc://0.0.0.0:12001
 CPO=tcp+k2rpc://0.0.0.0:9000
 TSO=tcp+k2rpc://0.0.0.0:13000
 
-# start CPO on 2 cores
-./build/src/k2/cmd/controlPlaneOracle/cpo_main -c1 --tcp_endpoints ${CPO} 9001 --data_dir ${CPODIR} --heartbeat_deadline=10s --enable_tx_checksum true --reactor-backend epoll --prometheus_port 63000 --assignment_timeout=1s &
-cpo_child_pid=$!
-
 # start nodepool on 3 cores
 ./build/src/k2/cmd/nodepool/nodepool --log_level INFO k2::skv_server=INFO -c3 --tcp_endpoints ${EPS} --enable_tx_checksum true --k23si_persistence_endpoint ${PERSISTENCE} --reactor-backend epoll --prometheus_port 63001 --k23si_cpo_endpoint ${CPO} --tso_endpoint ${TSO} --partition_request_timeout=30s &
 nodepool_child_pid=$!
@@ -25,6 +21,13 @@ persistence_child_pid=$!
 # start tso on 2 cores
 ./build/src/k2/cmd/tso/tso -c2 --tcp_endpoints ${TSO} 13001 --enable_tx_checksum true --reactor-backend epoll --prometheus_port 63003 &
 tso_child_pid=$!
+
+sleep 2
+
+# start CPO on 2 cores
+./build/src/k2/cmd/controlPlaneOracle/cpo_main -c2 --tcp_endpoints ${CPO} --data_dir ${CPODIR} --txn_heartbeat_deadline=10s --enable_tx_checksum true --reactor-backend epoll --prometheus_port 63000 --assignment_timeout=1s --nodepool_endpoints ${EPS} --tso_endpoints ${TSO} --persistence_endpoints ${PERSISTENCE} &
+cpo_child_pid=$!
+
 
 function finish {
   rv=$?

--- a/test/integration/test_collection.sh
+++ b/test/integration/test_collection.sh
@@ -22,8 +22,6 @@ persistence_child_pid=$!
 ./build/src/k2/cmd/tso/tso -c2 --tcp_endpoints ${TSO} 13001 --enable_tx_checksum true --reactor-backend epoll --prometheus_port 63003 &
 tso_child_pid=$!
 
-sleep 2
-
 ./build/src/k2/cmd/controlPlaneOracle/cpo_main -c2 --tcp_endpoints ${CPO} --data_dir ${CPODIR} --txn_heartbeat_deadline=10s --enable_tx_checksum true --reactor-backend epoll --prometheus_port 63000 --assignment_timeout=1s --nodepool_endpoints ${EPS} --tso_endpoints ${TSO} --persistence_endpoints ${PERSISTENCE} &
 cpo_child_pid=$!
 

--- a/test/integration/test_collection.sh
+++ b/test/integration/test_collection.sh
@@ -10,10 +10,6 @@ PERSISTENCE=tcp+k2rpc://0.0.0.0:12001
 CPO=tcp+k2rpc://0.0.0.0:9000
 TSO=tcp+k2rpc://0.0.0.0:13000
 
-# start CPO on 2 cores
-./build/src/k2/cmd/controlPlaneOracle/cpo_main -c2 --tcp_endpoints ${CPO} --data_dir ${CPODIR} --enable_tx_checksum true --reactor-backend epoll --prometheus_port 63000 --assignment_timeout=1s &
-cpo_child_pid=$!
-
 # start nodepool on 3 cores
 ./build/src/k2/cmd/nodepool/nodepool -c3 --tcp_endpoints ${EPS} --enable_tx_checksum true --k23si_persistence_endpoint ${PERSISTENCE} --reactor-backend epoll --prometheus_port 63001 --k23si_cpo_endpoint ${CPO} --tso_endpoint ${TSO} &
 nodepool_child_pid=$!
@@ -25,6 +21,11 @@ persistence_child_pid=$!
 # start tso on 2 cores
 ./build/src/k2/cmd/tso/tso -c2 --tcp_endpoints ${TSO} 13001 --enable_tx_checksum true --reactor-backend epoll --prometheus_port 63003 &
 tso_child_pid=$!
+
+sleep 2
+
+./build/src/k2/cmd/controlPlaneOracle/cpo_main -c2 --tcp_endpoints ${CPO} --data_dir ${CPODIR} --txn_heartbeat_deadline=10s --enable_tx_checksum true --reactor-backend epoll --prometheus_port 63000 --assignment_timeout=1s --nodepool_endpoints ${EPS} --tso_endpoints ${TSO} --persistence_endpoints ${PERSISTENCE} &
+cpo_child_pid=$!
 
 function finish {
   rv=$?

--- a/test/integration/test_heartbeat_monitor.sh
+++ b/test/integration/test_heartbeat_monitor.sh
@@ -22,8 +22,6 @@ persistence_child_pid=$!
 ./build/src/k2/cmd/tso/tso -c2 --tcp_endpoints ${TSO} 13001 --enable_tx_checksum true --reactor-backend epoll --prometheus_port 63003 &
 tso_child_pid=$!
 
-sleep 2
-
 # start CPO on 2 cores
 ./build/src/k2/cmd/controlPlaneOracle/cpo_main -c2 --tcp_endpoints ${CPO} --data_dir ${CPODIR} --txn_heartbeat_deadline=10s --enable_tx_checksum true --reactor-backend epoll --prometheus_port 63000 --assignment_timeout=1s --nodepool_endpoints ${EPS} --tso_endpoints ${TSO} --persistence_endpoints ${PERSISTENCE} &
 cpo_child_pid=$!

--- a/test/integration/test_heartbeat_monitor.sh
+++ b/test/integration/test_heartbeat_monitor.sh
@@ -4,14 +4,14 @@ cd ${topname}/../..
 set -e
 CPODIR=/tmp/___cpo_integ_test
 rm -rf ${CPODIR}
-EPS="tcp+k2rpc://0.0.0.0:10000 tcp+k2rpc://0.0.0.0:10001 tcp+k2rpc://0.0.0.0:10002"
+EPS="tcp+k2rpc://0.0.0.0:10000"
 
 PERSISTENCE=tcp+k2rpc://0.0.0.0:12001
 CPO=tcp+k2rpc://0.0.0.0:9000
 TSO=tcp+k2rpc://0.0.0.0:13000
 
-# start nodepool on 3 cores
-./build/src/k2/cmd/nodepool/nodepool -c3 --tcp_endpoints ${EPS} --enable_tx_checksum true --k23si_persistence_endpoint ${PERSISTENCE} --reactor-backend epoll --prometheus_port 63001 --k23si_cpo_endpoint ${CPO} --tso_endpoint ${TSO} &
+# start nodepool on 1 cores
+./build/src/k2/cmd/nodepool/nodepool --log_level INFO k2::skv_server=INFO -c1 --tcp_endpoints ${EPS} --enable_tx_checksum true --k23si_persistence_endpoint ${PERSISTENCE} --reactor-backend epoll --prometheus_port 63001 --k23si_cpo_endpoint ${CPO} --tso_endpoint ${TSO} --partition_request_timeout=30s &
 nodepool_child_pid=$!
 
 # start persistence on 1 cores
@@ -24,8 +24,10 @@ tso_child_pid=$!
 
 sleep 2
 
+# start CPO on 2 cores
 ./build/src/k2/cmd/controlPlaneOracle/cpo_main -c2 --tcp_endpoints ${CPO} --data_dir ${CPODIR} --txn_heartbeat_deadline=10s --enable_tx_checksum true --reactor-backend epoll --prometheus_port 63000 --assignment_timeout=1s --nodepool_endpoints ${EPS} --tso_endpoints ${TSO} --persistence_endpoints ${PERSISTENCE} &
 cpo_child_pid=$!
+
 
 function finish {
   rv=$?
@@ -35,10 +37,6 @@ function finish {
   kill ${cpo_child_pid}
   echo "Waiting for cpo child pid: ${cpo_child_pid}"
   wait ${cpo_child_pid}
-
-  kill ${nodepool_child_pid}
-  echo "Waiting for nodepool child pid: ${nodepool_child_pid}"
-  wait ${nodepool_child_pid}
 
   kill ${persistence_child_pid}
   echo "Waiting for persistence child pid: ${persistence_child_pid}"
@@ -53,4 +51,4 @@ trap finish EXIT
 
 sleep 2
 
-./build/test/k23si/schema_creation_test --cpo_endpoint ${CPO} --k2_endpoints ${EPS} --enable_tx_checksum true --reactor-backend epoll --prometheus_port 63100
+/build/test/integration/heartbeat_monitor.py --nodepool_pid=${nodepool_child_pid} --prometheus_port=63000

--- a/test/integration/test_k23si.sh
+++ b/test/integration/test_k23si.sh
@@ -22,8 +22,6 @@ persistence_child_pid=$!
 ./build/src/k2/cmd/tso/tso -c2 --tcp_endpoints ${TSO} 13001 --enable_tx_checksum true --reactor-backend epoll --prometheus_port 63003 &
 tso_child_pid=$!
 
-sleep 2
-
 ./build/src/k2/cmd/controlPlaneOracle/cpo_main -c2 --tcp_endpoints ${CPO} --data_dir ${CPODIR} --txn_heartbeat_deadline=10s --enable_tx_checksum true --reactor-backend epoll --prometheus_port 63000 --assignment_timeout=1s --nodepool_endpoints ${EPS} --tso_endpoints ${TSO} --persistence_endpoints ${PERSISTENCE} &
 cpo_child_pid=$!
 

--- a/test/integration/test_k23si_tpcc.sh
+++ b/test/integration/test_k23si_tpcc.sh
@@ -23,8 +23,6 @@ persistence_child_pid=$!
 ./build/src/k2/cmd/tso/tso -c2 --tcp_endpoints ${TSO} 13001 ${COMMON_ARGS} --prometheus_port 63003 &
 tso_child_pid=$!
 
-sleep 2
-
 ./build/src/k2/cmd/controlPlaneOracle/cpo_main -c2 --tcp_endpoints ${CPO} --data_dir ${CPODIR} --txn_heartbeat_deadline=10s --enable_tx_checksum true --reactor-backend epoll --prometheus_port 63000 --assignment_timeout=1s --nodepool_endpoints ${EPS} --tso_endpoints ${TSO} --persistence_endpoints ${PERSISTENCE} &
 cpo_child_pid=$!
 

--- a/test/integration/test_k23si_tpcc.sh
+++ b/test/integration/test_k23si_tpcc.sh
@@ -11,10 +11,6 @@ CPO=tcp+k2rpc://0.0.0.0:9000
 TSO=tcp+k2rpc://0.0.0.0:13000
 COMMON_ARGS="--enable_tx_checksum true --thread-affinity false"
 
-# start CPO on 1 cores
-./build/src/k2/cmd/controlPlaneOracle/cpo_main -c1 --tcp_endpoints ${CPO} 9001 --data_dir ${CPODIR} ${COMMON_ARGS}  --prometheus_port 63000 --assignment_timeout=1s --reactor-backend epoll --heartbeat_deadline=1s &
-cpo_child_pid=$!
-
 # start nodepool on 1 cores
 ./build/src/k2/cmd/nodepool/nodepool -c1 --tcp_endpoints ${EPS} --k23si_persistence_endpoint ${PERSISTENCE} ${COMMON_ARGS} --prometheus_port 63001 --k23si_cpo_endpoint ${CPO} --tso_endpoint ${TSO} --memory=3G --partition_request_timeout=6s &
 nodepool_child_pid=$!
@@ -26,6 +22,12 @@ persistence_child_pid=$!
 # start tso on 2 cores
 ./build/src/k2/cmd/tso/tso -c2 --tcp_endpoints ${TSO} 13001 ${COMMON_ARGS} --prometheus_port 63003 &
 tso_child_pid=$!
+
+sleep 2
+
+./build/src/k2/cmd/controlPlaneOracle/cpo_main -c2 --tcp_endpoints ${CPO} --data_dir ${CPODIR} --txn_heartbeat_deadline=10s --enable_tx_checksum true --reactor-backend epoll --prometheus_port 63000 --assignment_timeout=1s --nodepool_endpoints ${EPS} --tso_endpoints ${TSO} --persistence_endpoints ${PERSISTENCE} &
+cpo_child_pid=$!
+
 
 function finish {
   rv=$?
@@ -51,7 +53,7 @@ function finish {
 }
 trap finish EXIT
 
-sleep 5
+sleep 2
 
 NUMWH=1
 NUMDIST=1

--- a/test/integration/test_k23si_ycsb.sh
+++ b/test/integration/test_k23si_ycsb.sh
@@ -23,8 +23,6 @@ persistence_child_pid=$!
 ./build/src/k2/cmd/tso/tso -c2 --tcp_endpoints ${TSO} 13001 ${COMMON_ARGS} --prometheus_port 63003 &
 tso_child_pid=$!
 
-sleep 2
-
 ./build/src/k2/cmd/controlPlaneOracle/cpo_main -c2 --tcp_endpoints ${CPO} --data_dir ${CPODIR} --txn_heartbeat_deadline=10s --enable_tx_checksum true --reactor-backend epoll --prometheus_port 63000 --assignment_timeout=1s --nodepool_endpoints ${EPS} --tso_endpoints ${TSO} --persistence_endpoints ${PERSISTENCE} &
 cpo_child_pid=$!
 

--- a/test/integration/test_k23si_ycsb.sh
+++ b/test/integration/test_k23si_ycsb.sh
@@ -11,10 +11,6 @@ CPO=tcp+k2rpc://0.0.0.0:9000
 TSO=tcp+k2rpc://0.0.0.0:13000
 COMMON_ARGS="--enable_tx_checksum true --thread-affinity false"
 
-# start CPO on 1 cores
-./build/src/k2/cmd/controlPlaneOracle/cpo_main -c1 --tcp_endpoints ${CPO} 9001 --data_dir ${CPODIR} ${COMMON_ARGS}  --prometheus_port 63000 --assignment_timeout=1s --reactor-backend epoll --heartbeat_deadline=1s &
-cpo_child_pid=$!
-
 # start nodepool on 1 cores
 ./build/src/k2/cmd/nodepool/nodepool -c1 --tcp_endpoints ${EPS} --k23si_persistence_endpoint ${PERSISTENCE} ${COMMON_ARGS} --prometheus_port 63001 --k23si_cpo_endpoint ${CPO} --tso_endpoint ${TSO} --memory=3G --partition_request_timeout=6s &
 nodepool_child_pid=$!
@@ -26,6 +22,12 @@ persistence_child_pid=$!
 # start tso on 2 cores
 ./build/src/k2/cmd/tso/tso -c2 --tcp_endpoints ${TSO} 13001 ${COMMON_ARGS} --prometheus_port 63003 &
 tso_child_pid=$!
+
+sleep 2
+
+./build/src/k2/cmd/controlPlaneOracle/cpo_main -c2 --tcp_endpoints ${CPO} --data_dir ${CPODIR} --txn_heartbeat_deadline=10s --enable_tx_checksum true --reactor-backend epoll --prometheus_port 63000 --assignment_timeout=1s --nodepool_endpoints ${EPS} --tso_endpoints ${TSO} --persistence_endpoints ${PERSISTENCE} &
+cpo_child_pid=$!
+
 
 function finish {
   rv=$?
@@ -51,7 +53,7 @@ function finish {
 }
 trap finish EXIT
 
-sleep 5
+sleep 2
 
 echo ">>> Starting load ..."
 ./build/src/k2/cmd/ycsb/ycsb_client -c1 --tcp_remotes ${EPS} --cpo ${CPO} --tso_endpoint ${TSO} --data_load true --prometheus_port 63100 ${COMMON_ARGS} --memory=512M --partition_request_timeout=6s --dataload_txn_timeout=600s --num_concurrent_txns=2 --num_records=500 --num_records_insert=100 --request_dist="latest"

--- a/test/integration/test_query.sh
+++ b/test/integration/test_query.sh
@@ -22,8 +22,6 @@ persistence_child_pid=$!
 ./build/src/k2/cmd/tso/tso -c2 --tcp_endpoints ${TSO} 13001 --enable_tx_checksum true --reactor-backend epoll --prometheus_port 63003 &
 tso_child_pid=$!
 
-sleep 2
-
 ./build/src/k2/cmd/controlPlaneOracle/cpo_main -c2 --tcp_endpoints ${CPO} --data_dir ${CPODIR} --txn_heartbeat_deadline=10s --enable_tx_checksum true --reactor-backend epoll --prometheus_port 63000 --assignment_timeout=1s --nodepool_endpoints ${EPS} --tso_endpoints ${TSO} --persistence_endpoints ${PERSISTENCE} &
 cpo_child_pid=$!
 

--- a/test/integration/test_query.sh
+++ b/test/integration/test_query.sh
@@ -10,10 +10,6 @@ PERSISTENCE=tcp+k2rpc://0.0.0.0:12001
 CPO=tcp+k2rpc://0.0.0.0:9000
 TSO=tcp+k2rpc://0.0.0.0:13000
 
-# start CPO on 2 cores
-./build/src/k2/cmd/controlPlaneOracle/cpo_main -c1 --tcp_endpoints ${CPO} 9001 --data_dir ${CPODIR} --enable_tx_checksum true --reactor-backend epoll --prometheus_port 63000 --assignment_timeout=1s &
-cpo_child_pid=$!
-
 # start nodepool on 2 cores
 ./build/src/k2/cmd/nodepool/nodepool -c2 --tcp_endpoints ${EPS} --enable_tx_checksum true --k23si_persistence_endpoint ${PERSISTENCE} --reactor-backend epoll --prometheus_port 63001 --k23si_cpo_endpoint ${CPO} --tso_endpoint ${TSO} --k23si_query_pagination_limit 2 &
 nodepool_child_pid=$!
@@ -25,6 +21,11 @@ persistence_child_pid=$!
 # start tso on 2 cores
 ./build/src/k2/cmd/tso/tso -c2 --tcp_endpoints ${TSO} 13001 --enable_tx_checksum true --reactor-backend epoll --prometheus_port 63003 &
 tso_child_pid=$!
+
+sleep 2
+
+./build/src/k2/cmd/controlPlaneOracle/cpo_main -c2 --tcp_endpoints ${CPO} --data_dir ${CPODIR} --txn_heartbeat_deadline=10s --enable_tx_checksum true --reactor-backend epoll --prometheus_port 63000 --assignment_timeout=1s --nodepool_endpoints ${EPS} --tso_endpoints ${TSO} --persistence_endpoints ${PERSISTENCE} &
+cpo_child_pid=$!
 
 function finish {
   rv=$?

--- a/test/integration/test_schema_create.sh
+++ b/test/integration/test_schema_create.sh
@@ -22,8 +22,6 @@ persistence_child_pid=$!
 ./build/src/k2/cmd/tso/tso -c2 --tcp_endpoints ${TSO} 13001 --enable_tx_checksum true --reactor-backend epoll --prometheus_port 63003 &
 tso_child_pid=$!
 
-sleep 2
-
 ./build/src/k2/cmd/controlPlaneOracle/cpo_main -c2 --tcp_endpoints ${CPO} --data_dir ${CPODIR} --txn_heartbeat_deadline=10s --enable_tx_checksum true --reactor-backend epoll --prometheus_port 63000 --assignment_timeout=1s --nodepool_endpoints ${EPS} --tso_endpoints ${TSO} --persistence_endpoints ${PERSISTENCE} &
 cpo_child_pid=$!
 

--- a/test/integration/test_skv_client.sh
+++ b/test/integration/test_skv_client.sh
@@ -22,8 +22,6 @@ persistence_child_pid=$!
 ./build/src/k2/cmd/tso/tso -c2 --tcp_endpoints ${TSO} 13001 --enable_tx_checksum true --reactor-backend epoll --prometheus_port 63003 &
 tso_child_pid=$!
 
-sleep 2
-
 ./build/src/k2/cmd/controlPlaneOracle/cpo_main -c2 --tcp_endpoints ${CPO} --data_dir ${CPODIR} --txn_heartbeat_deadline=10s --enable_tx_checksum true --reactor-backend epoll --prometheus_port 63000 --assignment_timeout=1s --nodepool_endpoints ${EPS[@]} --tso_endpoints ${TSO} --persistence_endpoints ${PERSISTENCE} &
 cpo_child_pid=$!
 

--- a/test/integration/test_skv_client.sh
+++ b/test/integration/test_skv_client.sh
@@ -10,11 +10,7 @@ PERSISTENCE=tcp+k2rpc://0.0.0.0:12001
 CPO=tcp+k2rpc://0.0.0.0:9000
 TSO=tcp+k2rpc://0.0.0.0:13000
 
-# start CPO on 2 cores
-./build/src/k2/cmd/controlPlaneOracle/cpo_main -c1 --tcp_endpoints ${CPO} 9001 --data_dir ${CPODIR} --enable_tx_checksum true --reactor-backend epoll --prometheus_port 63000 --assignment_timeout=1s &
-cpo_child_pid=$!
-
-# start nodepool on 1 cores
+# start nodepool on 3 cores
 ./build/src/k2/cmd/nodepool/nodepool --log_level INFO k2::skv_server=INFO -c${#EPS[@]} --tcp_endpoints ${EPS[@]} --enable_tx_checksum true --k23si_persistence_endpoint ${PERSISTENCE} --reactor-backend epoll --prometheus_port 63001 --k23si_cpo_endpoint ${CPO} --tso_endpoint ${TSO} &
 nodepool_child_pid=$!
 
@@ -25,6 +21,11 @@ persistence_child_pid=$!
 # start tso on 2 cores
 ./build/src/k2/cmd/tso/tso -c2 --tcp_endpoints ${TSO} 13001 --enable_tx_checksum true --reactor-backend epoll --prometheus_port 63003 &
 tso_child_pid=$!
+
+sleep 2
+
+./build/src/k2/cmd/controlPlaneOracle/cpo_main -c2 --tcp_endpoints ${CPO} --data_dir ${CPODIR} --txn_heartbeat_deadline=10s --enable_tx_checksum true --reactor-backend epoll --prometheus_port 63000 --assignment_timeout=1s --nodepool_endpoints ${EPS[@]} --tso_endpoints ${TSO} --persistence_endpoints ${PERSISTENCE} &
+cpo_child_pid=$!
 
 function finish {
   rv=$?


### PR DESCRIPTION
Implement health monitoring in the CPO via heartbeats. Failed components are reported in metrics and the log. The heartbeat responder is implemented as an applet and added to the nodepool, tso, and persistence. The nodepool will respond to requests with a 410 error if the heartbeat responder is not getting heartbeats from the CPO.

Tested on integration and unit tests, and added a simple integration test that kills the nodepool and verifies the metrics in the CPO.