### PR TITLE
update getTimeNow() in test to return increasing timestamps

### DIFF
--- a/test/k23si/3SITxnTest.cpp
+++ b/test/k23si/3SITxnTest.cpp
@@ -35,6 +35,7 @@ Copyright(c) 2020 Futurewei Cloud
 #include <k2/cpo/client/CPOClient.h>
 #include <k2/transport/RPCDispatcher.h>  // for RPC
 #include "Log.h"
+#include "TestUtil.h"
 
 namespace k2{
 using namespace dto;
@@ -84,12 +85,6 @@ class txn_testing {
 public: // application
     txn_testing() { K2LOG_I(log::k23si, "ctor"); }
     ~txn_testing(){ K2LOG_I(log::k23si, "dtor"); }
-
-    static seastar::future<dto::Timestamp> getTimeNow() {
-        // TODO call TSO service with timeout and retry logic
-        auto nsecsSinceEpoch = sys_now_nsec_count();
-        return seastar::make_ready_future<dto::Timestamp>(dto::Timestamp(nsecsSinceEpoch, 123, 1000));
-    }
 
     // required for seastar::distributed interface
     seastar::future<> gracefulStop() {
@@ -2891,4 +2886,3 @@ int main(int argc, char** argv){
     app.addApplet<k2::txn_testing>();
     return app.start(argc, argv);
 }
-

--- a/test/k23si/K23SITest.cpp
+++ b/test/k23si/K23SITest.cpp
@@ -33,6 +33,7 @@ Copyright(c) 2020 Futurewei Cloud
 #include <k2/dto/ControlPlaneOracle.h>
 #include <k2/dto/MessageVerbs.h>
 #include "Log.h"
+#include "TestUtil.h"
 
 namespace k2 {
 using namespace dto;
@@ -53,12 +54,6 @@ class K23SITest {
 public:  // application lifespan
     K23SITest() { K2LOG_I(log::k23si, "ctor");}
     ~K23SITest(){ K2LOG_I(log::k23si, "dtor");}
-
-    static seastar::future<dto::Timestamp> getTimeNow() {
-        // TODO call TSO service with timeout and retry logic
-        auto nsecsSinceEpoch = sys_now_nsec_count();
-        return seastar::make_ready_future<dto::Timestamp>(dto::Timestamp(nsecsSinceEpoch, 1550647543, 1000));
-    }
 
     // required for seastar::distributed interface
     seastar::future<> gracefulStop() {


### PR DESCRIPTION
Fix the reported issue that the  getTimeNow() in test could return the same timestamps in some scenarios. The original idea to use initial time and offset had some issues, for example, 

[0000:00:04:55.167.190]-3si_txn_test-[0]-(k2::k23si_test) [ERROR] [/build/test/k23si/3SITxnTest.cpp:1159 @operator()] status({code=403, message=TRH create request is too old}) == dto::K23SIStatus::Created({code=201, message=})
3si_txn_test: /build/test/k23si/3SITxnTest.cpp:1159: k2::txn_testing::testScenario01()::<lambda(k2::dto::Timestamp&&)>::<lambda(k2::dto::K23SI_MTR&, k2::dto::Key&, k2::dto::Key&, k2::dto::Key&, k2::DataRec&, k2::DataRec&)>::<lambda(auto:122&&)> [with auto:122 = std::tuple<k2::Status, k2::dto::K23SIWriteResponse>]: Assertion `((status) == (dto::K23SIStatus::Created))' failed.

As a result, add the logic to check for the generate timestamp and sleep if necessary to make sure that we return an increasing timestamp.

All tests passed.
