### PR TITLE
Use hash collection for TPC-C item table

### DIFF
--- a/src/k2/cmd/tpcc/schema.h
+++ b/src/k2/cmd/tpcc/schema.h
@@ -35,6 +35,7 @@ Copyright(c) 2020 Futurewei Cloud
 #include "Log.h"
 using namespace k2;
 static const String tpccCollectionName = "TPCC";
+static const String itemCollectionName = "TPCCItem";
 
 #define CHECK_READ_STATUS(read_result) \
     do { \
@@ -640,7 +641,7 @@ public:
     std::optional<String> Info;
 
     static inline thread_local std::shared_ptr<dto::Schema> schema;
-    static inline String collectionName = tpccCollectionName;
+    static inline String collectionName = itemCollectionName;
     SKV_RECORD_FIELDS(ItemID, ImageID, Price, Name, Info);
 };
 

--- a/src/k2/cmd/tpcc/tpcc_client.cpp
+++ b/src/k2/cmd/tpcc/tpcc_client.cpp
@@ -289,7 +289,7 @@ private:
                 return _item_loader.loadData(_client, _num_concurrent_txns());
             });
         } else {
-            f = f.then([] { return seastar::sleep(15s); });
+            f = f.then([] { return seastar::sleep(20s); });
         }
 
         return f.then ([this, share] {
@@ -463,6 +463,7 @@ int main(int argc, char** argv) {;
         ("do_verification", bpo::value<bool>()->default_value(true), "Run verification tests after run")
         ("cpo_request_timeout", bpo::value<ParseableDuration>(), "CPO request timeout")
         ("cpo_request_backoff", bpo::value<ParseableDuration>(), "CPO request backoff")
+        ("create_collection_deadline", bpo::value<ParseableDuration>(), "Collection creation and assignment deadline")
         ("delivery_txn_batch_size", bpo::value<uint16_t>()->default_value(10), "The batch number of Delivery transaction")
         ("txn_weights", bpo::value<std::vector<int>>()->multitoken()->default_value(std::vector<int>({43,4,4,45,4})), "A comma-separated list of exactly 5 elements denoting the percentage for each txn type: Payment, OrderStatus, Delivery, NewOrder, and StockLevel");
 

--- a/src/k2/cmd/tpcc/tpcc_client.cpp
+++ b/src/k2/cmd/tpcc/tpcc_client.cpp
@@ -222,7 +222,7 @@ private:
             K2ASSERT(log::tpcc, result.status.is2xxOK(), "Failed to create schema");
         }));
 
-        schema_futures.push_back(_client.createSchema(tpccCollectionName, Item::item_schema)
+        schema_futures.push_back(_client.createSchema(itemCollectionName, Item::item_schema)
         .then([] (auto&& result) {
             K2ASSERT(log::tpcc, result.status.is2xxOK(), "Failed to create schema");
         }));
@@ -249,10 +249,38 @@ private:
         auto f = seastar::make_ready_future<>();
         if (_global_id == 0) {
             f = f.then ([this] {
-                K2LOG_I(log::tpcc, "Creating collection");
-                return _client.makeCollection("TPCC", getRangeEnds(_tcpRemotes().size(), _max_warehouses()));
-            }).discard_result()
-            .then([this] () {
+                K2LOG_I(log::tpcc, "Creating primary collection");
+                dto::CollectionMetadata metadata{
+                    .name = tpccCollectionName,
+                    .hashScheme = dto::HashScheme::Range,
+                    .storageDriver = dto::StorageDriver::K23SI,
+                    .capacity = {},
+                    .retentionPeriod = Duration{}
+                };
+                std::vector<String> endpoints(_tcpRemotes().begin()+_item_table_num_nodes(),
+                                                        _tcpRemotes().end());
+
+                return _client.makeCollection(std::move(metadata), std::move(endpoints),
+                                                getRangeEnds(_tcpRemotes().size()-_item_table_num_nodes(),
+                                                _max_warehouses()));
+            })
+            .then([this] (Status&& status) {
+                K2ASSERT(log::tpcc, status.is2xxOK(), "Failed to make primary collection");
+                K2LOG_I(log::tpcc, "Creating Item collection");
+                dto::CollectionMetadata metadata{
+                    .name = itemCollectionName,
+                    .hashScheme = dto::HashScheme::HashCRC32C,
+                    .storageDriver = dto::StorageDriver::K23SI,
+                    .capacity = {},
+                    .retentionPeriod = Duration{}
+                };
+                std::vector<String> endpoints(_tcpRemotes().begin(),
+                                                        _tcpRemotes().begin()+_item_table_num_nodes());
+
+                return _client.makeCollection(std::move(metadata), std::move(endpoints));
+            })
+            .then([this] (Status&& status) {
+                K2ASSERT(log::tpcc, status.is2xxOK(), "Failed to make Item collection");
                 return _schema_load();
             })
             .then([this] {
@@ -385,6 +413,7 @@ private:
     seastar::future<> _benchFuture = seastar::make_ready_future<>();
 
     ConfigVar<std::vector<String>> _tcpRemotes{"tcp_remotes"};
+    ConfigVar<uint32_t> _item_table_num_nodes{"item_table_num_nodes"};
     ConfigVar<bool> _do_data_load{"data_load"};
     ConfigVar<bool> _do_verification{"do_verification"};
     ConfigVar<int> _num_instances{"num_instances"};
@@ -417,6 +446,7 @@ int main(int argc, char** argv) {;
     k2::App app("TPCCClient");
     app.addOptions()
         ("tcp_remotes", bpo::value<std::vector<k2::String>>()->multitoken()->default_value(std::vector<k2::String>()), "A list(space-delimited) of TCP remote endpoints to assign to each core. e.g. 'tcp+k2rpc://192.168.1.2:12345'")
+        ("item_table_num_nodes", bpo::value<uint32_t>()->default_value(1), "Number of nodes to use (drawn from tcp_remotes) for the separate item table collection")
         ("cpo", bpo::value<k2::String>(), "URL of Control Plane Oracle (CPO), e.g. 'tcp+k2rpc://192.168.1.2:12345'")
         ("tso_endpoint", bpo::value<k2::String>(), "URL of Timestamp Oracle (TSO), e.g. 'tcp+k2rpc://192.168.1.2:12345'")
         ("data_load", bpo::value<bool>()->default_value(false), "If true, only data gen and load are performed. If false, only benchmark is performed.")

--- a/src/k2/cmd/tpcc/tpcc_client.cpp
+++ b/src/k2/cmd/tpcc/tpcc_client.cpp
@@ -261,7 +261,7 @@ private:
                 return _item_loader.loadData(_client, _num_concurrent_txns());
             });
         } else {
-            f = f.then([] { return seastar::sleep(5s); });
+            f = f.then([] { return seastar::sleep(15s); });
         }
 
         return f.then ([this, share] {

--- a/src/k2/cmd/tpcc/transactions.h
+++ b/src/k2/cmd/tpcc/transactions.h
@@ -105,7 +105,6 @@ public:
         })
         .handle_exception([] (auto exc) {
             K2LOG_W_EXC(log::tpcc, exc, "Txn failed after retries");
-            K2LOG_I(log::tpcc, "Txn failed after retries");
             return make_ready_future<bool>(false);
         });
     }
@@ -505,8 +504,7 @@ private:
         }
         uint32_t rollback = _random.UniformRandom(1, 100);
         if (rollback == 1) {
-            _lines.back().ItemID = 999999; //Item::InvalidID;
- //           _lines.back().ItemID = Item::InvalidID;
+            _lines.back().ItemID = Item::InvalidID;
         }
     }
 
@@ -571,7 +569,6 @@ private:
         })
         // commit txn
         .then_wrapped([this] (auto&& fut) {
-
             if (fut.failed()) {
                 _failed = true;
                 fut.ignore_ready_future();
@@ -1254,7 +1251,6 @@ private:
         })
         // commit txn
         .then_wrapped([this] (auto&& fut) {
-
             if (fut.failed()) {
                 _failed = true;
                 fut.ignore_ready_future();

--- a/src/k2/cmd/tpcc/transactions.h
+++ b/src/k2/cmd/tpcc/transactions.h
@@ -105,6 +105,7 @@ public:
         })
         .handle_exception([] (auto exc) {
             K2LOG_W_EXC(log::tpcc, exc, "Txn failed after retries");
+            K2LOG_I(log::tpcc, "Txn failed after retries");
             return make_ready_future<bool>(false);
         });
     }
@@ -504,7 +505,8 @@ private:
         }
         uint32_t rollback = _random.UniformRandom(1, 100);
         if (rollback == 1) {
-            _lines.back().ItemID = Item::InvalidID;
+            _lines.back().ItemID = 999999; //Item::InvalidID;
+ //           _lines.back().ItemID = Item::InvalidID;
         }
     }
 
@@ -569,6 +571,7 @@ private:
         })
         // commit txn
         .then_wrapped([this] (auto&& fut) {
+
             if (fut.failed()) {
                 _failed = true;
                 fut.ignore_ready_future();
@@ -887,9 +890,8 @@ public:
                 .then_wrapped([this] (auto&& fut) {
                     if (fut.failed()) {
                         _failed = true;
-                    } else {
-                         fut.ignore_ready_future();
-                    }  
+                    }
+                    fut.ignore_ready_future();
                 });
             })
             .then([this]() {
@@ -1252,6 +1254,7 @@ private:
         })
         // commit txn
         .then_wrapped([this] (auto&& fut) {
+
             if (fut.failed()) {
                 _failed = true;
                 fut.ignore_ready_future();

--- a/src/k2/cmd/tpcc/verify.cpp
+++ b/src/k2/cmd/tpcc/verify.cpp
@@ -516,6 +516,7 @@ future<> ConsistencyVerify::verifyOrderLineDelivery() {
         [this] () {
             return _txn.query(_query)
             .then([this] (auto&& response) {
+                //K2LOG_I(log::tpcc, "checking response for orderline: {}", response);
                 CHECK_READ_STATUS(response);
 
                 std::vector<future<>> orderFutures;
@@ -679,12 +680,13 @@ future<> ConsistencyVerify::runForEachWarehouseDistrict(consistencyOp op) {
         });
     }).discard_result()
     .then([this] () {
+        K2LOG_I(log::tpcc, "ending transaction for runForEachWarehouseDistrict");
         return _txn.end(true);
     })
     .then_wrapped([this] (auto&& fut) {
         if (fut.failed()) {
             K2LOG_W_EXC(log::tpcc, fut.get_exception(), "Txn failed");
-            K2ASSERT(log::tpcc, false, "Txn failed");
+            K2ASSERT(log::tpcc, false, "Txn failed with exception {}", fut.get_exception());
         }
         EndResult result = fut.get0();
         K2ASSERT(log::tpcc, result.status.is2xxOK(), "Txn end failed, bad status: {}", result.status);
@@ -735,4 +737,3 @@ future<> ConsistencyVerify::run() {
         return runForEachWarehouseDistrict(&ConsistencyVerify::verifyDistrictHistorySum);
     });
 }
-

--- a/src/k2/cmd/tpcc/verify.cpp
+++ b/src/k2/cmd/tpcc/verify.cpp
@@ -516,7 +516,7 @@ future<> ConsistencyVerify::verifyOrderLineDelivery() {
         [this] () {
             return _txn.query(_query)
             .then([this] (auto&& response) {
-                //K2LOG_I(log::tpcc, "checking response for orderline: {}", response);
+                K2LOG_D(log::tpcc, "checking response for orderline: {}", response);
                 CHECK_READ_STATUS(response);
 
                 std::vector<future<>> orderFutures;

--- a/src/k2/module/k23si/Module.cpp
+++ b/src/k2/module/k23si/Module.cpp
@@ -467,7 +467,7 @@ void K23SIPartitionModule::_scanAdvance(IndexerIterator& it, bool reverseDirecti
         --it;
 
         if (it->first.schemaName != schema) {
-            it = _indexer.end();  //_indexer.begin() ?
+            it = _indexer.end();
         }
     }
 }

--- a/src/k2/module/k23si/Module.cpp
+++ b/src/k2/module/k23si/Module.cpp
@@ -467,7 +467,7 @@ void K23SIPartitionModule::_scanAdvance(IndexerIterator& it, bool reverseDirecti
         --it;
 
         if (it->first.schemaName != schema) {
-            it = _indexer.end();
+            it = _indexer.end();  //_indexer.begin() ?
         }
     }
 }

--- a/test/integration/test_k23si_tpcc.sh
+++ b/test/integration/test_k23si_tpcc.sh
@@ -3,7 +3,6 @@ set -e
 topname=$(dirname "$0")
 source ${topname}/common_defs.sh
 cd ${topname}/../..
-<<<<<<< HEAD
 
 # start nodepool
 ./build/src/k2/cmd/nodepool/nodepool ${COMMON_ARGS} -c${#EPS[@]} --tcp_endpoints ${EPS[@]} --k23si_persistence_endpoint ${PERSISTENCE} --prometheus_port 63001 --k23si_cpo_endpoint ${CPO} --tso_endpoint ${TSO} --memory=3G --partition_request_timeout=6s &
@@ -50,7 +49,7 @@ sleep 2
 NUMWH=1
 NUMDIST=1
 echo ">>> Starting load ..."
-./build/src/k2/cmd/tpcc/tpcc_client ${COMMON_ARGS} -c1 --tcp_remotes ${EPS[@]} --cpo ${CPO} --tso_endpoint ${TSO} --data_load true --num_warehouses ${NUMWH} --districts_per_warehouse ${NUMDIST} --prometheus_port 63100 --memory=512M --partition_request_timeout=6s --dataload_txn_timeout=600s --do_verification true --num_concurrent_txns=2 --txn_weights={43,4,4,45,4}
+./build/src/k2/cmd/tpcc/tpcc_client ${COMMON_ARGS} -c1 --tcp_remotes ${EPS[@]} --cpo ${CPO} --tso_endpoint ${TSO} --data_load true --num_warehouses ${NUMWH} --districts_per_warehouse ${NUMDIST} --prometheus_port 63100 --memory=512M --partition_request_timeout=6s --dataload_txn_timeout=600s --do_verification true --num_concurrent_txns=2 --item_table_num_nodes=1 --txn_weights={43,4,4,45,4}
 
 sleep 1
 

--- a/test/integration/test_k23si_tpcc.sh
+++ b/test/integration/test_k23si_tpcc.sh
@@ -3,6 +3,7 @@ set -e
 topname=$(dirname "$0")
 source ${topname}/common_defs.sh
 cd ${topname}/../..
+<<<<<<< HEAD
 
 # start nodepool
 ./build/src/k2/cmd/nodepool/nodepool ${COMMON_ARGS} -c${#EPS[@]} --tcp_endpoints ${EPS[@]} --k23si_persistence_endpoint ${PERSISTENCE} --prometheus_port 63001 --k23si_cpo_endpoint ${CPO} --tso_endpoint ${TSO} --memory=3G --partition_request_timeout=6s &


### PR DESCRIPTION
Due to the range partitioning and key definition from the tpc-c spec, previously all of the tpc-c item rows were on a single partition that also owned the data for a tpc-c warehouse. The item table is heavily used and this caused that node to be overloaded and slow down the whole system's throughput (one symptom was the RDMA rx batch size was always maxed on that node).

This change puts the item table on a separate hash collection on a configurable number of nodes. Results:
- All txn types. Before: **171** txns/sec/nodepool core. After: **205** txns/sec/nodepool/core
- 50/50 payment/new order txns. Before: **160** txns/sec/nodepool core. After **464** txns/sec/nodepool core

RDMA rx batch sizes are similar and under the max for all nodes now. Also, abort rates are 10x higher than before so maybe the bottleneck has shifted to conflicts. Integration and unit tests pass. closes #242 