### PR TITLE
do not allow infinite push for read and write operations

### DIFF
--- a/src/k2/cmd/nodepool/nodepool_main.cpp
+++ b/src/k2/cmd/nodepool/nodepool_main.cpp
@@ -40,6 +40,7 @@ int main(int argc, char** argv) {
         ("k23si_cpo_endpoint", bpo::value<k2::String>(), "the endpoint for k2 CPO service")
         ("k23si_query_pagination_limit", bpo::value<uint32_t>(), "Max records to return in a single query response")
         ("k23si_query_push_limit", bpo::value<uint32_t>(), "Min records in response needed to avoid a push during query processing")
+        ("k23si_max_push_count", bpo::value<uint32_t>(), "Max push count in handleRead and handleWrite")
         ("k23si_persistence_endpoints", bpo::value<std::vector<k2::String>>()->multitoken()->default_value(std::vector<k2::String>()), "A space-delimited list of k2 persistence endpoints, each core will pick one endpoint");
 
     app.addApplet<k2::HeartbeatResponder>();

--- a/src/k2/module/k23si/Config.h
+++ b/src/k2/module/k23si/Config.h
@@ -71,5 +71,8 @@ struct K23SIConfig {
 
     // the endpoint for the CPO
     ConfigVar<String> cpoEndpoint{"k23si_cpo_endpoint", "tcp+k2rpc://127.0.0.1:12345"};
+
+    // maximum push count for a key during handleRead() and handWrite()
+    ConfigVar<uint32_t> maxPushCount{"k23si_max_push_count", 1};
 };
 }

--- a/src/k2/module/k23si/Module.h
+++ b/src/k2/module/k23si/Module.h
@@ -92,6 +92,9 @@ public:
     seastar::future<std::tuple<Status, dto::K23SIReadResponse>>
     handleRead(dto::K23SIReadRequest&& request, FastDeadline deadline);
 
+    seastar::future<std::tuple<Status, dto::K23SIReadResponse>>
+    _handleRead(dto::K23SIReadRequest&& request, FastDeadline deadline, uint32_t count);
+
     seastar::future<std::tuple<Status, dto::K23SIWriteResponse>>
     handleWrite(dto::K23SIWriteRequest&& request, FastDeadline deadline);
 
@@ -236,7 +239,7 @@ private: // methods
 
     // helper used to process the write part of a write request
     seastar::future<std::tuple<Status, dto::K23SIWriteResponse>>
-    _processWrite(dto::K23SIWriteRequest&& request, FastDeadline deadline);
+    _processWrite(dto::K23SIWriteRequest&& request, FastDeadline deadline, uint32_t count);
 
     void _unregisterVerbs();
 

--- a/src/k2/module/k23si/Module.h
+++ b/src/k2/module/k23si/Module.h
@@ -90,16 +90,13 @@ public:
     // on behalf of an incoming read (recursively). We only perform the recursive attempt
     // to read if we were allowed to retry by the PUSH operation
     seastar::future<std::tuple<Status, dto::K23SIReadResponse>>
-    handleRead(dto::K23SIReadRequest&& request, FastDeadline deadline);
-
-    seastar::future<std::tuple<Status, dto::K23SIReadResponse>>
-    _handleRead(dto::K23SIReadRequest&& request, FastDeadline deadline, uint32_t count);
+    handleRead(dto::K23SIReadRequest&& request, FastDeadline deadline, uint32_t count);
 
     seastar::future<std::tuple<Status, dto::K23SIWriteResponse>>
     handleWrite(dto::K23SIWriteRequest&& request, FastDeadline deadline);
 
     seastar::future<std::tuple<Status, dto::K23SIQueryResponse>>
-    handleQuery(dto::K23SIQueryRequest&& request, dto::K23SIQueryResponse&& response, FastDeadline deadline);
+    handleQuery(dto::K23SIQueryRequest&& request, dto::K23SIQueryResponse&& response, FastDeadline deadline, uint32_t count);
 
     seastar::future<std::tuple<Status, dto::K23SITxnPushResponse>>
     handleTxnPush(dto::K23SITxnPushRequest&& request);
@@ -147,7 +144,7 @@ private: // methods
     // incumbent transaction state at the TRH will be updated to reflect the abort decision.
     // The incumbent transaction will discover upon commit that the txn has been aborted.
     seastar::future<Status>
-    _doPush(dto::Key key, dto::Timestamp incumbentId, dto::K23SI_MTR challengerMTR, FastDeadline deadline);
+    _doPush(dto::Key key, dto::Timestamp incumbentId, dto::K23SI_MTR challengerMTR, FastDeadline deadline, uint32_t count);
 
     // validate requests are coming to the correct partition. return true if request is valid
     template<typename RequestT>


### PR DESCRIPTION
The bug was found by Jepsen tests. This PR is to only allow the push count for a key to be at most k23si_max_push_count, which is 1 by default.

