### PR TITLE
CPO select nodes for collection assignment

### DIFF
--- a/src/k2/assignmentManager/AssignmentManager.cpp
+++ b/src/k2/assignmentManager/AssignmentManager.cpp
@@ -29,6 +29,7 @@ Copyright(c) 2020 Futurewei Cloud
 #include <k2/dto/MessageVerbs.h>         // our DTO
 #include <k2/transport/RPCDispatcher.h>  // for RPC
 #include <k2/transport/Status.h>         // for RPC
+#include <k2/transport/Discovery.h>      // for selectBestEndpointString
 
 namespace k2 {
 
@@ -96,15 +97,7 @@ AssignmentManager::handleAssign(dto::AssignmentCreateRequest&& request) {
         partition.endpoints.insert(rdma_ep->url);
     }
 
-    String cpoEP = "";
-    for (const String& ep : request.cpoEndpoints) {
-        if (ep.find(RRDMARPCProtocol::proto) != String::npos && rdma_ep) {
-            cpoEP = ep;
-        }
-        else if (ep.find(TCPRPCProtocol::proto) != String::npos && !rdma_ep) {
-            cpoEP = ep;
-        }
-    }
+    String cpoEP = Discovery::selectBestEndpointString(request.cpoEndpoints);
     K2LOG_I(log::amgr, "From CPO: {} chose {}", request.cpoEndpoints, cpoEP);
 
     _collectionName = meta.name;

--- a/src/k2/cmd/httpclient/http_client.cpp
+++ b/src/k2/cmd/httpclient/http_client.cpp
@@ -432,10 +432,8 @@ int main(int argc, char** argv) {
     app.addApplet<k2::HTTPClient>();
     app.addOptions()
         // config for dependencies
-        ("tcp_remotes", bpo::value<std::vector<k2::String>>()->multitoken()->default_value(std::vector<k2::String>()), "A list(space-delimited) of endpoints to assign in the test collection")
         ("partition_request_timeout", bpo::value<k2::ParseableDuration>(), "Timeout of K23SI operations, as chrono literals")
         ("cpo", bpo::value<k2::String>(), "URL of Control Plane Oracle (CPO), e.g. 'tcp+k2rpc://192.168.1.2:12345'")
-        ("tso_endpoint", bpo::value<k2::String>(), "URL of Timestamp Oracle (TSO), e.g. 'tcp+k2rpc://192.168.1.2:12345'")
         ("cpo_request_timeout", bpo::value<k2::ParseableDuration>(), "CPO request timeout")
         ("cpo_request_backoff", bpo::value<k2::ParseableDuration>(), "CPO request backoff");
     return app.start(argc, argv);

--- a/src/k2/cmd/nodepool/nodepool_main.cpp
+++ b/src/k2/cmd/nodepool/nodepool_main.cpp
@@ -39,6 +39,7 @@ int main(int argc, char** argv) {
         ("k23si_query_pagination_limit", bpo::value<uint32_t>(), "Max records to return in a single query response")
         ("k23si_query_push_limit", bpo::value<uint32_t>(), "Min records in response needed to avoid a push during query processing")
         ("k23si_max_push_count", bpo::value<uint32_t>(), "Max push count in handleRead and handleWrite")
+        ("k23si_persistence_endpoints", bpo::value<std::vector<k2::String>>()->multitoken()->default_value(std::vector<k2::String>()), "A space-delimited list of k2 persistence endpoints, each core will pick one endpoint");
 
     app.addApplet<k2::cpo::HeartbeatResponder>();
     app.addApplet<k2::APIServer>();

--- a/src/k2/cmd/nodepool/nodepool_main.cpp
+++ b/src/k2/cmd/nodepool/nodepool_main.cpp
@@ -36,7 +36,6 @@ int main(int argc, char** argv) {
         ("partition_request_timeout", bpo::value<k2::ParseableDuration>(), "Timeout of K23SI operations, as chrono literals")
         ("cpo_request_timeout", bpo::value<k2::ParseableDuration>(), "CPO request timeout")
         ("cpo_request_backoff", bpo::value<k2::ParseableDuration>(), "CPO request backoff")
-        ("k23si_cpo_endpoint", bpo::value<k2::String>(), "the endpoint for k2 CPO service")
         ("k23si_query_pagination_limit", bpo::value<uint32_t>(), "Max records to return in a single query response")
         ("k23si_query_push_limit", bpo::value<uint32_t>(), "Min records in response needed to avoid a push during query processing")
         ("k23si_max_push_count", bpo::value<uint32_t>(), "Max push count in handleRead and handleWrite")

--- a/src/k2/cmd/nodepool/nodepool_main.cpp
+++ b/src/k2/cmd/nodepool/nodepool_main.cpp
@@ -33,7 +33,6 @@ int main(int argc, char** argv) {
     k2::App app("NodePoolService");
 
     app.addOptions()
-        ("tso_endpoint", bpo::value<k2::String>(), "URL of Timestamp Oracle (TSO) endpoint")
         ("partition_request_timeout", bpo::value<k2::ParseableDuration>(), "Timeout of K23SI operations, as chrono literals")
         ("cpo_request_timeout", bpo::value<k2::ParseableDuration>(), "CPO request timeout")
         ("cpo_request_backoff", bpo::value<k2::ParseableDuration>(), "CPO request backoff")
@@ -41,7 +40,6 @@ int main(int argc, char** argv) {
         ("k23si_query_pagination_limit", bpo::value<uint32_t>(), "Max records to return in a single query response")
         ("k23si_query_push_limit", bpo::value<uint32_t>(), "Min records in response needed to avoid a push during query processing")
         ("k23si_max_push_count", bpo::value<uint32_t>(), "Max push count in handleRead and handleWrite")
-        ("k23si_persistence_endpoints", bpo::value<std::vector<k2::String>>()->multitoken()->default_value(std::vector<k2::String>()), "A space-delimited list of k2 persistence endpoints, each core will pick one endpoint");
 
     app.addApplet<k2::cpo::HeartbeatResponder>();
     app.addApplet<k2::APIServer>();

--- a/src/k2/cmd/tpcc/tpcc_client.cpp
+++ b/src/k2/cmd/tpcc/tpcc_client.cpp
@@ -412,7 +412,6 @@ private:
     std::vector<future<>> _tpcc_futures;
     seastar::future<> _benchFuture = seastar::make_ready_future<>();
 
-    ConfigVar<std::vector<String>> _tcpRemotes{"tcp_remotes"};
     ConfigVar<uint32_t> _item_table_num_nodes{"item_table_num_nodes"};
     ConfigVar<bool> _do_data_load{"data_load"};
     ConfigVar<bool> _do_verification{"do_verification"};
@@ -445,10 +444,8 @@ private:
 int main(int argc, char** argv) {;
     k2::App app("TPCCClient");
     app.addOptions()
-        ("tcp_remotes", bpo::value<std::vector<k2::String>>()->multitoken()->default_value(std::vector<k2::String>()), "A list(space-delimited) of TCP remote endpoints to assign to each core. e.g. 'tcp+k2rpc://192.168.1.2:12345'")
         ("item_table_num_nodes", bpo::value<uint32_t>()->default_value(1), "Number of nodes to use (drawn from tcp_remotes) for the separate item table collection")
         ("cpo", bpo::value<k2::String>(), "URL of Control Plane Oracle (CPO), e.g. 'tcp+k2rpc://192.168.1.2:12345'")
-        ("tso_endpoint", bpo::value<k2::String>(), "URL of Timestamp Oracle (TSO), e.g. 'tcp+k2rpc://192.168.1.2:12345'")
         ("data_load", bpo::value<bool>()->default_value(false), "If true, only data gen and load are performed. If false, only benchmark is performed.")
         ("num_instances", bpo::value<int>()->default_value(1), "Number of client instances.")
         ("instance_id", bpo::value<int>()->default_value(0), "ID of this client instance.")

--- a/src/k2/cmd/tpcc/tpcc_client.cpp
+++ b/src/k2/cmd/tpcc/tpcc_client.cpp
@@ -254,14 +254,17 @@ private:
                     .name = tpccCollectionName,
                     .hashScheme = dto::HashScheme::Range,
                     .storageDriver = dto::StorageDriver::K23SI,
-                    .capacity = {},
+                    .capacity = {
+                        .dataCapacityMegaBytes = 0,
+                        .readIOPs = 0,
+                        .writeIOPs = 0,
+                        .minNodes = _warehouse_tables_num_nodes()
+                    },
                     .retentionPeriod = Duration{}
                 };
-                std::vector<String> endpoints(_tcpRemotes().begin()+_item_table_num_nodes(),
-                                                        _tcpRemotes().end());
 
-                return _client.makeCollection(std::move(metadata), std::move(endpoints),
-                                                getRangeEnds(_tcpRemotes().size()-_item_table_num_nodes(),
+                return _client.makeCollection(std::move(metadata),
+                                                getRangeEnds(_warehouse_tables_num_nodes()-_item_table_num_nodes(),
                                                 _max_warehouses()));
             })
             .then([this] (Status&& status) {
@@ -271,13 +274,16 @@ private:
                     .name = itemCollectionName,
                     .hashScheme = dto::HashScheme::HashCRC32C,
                     .storageDriver = dto::StorageDriver::K23SI,
-                    .capacity = {},
+                    .capacity = {
+                        .dataCapacityMegaBytes = 0,
+                        .readIOPs = 0,
+                        .writeIOPs = 0,
+                        .minNodes = _item_table_num_nodes()
+                    },
                     .retentionPeriod = Duration{}
                 };
-                std::vector<String> endpoints(_tcpRemotes().begin(),
-                                                        _tcpRemotes().begin()+_item_table_num_nodes());
 
-                return _client.makeCollection(std::move(metadata), std::move(endpoints));
+                return _client.makeCollection(std::move(metadata));
             })
             .then([this] (Status&& status) {
                 K2ASSERT(log::tpcc, status.is2xxOK(), "Failed to make Item collection");
@@ -413,6 +419,7 @@ private:
     seastar::future<> _benchFuture = seastar::make_ready_future<>();
 
     ConfigVar<uint32_t> _item_table_num_nodes{"item_table_num_nodes"};
+    ConfigVar<uint32_t> _warehouse_tables_num_nodes{"warehouse_tables_num_nodes"};
     ConfigVar<bool> _do_data_load{"data_load"};
     ConfigVar<bool> _do_verification{"do_verification"};
     ConfigVar<int> _num_instances{"num_instances"};
@@ -444,7 +451,8 @@ private:
 int main(int argc, char** argv) {;
     k2::App app("TPCCClient");
     app.addOptions()
-        ("item_table_num_nodes", bpo::value<uint32_t>()->default_value(1), "Number of nodes to use (drawn from tcp_remotes) for the separate item table collection")
+        ("item_table_num_nodes", bpo::value<uint32_t>()->default_value(1), "Number of nodes to use for the separate item table collection")
+        ("warehouse_tables_num_nodes", bpo::value<uint32_t>()->default_value(1), "Number of nodes to use for the warehouse indexed tables")
         ("cpo", bpo::value<k2::String>(), "URL of Control Plane Oracle (CPO), e.g. 'tcp+k2rpc://192.168.1.2:12345'")
         ("data_load", bpo::value<bool>()->default_value(false), "If true, only data gen and load are performed. If false, only benchmark is performed.")
         ("num_instances", bpo::value<int>()->default_value(1), "Number of client instances.")

--- a/src/k2/cmd/txbench/k23sibench_client.cpp
+++ b/src/k2/cmd/txbench/k23sibench_client.cpp
@@ -331,10 +331,8 @@ int main(int argc, char** argv) {
         ("test_duration", bpo::value<ParseableDuration>(), "How long to run")
         ("txn_timeout", bpo::value<ParseableDuration>(), "timeout for each transaction")
         // config for dependencies
-        ("tcp_remotes", bpo::value<std::vector<String>>()->multitoken()->default_value(std::vector<String>()), "A list(space-delimited) of endpoints to assign in the test collection")
         ("partition_request_timeout", bpo::value<ParseableDuration>(), "Timeout of K23SI operations, as chrono literals")
         ("cpo", bpo::value<String>(), "URL of Control Plane Oracle (CPO), e.g. 'tcp+k2rpc://192.168.1.2:12345'")
-        ("tso_endpoint", bpo::value<String>(), "URL of Timestamp Oracle (TSO), e.g. 'tcp+k2rpc://192.168.1.2:12345'")
         ("cpo_request_timeout", bpo::value<ParseableDuration>(), "CPO request timeout")
         ("cpo_request_backoff", bpo::value<ParseableDuration>(), "CPO request backoff");
     return app.start(argc, argv);

--- a/src/k2/cmd/txbench/k23sibench_client.cpp
+++ b/src/k2/cmd/txbench/k23sibench_client.cpp
@@ -115,8 +115,21 @@ public:  // application lifespan
         if (myid == 0) {
             K2LOG_I(log::txbench, "Creating collection...");
             _benchFut = _benchFut.then([this] {
-                return _client.makeCollection(collname).discard_result()
-                .then([this] () {
+                k2::dto::CollectionMetadata meta{
+                    .name = collname,
+                    .hashScheme = dto::HashScheme::HashCRC32C,
+                    .storageDriver = dto::StorageDriver::K23SI,
+                    .capacity{
+                        .dataCapacityMegaBytes = 0,
+                        .readIOPs = 0,
+                        .writeIOPs = 0,
+                        .minNodes = _numPartitions()
+                    },
+                    .retentionPeriod = 5h
+                };
+                return _client.makeCollection(std::move(meta))
+                .then([this] (Status&& status) {
+                    K2ASSERT(log::txbench, status.is2xxOK(), "Failed to create collection");
                     return _client.createSchema(collname, _schema);
                 }).discard_result();
             });
@@ -302,6 +315,7 @@ private://metrics
     uint64_t _failWrites = 0;
 
    private:
+    ConfigVar<uint32_t> _numPartitions{"num_partitions"};
     ConfigVar<uint32_t> _dataSize{"data_size"};
     ConfigVar<uint32_t> _reads{"reads"};
     ConfigVar<uint32_t> _writes{"writes"};
@@ -323,6 +337,7 @@ int main(int argc, char** argv) {
     app.addApplet<tso::TSOClient>();
     app.addApplet<Client>();
     app.addOptions()
+        ("num_partitions", bpo::value<uint32_t>()->default_value(1), "How many k2 storage nodes to use")
         ("data_size", bpo::value<uint32_t>()->default_value(512), "How many bytes to write in records")
         ("reads", bpo::value<uint32_t>()->default_value(1), "How many reads to do in each txn")
         ("writes", bpo::value<uint32_t>()->default_value(1), "How many writes to do in each txn")

--- a/src/k2/cmd/ycsb/ycsb_client.cpp
+++ b/src/k2/cmd/ycsb/ycsb_client.cpp
@@ -383,7 +383,6 @@ private:
     std::shared_ptr<RandomGenerator> _scanLengthDist; // Request distribution for selecting length of scan
     size_t _num_keys; // total keys in keyspace
 
-    ConfigVar<std::vector<String>> _tcpRemotes{"tcp_remotes"};
     ConfigVar<bool> _do_data_load{"data_load"};
     ConfigVar<int> _num_concurrent_txns{"num_concurrent_txns"};
     ConfigVar<uint32_t> _num_fields{"num_fields"};
@@ -423,9 +422,7 @@ private:
 int main(int argc, char** argv) {;
     k2::App app("YCSBClient");
     app.addOptions()
-        ("tcp_remotes", bpo::value<std::vector<k2::String>>()->multitoken()->default_value(std::vector<k2::String>()), "A list(space-delimited) of TCP remote endpoints to assign to each core. e.g. 'tcp+k2rpc://192.168.1.2:12345'")
         ("cpo", bpo::value<k2::String>(), "URL of Control Plane Oracle (CPO), e.g. 'tcp+k2rpc://192.168.1.2:12345'")
-        ("tso_endpoint", bpo::value<k2::String>(), "URL of Timestamp Oracle (TSO), e.g. 'tcp+k2rpc://192.168.1.2:12345'")
         ("data_load", bpo::value<bool>()->default_value(false), "If true, only data gen and load are performed. If false, only benchmark is performed.")
         ("num_concurrent_txns", bpo::value<int>()->default_value(2), "Number of concurrent transactions to use")
         ("test_duration", bpo::value<k2::ParseableDuration>(), "How long in seconds to run")

--- a/src/k2/cpo/client/Client.h
+++ b/src/k2/cpo/client/Client.h
@@ -57,9 +57,8 @@ public:
     // Creates a collection and waits for it to be assigned. If the collection already exisits,
     // the future is still completed successfully
     template<typename ClockT=Clock>
-    seastar::future<Status> createAndWaitForCollection(Deadline<ClockT> deadline, dto::CollectionMetadata&& metadata, std::vector<String>&& clusterEndpoints, std::vector<String>&& rangeEnds) {
+    seastar::future<Status> createAndWaitForCollection(Deadline<ClockT> deadline, dto::CollectionMetadata&& metadata, std::vector<String>&& rangeEnds) {
         dto::CollectionCreateRequest request{.metadata = std::move(metadata),
-                                             .clusterEndpoints = std::move(clusterEndpoints),
                                              .rangeEnds = std::move(rangeEnds)};
 
         Duration timeout = std::min(deadline.getRemaining(), cpo_request_timeout());

--- a/src/k2/cpo/service/HealthMonitor.cpp
+++ b/src/k2/cpo/service/HealthMonitor.cpp
@@ -23,6 +23,7 @@ Copyright(c) 2021 Futurewei Cloud
 
 #include "HealthMonitor.h"
 
+#include <k2/appbase/Appbase.h>
 #include <k2/dto/MessageVerbs.h>
 
 namespace k2::cpo {
@@ -176,15 +177,30 @@ void HealthMonitor::_registerMetrics() {
 // TODO: These three get*Endpoints functions are implemented assuming the auto-rrdma
 // protocol will be improved to support full auto-negotiation. If it isn't then one option
 // is to change these to return the endpoints received from the RPCServers heartbeat responses.
-std::vector<String> HealthMonitor::getNodepoolEndpoints() {
+seastar::future<std::vector<String>> HealthMonitor::getNodepoolEndpoints() {
+    return AppBase().getDist<HealthMonitor>().invoke_on(_heartbeatMonitorShardId(),
+                            &HealthMonitor::getNodepoolEndpointsHelper);
+}
+
+seastar::future<std::vector<String>> HealthMonitor::getTSOEndpoints() {
+    return AppBase().getDist<HealthMonitor>().invoke_on(_heartbeatMonitorShardId(),
+                            &HealthMonitor::getTSOEndpointsHelper);
+}
+
+seastar::future<std::vector<String>> HealthMonitor::getPersistEndpoints() {
+    return AppBase().getDist<HealthMonitor>().invoke_on(_heartbeatMonitorShardId(),
+                            &HealthMonitor::getPersistEndpointsHelper);
+}
+
+std::vector<String> HealthMonitor::getNodepoolEndpointsHelper() {
     return _nodepoolEndpoints();
 }
 
-std::vector<String> HealthMonitor::getTSOEndpoints() {
+std::vector<String> HealthMonitor::getTSOEndpointsHelper() {
     return _TSOEndpoints();
 }
 
-std::vector<String> HealthMonitor::getPersistEndpoints() {
+std::vector<String> HealthMonitor::getPersistEndpointsHelper() {
     return _persistEndpoints();
 }
 

--- a/src/k2/cpo/service/HealthMonitor.cpp
+++ b/src/k2/cpo/service/HealthMonitor.cpp
@@ -173,6 +173,21 @@ void HealthMonitor::_registerMetrics() {
     });
 }
 
+// TODO: These three get*Endpoints functions are implemented assuming the auto-rrdma
+// protocol will be improved to support full auto-negotiation. If it isn't then one option
+// is to change these to return the endpoints received from the RPCServers heartbeat responses.
+std::vector<String> HealthMonitor::getNodepoolEndpoints() {
+    return _nodepoolEndpoints();
+}
+
+std::vector<String> HealthMonitor::getTSOEndpoints() {
+    return _TSOEndpoints();
+}
+
+std::vector<String> HealthMonitor::getPersistEndpoints() {
+    return _persistEndpoints();
+}
+
 seastar::future<> HealthMonitor::start() {
     if (seastar::this_shard_id() != _heartbeatMonitorShardId()) {
         return seastar::make_ready_future<>();

--- a/src/k2/cpo/service/HealthMonitor.h
+++ b/src/k2/cpo/service/HealthMonitor.h
@@ -99,14 +99,18 @@ private:
     void _addHBControl(RPCServer&& server, TimePoint nextHB);
     void _checkHBs();
 
+    std::vector<String> getNodepoolEndpointsHelper();
+    std::vector<String> getTSOEndpointsHelper();
+    std::vector<String> getPersistEndpointsHelper();
+
 public:
     // required for seastar::distributed interface
     seastar::future<> gracefulStop();
     seastar::future<> start();
 
-    std::vector<String> getNodepoolEndpoints();
-    std::vector<String> getTSOEndpoints();
-    std::vector<String> getPersistEndpoints();
+    seastar::future<std::vector<String>> getNodepoolEndpoints();
+    seastar::future<std::vector<String>> getTSOEndpoints();
+    seastar::future<std::vector<String>> getPersistEndpoints();
 };  // class HealthMonitor
 
 } // namespace k2

--- a/src/k2/cpo/service/HealthMonitor.h
+++ b/src/k2/cpo/service/HealthMonitor.h
@@ -37,18 +37,6 @@ Copyright(c) 2021 Futurewei Cloud
 
 namespace k2::cpo {
 
-// Represents the target of a heartbeat request, which can be anything that responds to a
-// Chogori platform RPC request. The data here is informational only and is does not affect the
-// heartbeat monitor operation but can be used by other CPO components or for logging purposes
-class RPCServer {
-public:
-    String ID;
-    String role;
-    String roleMetadata;
-    std::vector<String> endpoints;
-    K2_DEF_FMT(RPCServer, ID, role, roleMetadata, endpoints);
-};
-
 // The data needed for a single target (one-to-one with an RPCServer above) for the heartbeat monitor to
 // operate on
 class HeartbeatControl {
@@ -95,6 +83,12 @@ private:
     const String _tsoRole{"TSO"};
     const String _persistRole{"Persistence"};
 
+    // Endpoints for cluter components, initialized from the command line parameters and updated
+    // with
+    std::vector<String> _nodepoolCurrentEndpoints;
+    std::vector<String> _tsoCurrentEndpoints;
+    std::vector<String> _persistEndpoints;
+
     void _addHBControl(RPCServer&& server, TimePoint nextHB);
     void _checkHBs();
 
@@ -102,6 +96,10 @@ public:
     // required for seastar::distributed interface
     seastar::future<> gracefulStop();
     seastar::future<> start();
+
+    std::vector<String> getNodepoolEndpoints();
+    std::vector<String> getTSOEndpoints();
+    std::vector<String> getPersistEndpoints();
 };  // class HealthMonitor
 
 } // namespace k2

--- a/src/k2/cpo/service/HealthMonitor.h
+++ b/src/k2/cpo/service/HealthMonitor.h
@@ -28,14 +28,27 @@ Copyright(c) 2021 Futurewei Cloud
 #include <seastar/core/future.hh>  // for future stuff
 
 #include <k2/appbase/AppEssentials.h>
-#include <k2/cpo/service/Service.h>
 #include <k2/dto/ControlPlaneOracle.h>
 #include <k2/dto/LogStream.h>
 #include <k2/transport/Prometheus.h>
 #include <k2/transport/Status.h>
 #include <k2/common/Timer.h>
 
+#include "Log.h"
+
 namespace k2::cpo {
+
+// Represents the target of a heartbeat request, which can be anything that responds to a
+// Chogori platform RPC request. The data here is informational only and is does not affect the
+// heartbeat monitor operation but can be used by other CPO components or for logging purposes
+class RPCServer {
+public:
+    String ID;
+    String role;
+    String roleMetadata;
+    std::vector<String> endpoints;
+    K2_DEF_FMT(RPCServer, ID, role, roleMetadata, endpoints);
+};
 
 // The data needed for a single target (one-to-one with an RPCServer above) for the heartbeat monitor to
 // operate on
@@ -82,12 +95,6 @@ private:
     const String _nodepoolRole{"Nodepool"};
     const String _tsoRole{"TSO"};
     const String _persistRole{"Persistence"};
-
-    // Endpoints for cluter components, initialized from the command line parameters and updated
-    // with
-    std::vector<String> _nodepoolCurrentEndpoints;
-    std::vector<String> _tsoCurrentEndpoints;
-    std::vector<String> _persistEndpoints;
 
     void _addHBControl(RPCServer&& server, TimePoint nextHB);
     void _checkHBs();

--- a/src/k2/cpo/service/Log.h
+++ b/src/k2/cpo/service/Log.h
@@ -1,0 +1,7 @@
+#pragma once
+
+namespace k2::cpo {
+namespace log {
+inline thread_local k2::logging::Logger cposvr("k2::cpo_service");
+}
+}

--- a/src/k2/cpo/service/Service.cpp
+++ b/src/k2/cpo/service/Service.cpp
@@ -117,6 +117,26 @@ seastar::future<> CPOService::start() {
         return AppBase().getDist<CPOService>().invoke_on(0, &CPOService::handleMetadataGet, std::move(request));
     });
 
+    RPC().registerRPCObserver<dto::GetTSOEndpointsRequest, dto::GetTSOEndpointsResponse>(dto::Verbs::CPO_GET_TSO_ENDPOINTS, [this] (dto::GetTSOEndpointsRequest&& request) {
+        (void) request;
+        return AppBase().getDist<HealthMonitor>().invoke_on(_heartbeatMonitorShardId(),
+                                &HealthMonitor::getTSOEndpoints)
+        .then([this] (std::vector<String>&& eps) {
+            return RPCResponse(Statuses::S200_OK("GetTSOEndpoints success"),
+                               dto::GetTSOEndpointsResponse{std::move(eps)});
+        });
+    });
+
+    RPC().registerRPCObserver<dto::GetPersistenceEndpointsRequest, dto::GetPersistenceEndpointsResponse>(dto::Verbs::CPO_GET_PERSISTENCE_ENDPOINTS, [this] (dto::GetPersistenceEndpointsRequest&& request) {
+        (void) request;
+        return AppBase().getDist<HealthMonitor>().invoke_on(_heartbeatMonitorShardId(),
+                                &HealthMonitor::getPersistEndpoints)
+        .then([this] (std::vector<String>&& eps) {
+            return RPCResponse(Statuses::S200_OK("GetPersistenceEndpoints success"),
+                               dto::GetPersistenceEndpointsResponse{std::move(eps)});
+        });
+    });
+
     api_server.registerAPIObserver<dto::GetSchemasRequest, dto::GetSchemasResponse>("GetSchemas", "CPO get all schemas for a collection",
     [this] (dto::GetSchemasRequest&& request) {
         return AppBase().getDist<CPOService>().invoke_on(0, &CPOService::handleSchemasGet, std::move(request));
@@ -132,13 +152,35 @@ seastar::future<> CPOService::start() {
     return seastar::make_ready_future<>();
 }
 
-int makeRangePartitionMap(dto::Collection& collection, const std::vector<String>& eps, const std::vector<String>& rangeEnds) {
+seastar::future<> CPOService::_getNodes() {
+    return AppBase().getDist<HealthMonitor>().invoke_on(_heartbeatMonitorShardId(), &HealthMonitor::getNodepoolEndpoints)
+    .then([this] (std::vector<String>&& nodes) {
+        for (const String& node : nodes) {
+            if (_nodesToCollection.find(node) == _nodesToCollection.end()) {
+                _nodesToCollection[node] = NodeAssignmentEntry{.collection = "", .assigned = false};
+            }
+        }
+
+        return seastar::make_ready_future<>();
+    });
+}
+
+String CPOService::_assignToFreeNode(String collection) {
+    auto it = _nodesToCollection.begin();
+    for (; it != _nodesToCollection.end(); ++it) {
+        if (!(it->second.assigned)) {
+            it->second.assigned = true;
+            it->second.collection = collection;
+            return it->first;
+        }
+    }
+
+    return "";
+}
+
+int CPOService::_makeRangePartitionMap(dto::Collection& collection, const std::vector<String>& rangeEnds) {
     String lastEnd = "";
 
-    if (rangeEnds.size() != eps.size()) {
-        K2LOG_W(log::cposvr, "Error in client's make collection request: collection endpoints size does not equal rangeEnds size");
-        return -1;
-    }
     // The partition for a key is found using lower_bound on the start keys,
     // so it is OK for the last range end key to be ""
     if (rangeEnds[rangeEnds.size()-1] != "") {
@@ -146,7 +188,13 @@ int makeRangePartitionMap(dto::Collection& collection, const std::vector<String>
         return -1;
     }
 
-    for (uint64_t i = 0; i < eps.size(); ++i) {
+    for (uint64_t i = 0; i < rangeEnds.size(); ++i) {
+        String node = _assignToFreeNode(collection.metadata.name);
+        if (node == "") {
+            K2LOG_W(log::cposvr, "No free nodes for assignment");
+            return -1;
+        }
+
         dto::Partition part {
             .keyRangeV{
                 .startKey=lastEnd,
@@ -157,7 +205,7 @@ int makeRangePartitionMap(dto::Collection& collection, const std::vector<String>
                     .assignmentVersion=1
                 },
             },
-            .endpoints={eps[i]},
+            .endpoints={node},
             .astate=dto::AssignmentState::PendingAssignment
         };
 
@@ -169,13 +217,18 @@ int makeRangePartitionMap(dto::Collection& collection, const std::vector<String>
     return 0;
 }
 
-void makeHashPartitionMap(dto::Collection& collection, const std::vector<String>& eps) {
+int CPOService::_makeHashPartitionMap(dto::Collection& collection, uint32_t numNodes) {
     const uint64_t max = std::numeric_limits<uint64_t>::max();
 
-    uint64_t partSize = (eps.size() > 0) ? (max / eps.size()) : (max);
-    for (uint64_t i =0; i < eps.size(); ++i) {
+    uint64_t partSize = (numNodes > 0) ? (max / numNodes) : (max);
+    for (uint64_t i =0; i < numNodes; ++i) {
         uint64_t start = i*partSize;
-        uint64_t end = (i == eps.size() -1) ? (max) : ((i+1)*partSize - 1);
+        uint64_t end = (i == numNodes -1) ? (max) : ((i+1)*partSize - 1);
+        String node = _assignToFreeNode(collection.metadata.name);
+        if (node == "") {
+            K2LOG_W(log::cposvr, "No free nodes for assignment");
+            return -1;
+        }
 
         dto::Partition part{
             .keyRangeV{
@@ -187,52 +240,56 @@ void makeHashPartitionMap(dto::Collection& collection, const std::vector<String>
                     .assignmentVersion=1
                 },
             },
-            .endpoints={eps[i]},
+            .endpoints={node},
             .astate=dto::AssignmentState::PendingAssignment
         };
         collection.partitionMap.partitions.push_back(std::move(part));
     }
 
     collection.partitionMap.version++;
+
+    return 0;
 }
 
 seastar::future<std::tuple<Status, dto::CollectionCreateResponse>>
 CPOService::handleCreate(dto::CollectionCreateRequest&& request) {
-    K2LOG_I(log::cposvr, "Received collection create request for name={}", request.metadata.name);
-    auto cpath = _getCollectionPath(request.metadata.name);
-    if (fileutil::fileExists(cpath)) {
-        return RPCResponse(Statuses::S403_Forbidden("collection already exists"), dto::CollectionCreateResponse());
-    }
-    request.metadata.heartbeatDeadline = _collectionHeartbeatDeadline();
-    // create a collection from the incoming request
-    dto::Collection collection;
-    collection.metadata = request.metadata;
+    return _getNodes().then([this, request=std::move(request)] () mutable {
+        K2LOG_I(log::cposvr, "Received collection create request for name={}", request.metadata.name);
+        auto cpath = _getCollectionPath(request.metadata.name);
+        if (fileutil::fileExists(cpath)) {
+            return RPCResponse(Statuses::S403_Forbidden("collection already exists"), dto::CollectionCreateResponse());
+        }
+        request.metadata.heartbeatDeadline = _collectionHeartbeatDeadline();
+        // create a collection from the incoming request
+        dto::Collection collection;
+        collection.metadata = request.metadata;
 
-    int err = 0;
-    if (collection.metadata.hashScheme == dto::HashScheme::HashCRC32C) {
-        makeHashPartitionMap(collection, request.clusterEndpoints);
-    }
-    else if (collection.metadata.hashScheme == dto::HashScheme::Range) {
-        err = makeRangePartitionMap(collection, request.clusterEndpoints, request.rangeEnds);
-    }
-    else {
-        return RPCResponse(Statuses::S403_Forbidden("Unknown hashScheme"), dto::CollectionCreateResponse());
-    }
+        int err = 0;
+        if (collection.metadata.hashScheme == dto::HashScheme::HashCRC32C) {
+            err = _makeHashPartitionMap(collection, request.metadata.capacity.minNodes);
+        }
+        else if (collection.metadata.hashScheme == dto::HashScheme::Range) {
+            err = _makeRangePartitionMap(collection, request.rangeEnds);
+        }
+        else {
+            return RPCResponse(Statuses::S403_Forbidden("Unknown hashScheme"), dto::CollectionCreateResponse());
+        }
 
-    if (err) {
-        return RPCResponse(Statuses::S400_Bad_Request("Bad rangeEnds"), dto::CollectionCreateResponse());
-    }
+        if (err) {
+            return RPCResponse(Statuses::S403_Forbidden("Could not find free nodes"), dto::CollectionCreateResponse());
+        }
 
-    schemas[collection.metadata.name] = std::vector<dto::Schema>();
+        schemas[collection.metadata.name] = std::vector<dto::Schema>();
 
-    auto status = _saveCollection(collection);
-    if (!status.is2xxOK()) {
+        auto status = _saveCollection(collection);
+        if (!status.is2xxOK()) {
+            return RPCResponse(std::move(status), dto::CollectionCreateResponse());
+        }
+
+        K2LOG_I(log::cposvr, "Created collection {}", cpath);
+        _assignCollection(collection);
         return RPCResponse(std::move(status), dto::CollectionCreateResponse());
-    }
-
-    K2LOG_I(log::cposvr, "Created collection {}", cpath);
-    _assignCollection(collection);
-    return RPCResponse(std::move(status), dto::CollectionCreateResponse());
+    });
 }
 
 seastar::future<std::tuple<Status, dto::CollectionGetResponse>>

--- a/src/k2/cpo/service/Service.h
+++ b/src/k2/cpo/service/Service.h
@@ -43,7 +43,7 @@ namespace k2::cpo {
 class NodeAssignmentEntry {
 public:
     String collection;
-    bool assigned;
+    bool assigned{false};
 };
 
 class CPOService {

--- a/src/k2/cpo/service/Service.h
+++ b/src/k2/cpo/service/Service.h
@@ -34,10 +34,18 @@ Copyright(c) 2020 Futurewei Cloud
 #include <k2/dto/LogStream.h>
 #include <k2/transport/Status.h>
 
+#include "Log.h"
+#include "HealthMonitor.h"
+
 namespace k2::cpo {
-namespace log {
-inline thread_local k2::logging::Logger cposvr("k2::cpo_service");
-}
+
+// Used by the CPOService class to track mapping of nodes to assigned collections
+class NodeAssignmentEntry {
+public:
+    String collection;
+    bool assigned;
+};
+
 class CPOService {
 private:
     ConfigVar<String> _dataDir{"data_dir"};
@@ -51,12 +59,17 @@ private:
     ConfigDuration _collectionHeartbeatDeadline{"txn_heartbeat_deadline", 100ms};
     std::unordered_map<String, seastar::future<>> _assignments;
     std::unordered_map<String, std::vector<dto::PartitionMetdataRecord>> _metadataRecords;
+    std::map<String, NodeAssignmentEntry> _nodesToCollection;
     std::tuple<Status, dto::Collection> _getCollection(String name);
     Status _saveCollection(dto::Collection& collection);
     Status _saveSchemas(const String& collectionName);
     Status _loadSchemas(const String& collectionName);
     seastar::future<Status> _pushSchema(const dto::Collection& collection, const dto::Schema& schema);
     void _handleCompletedAssignment(const String& cname, dto::AssignmentCreateResponse&& request);
+    seastar::future<> _getNodes(); // Get list of nodes from health monitor
+    String _assignToFreeNode(String collection);
+    int _makeHashPartitionMap(dto::Collection& collection, uint32_t numNodes);
+    int _makeRangePartitionMap(dto::Collection& collection, const std::vector<String>& rangeEnds);
 
     // Collection name -> schemas
     std::unordered_map<String, std::vector<dto::Schema>> schemas;

--- a/src/k2/dto/AssignmentManager.h
+++ b/src/k2/dto/AssignmentManager.h
@@ -33,8 +33,8 @@ namespace dto {
 struct AssignmentCreateRequest {
     CollectionMetadata collectionMeta;
     Partition partition;
-    std::vector<String> cpoEndpoints
-    K2_PAYLOAD_FIELDS(collectionMeta, partition, cpoEndpoints);
+    String cpoEndpoint;
+    K2_PAYLOAD_FIELDS(collectionMeta, partition, cpoEndpoint);
 };
 
 // Response to AssignmentCreateRequest

--- a/src/k2/dto/AssignmentManager.h
+++ b/src/k2/dto/AssignmentManager.h
@@ -33,7 +33,8 @@ namespace dto {
 struct AssignmentCreateRequest {
     CollectionMetadata collectionMeta;
     Partition partition;
-    K2_PAYLOAD_FIELDS(collectionMeta, partition);
+    std::vector<String> cpoEndpoints
+    K2_PAYLOAD_FIELDS(collectionMeta, partition, cpoEndpoints);
 };
 
 // Response to AssignmentCreateRequest

--- a/src/k2/dto/AssignmentManager.h
+++ b/src/k2/dto/AssignmentManager.h
@@ -33,8 +33,8 @@ namespace dto {
 struct AssignmentCreateRequest {
     CollectionMetadata collectionMeta;
     Partition partition;
-    String cpoEndpoint;
-    K2_PAYLOAD_FIELDS(collectionMeta, partition, cpoEndpoint);
+    std::vector<String> cpoEndpoints;
+    K2_PAYLOAD_FIELDS(collectionMeta, partition, cpoEndpoints);
 };
 
 // Response to AssignmentCreateRequest

--- a/src/k2/dto/Collection.h
+++ b/src/k2/dto/Collection.h
@@ -149,8 +149,9 @@ struct CollectionCapacity {
     uint64_t dataCapacityMegaBytes = 0;
     uint64_t readIOPs = 0;
     uint64_t writeIOPs = 0;
-    K2_PAYLOAD_FIELDS(dataCapacityMegaBytes, readIOPs, writeIOPs);
-    K2_DEF_FMT(CollectionCapacity, dataCapacityMegaBytes, readIOPs, writeIOPs);
+    uint32_t minNodes = 0;
+    K2_PAYLOAD_FIELDS(dataCapacityMegaBytes, readIOPs, writeIOPs, minNodes);
+    K2_DEF_FMT(CollectionCapacity, dataCapacityMegaBytes, readIOPs, writeIOPs, minNodes);
 };
 
 K2_DEF_ENUM(HashScheme,

--- a/src/k2/dto/ControlPlaneOracle.h
+++ b/src/k2/dto/ControlPlaneOracle.h
@@ -124,22 +124,6 @@ struct Schema {
     K2_DEF_FMT(Schema, name, version, fields, partitionKeyFields, rangeKeyFields);
 };
 
-// Represents anything that responds to a Chogori platform RPC request.
-// The data originates from the CPO HealthMonitor which is passed RPCServer IDs and roles on the
-// command line, and roleMetadata and endpoints are returned in heartbeat responses.
-//
-// The CPO also uses this to return the endpoints for specific components when requested (e.g.
-// GetTSOServersRequest below)
-class RPCServer {
-public:
-    String ID;
-    String role;
-    String roleMetadata;
-    std::vector<String> endpoints;
-    K2_PAYLOAD_FIELDS(ID, role, roleMetadata, endpoints);
-    K2_DEF_FMT(RPCServer, ID, role, roleMetadata, endpoints);
-};
-
 // Request to create a schema and attach it to a collection
 // If schemaName already exists, it creates a new version
 struct CreateSchemaRequest {
@@ -166,6 +150,26 @@ struct GetSchemasResponse {
     std::vector<Schema> schemas;
     K2_PAYLOAD_FIELDS(schemas);
     K2_DEF_FMT(GetSchemasResponse, schemas);
+};
+
+struct GetTSOEndpointsRequest {
+    K2_PAYLOAD_EMPTY;
+    K2_DEF_FMT(GetTSOEndpointsRequest);
+};
+
+struct GetTSOEndpointsResponse {
+    std::vector<String> endpoints;
+    K2_DEF_FMT(GetTSOEndpointsResponse, endpoints);
+};
+
+struct GetPersistenceEndpointsRequest {
+    K2_PAYLOAD_EMPTY;
+    K2_DEF_FMT(GetPersistenceEndpointsRequest);
+};
+
+struct GetPersistenceEndpointsResponse {
+    std::vector<String> endpoints;
+    K2_DEF_FMT(GetPersistenceEndpointsResponse, endpoints);
 };
 
 struct HeartbeatRequest {

--- a/src/k2/dto/ControlPlaneOracle.h
+++ b/src/k2/dto/ControlPlaneOracle.h
@@ -45,14 +45,12 @@ struct CPOClientException : public std::exception {
 struct CollectionCreateRequest {
     // The metadata which describes the collection K2 should create
     CollectionMetadata metadata;
-    // the endpoints of the k2 cluster to use for setting up this collection
-    std::vector<String> clusterEndpoints;
     // Only relevant for range partitioned collections. Contains the key range
     // endpoints for each partition.
     std::vector<String> rangeEnds;
 
-    K2_PAYLOAD_FIELDS(metadata, clusterEndpoints, rangeEnds);
-    K2_DEF_FMT(CollectionCreateRequest, metadata, clusterEndpoints, rangeEnds);
+    K2_PAYLOAD_FIELDS(metadata, rangeEnds);
+    K2_DEF_FMT(CollectionCreateRequest, metadata, rangeEnds);
 };
 
 // Response to CollectionCreateRequest
@@ -124,6 +122,22 @@ struct Schema {
     K2_PAYLOAD_FIELDS(name, version, fields, partitionKeyFields, rangeKeyFields);
 
     K2_DEF_FMT(Schema, name, version, fields, partitionKeyFields, rangeKeyFields);
+};
+
+// Represents anything that responds to a Chogori platform RPC request.
+// The data originates from the CPO HealthMonitor which is passed RPCServer IDs and roles on the
+// command line, and roleMetadata and endpoints are returned in heartbeat responses.
+//
+// The CPO also uses this to return the endpoints for specific components when requested (e.g.
+// GetTSOServersRequest below)
+class RPCServer {
+public:
+    String ID;
+    String role;
+    String roleMetadata;
+    std::vector<String> endpoints;
+    K2_PAYLOAD_FIELDS(ID, role, roleMetadata, endpoints);
+    K2_DEF_FMT(RPCServer, ID, role, roleMetadata, endpoints);
 };
 
 // Request to create a schema and attach it to a collection

--- a/src/k2/dto/ControlPlaneOracle.h
+++ b/src/k2/dto/ControlPlaneOracle.h
@@ -159,6 +159,7 @@ struct GetTSOEndpointsRequest {
 
 struct GetTSOEndpointsResponse {
     std::vector<String> endpoints;
+    K2_PAYLOAD_FIELDS(endpoints);
     K2_DEF_FMT(GetTSOEndpointsResponse, endpoints);
 };
 
@@ -169,6 +170,7 @@ struct GetPersistenceEndpointsRequest {
 
 struct GetPersistenceEndpointsResponse {
     std::vector<String> endpoints;
+    K2_PAYLOAD_FIELDS(endpoints);
     K2_DEF_FMT(GetPersistenceEndpointsResponse, endpoints);
 };
 

--- a/src/k2/dto/MessageVerbs.h
+++ b/src/k2/dto/MessageVerbs.h
@@ -46,6 +46,8 @@ enum Verbs : k2::Verb {
     CPO_COLLECTION_DROP,
 
     CPO_HEARTBEAT,
+    CPO_GET_TSO_ENDPOINTS,
+    CPO_GET_PERSISTENCE_ENDPOINTS,
 
     /************ Assignment *****************/
     // K2Assignment: CPO asks K2 to assign a partition

--- a/src/k2/module/k23si/Config.h
+++ b/src/k2/module/k23si/Config.h
@@ -64,6 +64,8 @@ struct K23SIConfig {
     // Default is > paginiationLimit so it will always push
     ConfigVar<uint32_t> queryPushLimit{"k23si_query_push_limit", 11};
 
+    // the endpoint for our persistence
+    ConfigVar<std::vector<String>> persistenceEndpoint{"k23si_persistence_endpoints"};
     ConfigDuration persistenceTimeout{"k23si_persistence_timeout", 10s};
     ConfigDuration persistenceAutoflushDeadline{"k23si_autoflush_deadline", 1s};
 

--- a/src/k2/module/k23si/Config.h
+++ b/src/k2/module/k23si/Config.h
@@ -64,13 +64,8 @@ struct K23SIConfig {
     // Default is > paginiationLimit so it will always push
     ConfigVar<uint32_t> queryPushLimit{"k23si_query_push_limit", 11};
 
-    // the endpoint for our persistence
-    ConfigVar<std::vector<String>> persistenceEndpoint{"k23si_persistence_endpoints"};
     ConfigDuration persistenceTimeout{"k23si_persistence_timeout", 10s};
     ConfigDuration persistenceAutoflushDeadline{"k23si_autoflush_deadline", 1s};
-
-    // the endpoint for the CPO
-    ConfigVar<String> cpoEndpoint{"k23si_cpo_endpoint", "tcp+k2rpc://127.0.0.1:12345"};
 
     // maximum push count for a key during handleRead() and handWrite()
     ConfigVar<uint32_t> maxPushCount{"k23si_max_push_count", 1};

--- a/src/k2/module/k23si/Module.h
+++ b/src/k2/module/k23si/Module.h
@@ -83,7 +83,7 @@ typedef IndexerT::iterator IndexerIterator;
 
 class K23SIPartitionModule {
 public: // lifecycle
-    K23SIPartitionModule(dto::CollectionMetadata cmeta, dto::Partition partition);
+    K23SIPartitionModule(dto::CollectionMetadata cmeta, dto::Partition partition, String cpoEndpoint);
     ~K23SIPartitionModule();
 
     seastar::future<> start();
@@ -289,6 +289,7 @@ private:  // members
     std::shared_ptr<Persistence> _persistence;
 
     cpo::CPOClient _cpo;
+    String _cpoEndpoint; // Obtained from the CPO assignment request
 
     sm::metric_groups _metricGroups;
 

--- a/src/k2/module/k23si/TxnManager.cpp
+++ b/src/k2/module/k23si/TxnManager.cpp
@@ -76,12 +76,12 @@ void TxnManager::_registerMetrics() {
     });
 }
 
-seastar::future<> TxnManager::start(const String& collectionName, dto::Timestamp rts, Duration hbDeadline, std::shared_ptr<Persistence> persistence) {
+seastar::future<> TxnManager::start(const String& collectionName, dto::Timestamp rts, Duration hbDeadline, std::shared_ptr<Persistence> persistence, const String& cpoEndpoint) {
     K2LOG_D(log::skvsvr, "start");
-    _cpo.init(_config.cpoEndpoint());
+    _cpo.init(cpoEndpoint);
     _collectionName = collectionName;
     _hbDeadline = hbDeadline;
-    _persistence= persistence;
+    _persistence = persistence;
     updateRetentionTimestamp(rts);
     // We need to call this now so that a recent time is used for a new
     // transaction's heartbeat expiry if it comes in before the first heartbeat timer callback

--- a/src/k2/module/k23si/TxnManager.h
+++ b/src/k2/module/k23si/TxnManager.h
@@ -120,7 +120,7 @@ public: // lifecycle
     // When started, we need to be told:
     // - the current retentionTimestamp
     // - the heartbeat interval for the collection
-    seastar::future<> start(const String& collectionName, dto::Timestamp rts, Duration hbDeadline, std::shared_ptr<Persistence> persistence);
+    seastar::future<> start(const String& collectionName, dto::Timestamp rts, Duration hbDeadline, std::shared_ptr<Persistence> persistence, const String& cpoEndpoint);
 
     // called when
     seastar::future<> gracefulStop();

--- a/src/k2/module/k23si/TxnWIMetaManager.cpp
+++ b/src/k2/module/k23si/TxnWIMetaManager.cpp
@@ -73,9 +73,9 @@ TxnWIMeta* TxnWIMetaManager::getTxnWIMeta(dto::Timestamp ts) {
     return nullptr;
 }
 
-seastar::future<> TxnWIMetaManager::start(dto::Timestamp rts, std::shared_ptr<Persistence> persistence) {
+seastar::future<> TxnWIMetaManager::start(dto::Timestamp rts, std::shared_ptr<Persistence> persistence, const String& cpoEndpoint) {
     K2LOG_D(log::skvsvr, "starting");
-    _cpo.init(_config.cpoEndpoint());
+    _cpo.init(cpoEndpoint);
     _persistence = persistence;
     updateRetentionTimestamp(rts);
 

--- a/src/k2/module/k23si/TxnWIMetaManager.h
+++ b/src/k2/module/k23si/TxnWIMetaManager.h
@@ -71,7 +71,7 @@ public:
     // When started, we need to be told:
     // - the current retentionTimestamp
     // - the heartbeat interval for the collection
-    seastar::future<> start(dto::Timestamp rts, std::shared_ptr<Persistence> persistence);
+    seastar::future<> start(dto::Timestamp rts, std::shared_ptr<Persistence> persistence, const String& cpoEndpoint);
     seastar::future<> gracefulStop();
 
     // Update the stored retention window timestamp.

--- a/src/k2/module/k23si/client/k23si_client.cpp
+++ b/src/k2/module/k23si/client/k23si_client.cpp
@@ -305,9 +305,6 @@ K23SIClient::K23SIClient(const K23SIClientConfig &) :
 }
 
 seastar::future<> K23SIClient::start() {
-    for (auto it = _tcpRemotes().begin(); it != _tcpRemotes().end(); ++it) {
-        _k2endpoints.push_back(String(*it));
-    }
     K2LOG_I(log::skvclient, "_cpo={}", _cpo());
     cpo_client.init(_cpo());
 

--- a/src/k2/module/k23si/client/k23si_client.cpp
+++ b/src/k2/module/k23si/client/k23si_client.cpp
@@ -318,23 +318,8 @@ seastar::future<> K23SIClient::gracefulStop() {
     return seastar::make_ready_future<>();
 }
 
-seastar::future<Status> K23SIClient::makeCollection(const String& collection, std::vector<String>&& rangeEnds) {
-    std::vector<String> endpoints = _k2endpoints;
-    dto::HashScheme scheme = rangeEnds.size() ? dto::HashScheme::Range : dto::HashScheme::HashCRC32C;
-
-    dto::CollectionMetadata metadata{
-        .name = collection,
-        .hashScheme = scheme,
-        .storageDriver = dto::StorageDriver::K23SI,
-        .capacity = {},
-        .retentionPeriod = Duration(retention_window())
-    };
-
-    return makeCollection(std::move(metadata), std::move(endpoints), std::move(rangeEnds));
-}
-
-seastar::future<Status> K23SIClient::makeCollection(dto::CollectionMetadata&& metadata, std::vector<String>&& endpoints, std::vector<String>&& rangeEnds) {
-    return cpo_client.createAndWaitForCollection(Deadline<>(create_collection_deadline()), std::move(metadata), std::move(endpoints), std::move(rangeEnds));
+seastar::future<Status> K23SIClient::makeCollection(dto::CollectionMetadata&& metadata, std::vector<String>&& rangeEnds) {
+    return cpo_client.createAndWaitForCollection(Deadline<>(create_collection_deadline()), std::move(metadata), std::move(rangeEnds));
 }
 
 seastar::future<K2TxnHandle> K23SIClient::beginTxn(const K2TxnOptions& options) {

--- a/src/k2/module/k23si/client/k23si_client.h
+++ b/src/k2/module/k23si/client/k23si_client.h
@@ -164,7 +164,6 @@ private:
     seastar::future<std::tuple<Status, std::shared_ptr<dto::Schema>>> getSchemaInternal(const String& collectionName, const String& schemaName, int64_t schemaVersion, bool doCPORefresh = true);
 
     sm::metric_groups _metric_groups;
-    std::vector<String> _k2endpoints;
 };
 
 

--- a/src/k2/module/k23si/client/k23si_client.h
+++ b/src/k2/module/k23si/client/k23si_client.h
@@ -134,17 +134,13 @@ public:
 
     seastar::future<> start();
     seastar::future<> gracefulStop();
-    // First version of makeCollection is deprecated, do not use.
-    // TODO: remove first version of makeCollection and update the test code.
-    seastar::future<Status> makeCollection(const String& collection, std::vector<String>&& rangeEnds=std::vector<String>());
-    seastar::future<Status> makeCollection(dto::CollectionMetadata&& metadata, std::vector<String>&& endpoints, std::vector<String>&& rangeEnds=std::vector<String>());
+    seastar::future<Status> makeCollection(dto::CollectionMetadata&& metadata,  std::vector<String>&& rangeEnds=std::vector<String>());
     seastar::future<K2TxnHandle> beginTxn(const K2TxnOptions& options);
     static constexpr int64_t ANY_VERSION = -1;
     seastar::future<GetSchemaResult> getSchema(const String& collectionName, const String& schemaName, int64_t schemaVersion);
     seastar::future<CreateSchemaResult> createSchema(const String& collectionName, dto::Schema schema);
     seastar::future<CreateQueryResult> createQuery(const String& collectionName, const String& schemaName);
 
-    ConfigVar<std::vector<String>> _tcpRemotes{"tcp_remotes"};
     ConfigVar<String> _cpo{"cpo"};
     ConfigDuration create_collection_deadline{"create_collection_deadline", 1s};
     ConfigDuration retention_window{"retention_window", 600s};

--- a/src/k2/transport/Discovery.h
+++ b/src/k2/transport/Discovery.h
@@ -71,6 +71,24 @@ public :  // application lifespan
         // no match
         return nullptr;
     }
+
+    template<typename StringContainer>
+    static String selectBestEndpointString(const StringContainer& urls) {
+        bool rdma = seastar::engine()._rdma_stack != nullptr;
+        String selectedEP = "";
+
+        for (const String& ep : urls) {
+            if (ep.find(RRDMARPCProtocol::proto) != String::npos && rdma) {
+                selectedEP = ep;
+            }
+            else if (ep.find(TCPRPCProtocol::proto) != String::npos && !rdma) {
+                selectedEP = ep;
+            }
+        }
+
+        return selectedEP;
+    }
+
     // required for seastar::distributed interface
     seastar::future<> gracefulStop();
     seastar::future<> start();

--- a/src/k2/tso/client/Client.cpp
+++ b/src/k2/tso/client/Client.cpp
@@ -27,6 +27,7 @@ Copyright(c) 2020 Futurewei Cloud
 
 #include <seastar/core/sleep.hh>
 
+#include <k2/dto/ControlPlaneOracle.h>
 #include <k2/transport/RPCDispatcher.h>  // for RPC
 #include <k2/transport/RetryStrategy.h>
 
@@ -60,17 +61,29 @@ seastar::future<> TSOClient::start() {
 
 seastar::future<> TSOClient::bootstrap(const String& cpoEndpoint) {
     K2LOG_I(log::tsoclient, "start bootstrap with CPO server url: {}", cpoEndpoint);
+    auto cpoEP = RPC().getTXEndpoint(cpoEndpoint);
+    if (!cpoEP) {
+        K2LOG_E(log::tsoclient, "CPO endpoint is invalid: {}", cpoEndpoint);
+        return seastar::make_exception_future<>(std::runtime_error("Could not bootstrap TSO client"));
+    }
+
+    dto::GetTSOEndpointsRequest request{};
     _stopped = false;
-
     _registerMetrics();
-    return RPC().callRPC<dto::CollectionCreateRequest, dto::CollectionCreateResponse>
-            (dto::Verbs::CPO_GET_TSO_ENDPOINTS, request, *_cpoEndpoint, 1s)
-    .then([](auto&& response) {
-        // response for collection create
-        auto& [status, resp] = response;
 
-    _tsoServerEndpoint = RPC().getTXEndpoint(_bootstrapTSOServerURL());
-    return _discoverServiceNodes();
+    return RPC().callRPC<dto::GetTSOEndpointsRequest, dto::GetTSOEndpointsResponse>
+            (dto::Verbs::CPO_GET_TSO_ENDPOINTS, request, *cpoEP, 1s)
+    .then([this](auto&& response) {
+        auto& [status, resp] = response;
+        if (!status.is2xxOK() || resp.endpoints.size() == 0) {
+            K2LOG_E(log::tsoclient, "Get TSO endpoints failed with status {} and endpoint size {}",
+                        status, resp.endpoints.size());
+            return seastar::make_exception_future<>(std::runtime_error("Could not bootstrap TSO client"));
+        }
+
+        _tsoServerEndpoint = RPC().getTXEndpoint(resp.endpoints[0]);
+        return _discoverServiceNodes();
+    });
 }
 
 seastar::future<> TSOClient::gracefulStop() {
@@ -152,7 +165,7 @@ seastar::future<> TSOClient::_discoverServiceNodes() {
                 return seastar::make_exception_future<>(StopRetryException{});
             }
             if (!_tsoServerEndpoint) {
-                K2LOG_E(log::tsoclient, "Invalid TSO server endpoint: {}", _bootstrapTSOServerURL());
+                K2LOG_E(log::tsoclient, "Invalid TSO server endpoint");
                 return seastar::make_exception_future(StopRetryException{});
             }
             K2LOG_I(log::tsoclient, "Sending with retriesLeft={}, and timeout={}ms, with {}", retriesLeft, timeout, *_tsoServerEndpoint);

--- a/src/k2/tso/client/Client.h
+++ b/src/k2/tso/client/Client.h
@@ -72,7 +72,7 @@ private: // methods
     seastar::future<dto::Timestamp> _getTimestampWithLatency(OperationLatencyReporter&& reporter);
 
 private: // fields
-    ConfigVar<String> _bootstrapTSOServerURL{"tso_endpoint"};
+    ConfigVar<String> _cpoEndpoint{"cpo_endpoint", ""};
 
     // to tell if we've been signaled to stop
     bool _stopped{true};

--- a/src/k2/tso/client/Client.h
+++ b/src/k2/tso/client/Client.h
@@ -45,6 +45,7 @@ class TSOClient {
 public:
     seastar::future<> start();
     seastar::future<> gracefulStop();
+    seastar::future<> bootstrap(const String& cpoEndpoint);
 
     // get a K2 timestamp
     seastar::future<dto::Timestamp> getTimestamp();
@@ -72,7 +73,7 @@ private: // methods
     seastar::future<dto::Timestamp> _getTimestampWithLatency(OperationLatencyReporter&& reporter);
 
 private: // fields
-    ConfigVar<String> _cpoEndpoint{"cpo_endpoint", ""};
+    ConfigVar<String> _cpoEndpoint{"cpo", ""};
 
     // to tell if we've been signaled to stop
     bool _stopped{true};

--- a/test/cpo/CPOTest.cpp
+++ b/test/cpo/CPOTest.cpp
@@ -106,11 +106,11 @@ seastar::future<> CPOTest::runTest2() {
             .capacity{
                 .dataCapacityMegaBytes=1,
                 .readIOPs=100,
-                .writeIOPs=200
+                .writeIOPs=200,
+                .minNodes=0
             },
             .retentionPeriod = 1h*90*24
         },
-        .clusterEndpoints{},
         .rangeEnds{}
     };
     return RPC()
@@ -131,11 +131,11 @@ seastar::future<> CPOTest::runTest3() {
             .capacity{
                 .dataCapacityMegaBytes = 1000,
                 .readIOPs = 100000,
-                .writeIOPs = 100000
+                .writeIOPs = 100000,
+                .minNodes = 0
             },
             .retentionPeriod = 1h
         },
-        .clusterEndpoints{},
         .rangeEnds{}
     };
 
@@ -177,11 +177,11 @@ seastar::future<> CPOTest::runTest5() {
             .capacity{
                 .dataCapacityMegaBytes = 1000,
                 .readIOPs = 100000,
-                .writeIOPs = 100000
+                .writeIOPs = 100000,
+                .minNodes = 3 // Integration test script is set up for a three core nodepool
             },
             .retentionPeriod = 5h
         },
-        .clusterEndpoints = _k2ConfigEps(),
         .rangeEnds{}
     };
     return RPC()
@@ -215,7 +215,7 @@ seastar::future<> CPOTest::runTest5() {
             K2EXPECT(log::cpotest, resp.collection.partitionMap.partitions.size(), 3);
 
             // how many partitions we have
-            uint64_t numparts = _k2ConfigEps().size();
+            uint64_t numparts = resp.collection.partitionMap.partitions.size();
             auto max = std::numeric_limits<uint64_t>::max();
             // how big is each one
             uint64_t partSize = max / numparts;
@@ -227,8 +227,7 @@ seastar::future<> CPOTest::runTest5() {
                 K2EXPECT(log::cpotest, p.keyRangeV.pvid.assignmentVersion, 1);
                 K2EXPECT(log::cpotest, p.keyRangeV.pvid.id, i);
                 K2EXPECT(log::cpotest, p.keyRangeV.startKey, std::to_string(i * partSize));
-                K2EXPECT(log::cpotest, p.keyRangeV.endKey, std::to_string(i == _k2ConfigEps().size() - 1 ? max : (i + 1) * partSize - 1));
-                K2EXPECT(log::cpotest, *p.endpoints.begin(), _k2ConfigEps()[i]);
+                K2EXPECT(log::cpotest, p.keyRangeV.endKey, std::to_string(i == numparts - 1 ? max : (i + 1) * partSize - 1));
             }
         });
 }

--- a/test/cpo/CPOTest.h
+++ b/test/cpo/CPOTest.h
@@ -51,7 +51,6 @@ public:  // application lifespan
 private:
     int exitcode = -1;
     std::unique_ptr<k2::TXEndpoint> _cpoEndpoint;
-    k2::ConfigVar<std::vector<k2::String>> _k2ConfigEps{"k2_endpoints"};
     seastar::future<> _testFuture = seastar::make_ready_future();
     seastar::timer<> _testTimer;
 };

--- a/test/cpo/Main.cpp
+++ b/test/cpo/Main.cpp
@@ -27,7 +27,6 @@ Copyright(c) 2020 Futurewei Cloud
 int main(int argc, char** argv) {
     k2::App app("CPOTest");
     app.addOptions()("cpo_endpoint", bpo::value<k2::String>(), "The endpoint of the CPO service");
-    app.addOptions()("k2_endpoints", bpo::value<std::vector<k2::String>>()->multitoken(), "The endpoints of the k2 cluster");
     app.addApplet<CPOTest>();
     return app.start(argc, argv);
 }

--- a/test/dto/PartitionTest.cpp
+++ b/test/dto/PartitionTest.cpp
@@ -58,8 +58,19 @@ public:  // application lifespan
             rangeEnds.push_back("c");
             rangeEnds.push_back("e");
             rangeEnds.push_back("");
-
-            return _client.makeCollection(collname, std::move(rangeEnds));
+            k2::dto::CollectionMetadata meta{
+                .name = collname,
+                .hashScheme = dto::HashScheme::Range,
+                .storageDriver = dto::StorageDriver::K23SI,
+                .capacity{
+                    .dataCapacityMegaBytes = 0,
+                    .readIOPs = 0,
+                    .writeIOPs = 0,
+                    .minNodes = 3
+                },
+                .retentionPeriod = 5h
+            };
+            return _client.makeCollection(std::move(meta), std::move(rangeEnds));
         })
         .then([](auto&& status) {
             K2EXPECT(log::ptest, status.is2xxOK(), true);
@@ -181,8 +192,6 @@ seastar::future<> runScenario01() {
 int main(int argc, char** argv) {
     k2::App app("PartitionTest");
     app.addOptions()
-        ("tcp_remotes", bpo::value<std::vector<k2::String>>()->multitoken()->default_value(std::vector<k2::String>()), "A list(space-delimited) of endpoints to assign in the test collection")
-        ("tso_endpoint", bpo::value<k2::String>(), "URL of Timestamp Oracle (TSO), e.g. 'tcp+k2rpc://192.168.1.2:12345'")
         ("cpo", bpo::value<k2::String>(), "URL of Control Plane Oracle (CPO), e.g. 'tcp+k2rpc://192.168.1.2:12345'");
     app.addApplet<k2::tso::TSOClient>();
     app.addApplet<PartitionTest>();

--- a/test/integration/test_3si_txn.sh
+++ b/test/integration/test_3si_txn.sh
@@ -47,4 +47,4 @@ trap finish EXIT
 
 sleep 2
 
-./build/test/k23si/3si_txn_test ${COMMON_ARGS} --cpo_endpoint ${CPO} --prometheus_port 63100
+./build/test/k23si/3si_txn_test ${COMMON_ARGS} --cpo ${CPO} --prometheus_port 63100

--- a/test/integration/test_3si_txn.sh
+++ b/test/integration/test_3si_txn.sh
@@ -5,7 +5,7 @@ source ${topname}/common_defs.sh
 cd ${topname}/../..
 
 # start nodepool
-./build/src/k2/cmd/nodepool/nodepool ${COMMON_ARGS} --log_level INFO k2::skv_server=INFO -c${#EPS[@]} --tcp_endpoints ${EPS[@]} --k23si_persistence_endpoint ${PERSISTENCE} --prometheus_port 63001 --k23si_cpo_endpoint ${CPO} --tso_endpoint ${TSO} --partition_request_timeout=30s &
+./build/src/k2/cmd/nodepool/nodepool ${COMMON_ARGS} --log_level INFO k2::skv_server=INFO -c${#EPS[@]} --tcp_endpoints ${EPS[@]} --k23si_persistence_endpoint ${PERSISTENCE} --prometheus_port 63001 --partition_request_timeout=30s &
 nodepool_child_pid=$!
 
 # start persistence
@@ -47,4 +47,4 @@ trap finish EXIT
 
 sleep 2
 
-./build/test/k23si/3si_txn_test ${COMMON_ARGS} --cpo_endpoint ${CPO} --k2_endpoints ${EPS[@]} --prometheus_port 63100 --tso_endpoint ${TSO}
+./build/test/k23si/3si_txn_test ${COMMON_ARGS} --cpo_endpoint ${CPO} --prometheus_port 63100

--- a/test/integration/test_collection.sh
+++ b/test/integration/test_collection.sh
@@ -5,7 +5,7 @@ source ${topname}/common_defs.sh
 cd ${topname}/../..
 
 # start nodepool
-./build/src/k2/cmd/nodepool/nodepool ${COMMON_ARGS} -c${#EPS[@]} --tcp_endpoints ${EPS[@]} --k23si_persistence_endpoint ${PERSISTENCE} --prometheus_port 63001 --k23si_cpo_endpoint ${CPO} --tso_endpoint ${TSO} &
+./build/src/k2/cmd/nodepool/nodepool ${COMMON_ARGS} -c${#EPS[@]} --tcp_endpoints ${EPS[@]} --k23si_persistence_endpoint ${PERSISTENCE} --prometheus_port 63001 &
 nodepool_child_pid=$!
 
 # start persistence
@@ -45,4 +45,4 @@ trap finish EXIT
 
 sleep 2
 
-./build/test/cpo/cpo_test ${COMMON_ARGS} --cpo_endpoint ${CPO} --k2_endpoints ${EPS[@]} --prometheus_port 63100
+./build/test/cpo/cpo_test ${COMMON_ARGS} --cpo_endpoint ${CPO} --prometheus_port 63100

--- a/test/integration/test_heartbeat_monitor.sh
+++ b/test/integration/test_heartbeat_monitor.sh
@@ -5,7 +5,7 @@ source ${topname}/common_defs.sh
 cd ${topname}/../..
 
 # start nodepool
-./build/src/k2/cmd/nodepool/nodepool ${COMMON_ARGS} --log_level INFO k2::skv_server=INFO -c1 --tcp_endpoints ${EPS[0]} --k23si_persistence_endpoint ${PERSISTENCE} --prometheus_port 63001 --k23si_cpo_endpoint ${CPO} --tso_endpoint ${TSO} --partition_request_timeout=30s &
+./build/src/k2/cmd/nodepool/nodepool ${COMMON_ARGS} --log_level INFO k2::skv_server=INFO -c1 --tcp_endpoints ${EPS[0]} --k23si_persistence_endpoint ${PERSISTENCE} --prometheus_port 63001 --partition_request_timeout=30s &
 nodepool_child_pid=$!
 
 # start persistence

--- a/test/integration/test_http_client.sh
+++ b/test/integration/test_http_client.sh
@@ -9,7 +9,7 @@ cd ${topname}/../..
 cpo_child_pid=$!
 
 # start nodepool
-./build/src/k2/cmd/nodepool/nodepool ${COMMON_ARGS} -c${#EPS[@]} --tcp_endpoints ${EPS[@]} --k23si_persistence_endpoint ${PERSISTENCE} --prometheus_port 63001 --k23si_cpo_endpoint ${CPO} --tso_endpoint ${TSO} --memory=1G --partition_request_timeout=6s &
+./build/src/k2/cmd/nodepool/nodepool ${COMMON_ARGS} -c${#EPS[@]} --tcp_endpoints ${EPS[@]} --k23si_persistence_endpoint ${PERSISTENCE} --prometheus_port 63001 --memory=1G --partition_request_timeout=6s &
 nodepool_child_pid=$!
 
 # start persistence
@@ -22,7 +22,7 @@ tso_child_pid=$!
 
 sleep 2
 
-./build/src/k2/cmd/httpclient/http_client ${COMMON_ARGS} -c1 --tcp_endpoints ${HTTP} --tcp_remotes ${EPS[@]} --memory=1G --cpo ${CPO} --tso_endpoint ${TSO} &
+./build/src/k2/cmd/httpclient/http_client ${COMMON_ARGS} -c1 --tcp_endpoints ${HTTP} --memory=1G --cpo ${CPO} &
 http_child_pid=$!
 
 function finish {

--- a/test/integration/test_http_client.sh
+++ b/test/integration/test_http_client.sh
@@ -22,7 +22,7 @@ tso_child_pid=$!
 
 sleep 2
 
-./build/src/k2/cmd/httpclient/http_client ${COMMON_ARGS} -c1 --tcp_endpoints ${HTTP} --memory=1G --cpo ${CPO} &
+./build/src/k2/cmd/httpclient/http_client ${COMMON_ARGS} -c1 --tcp_endpoints ${HTTP} --memory=1G --num_partitions=3 --cpo ${CPO} &
 http_child_pid=$!
 
 function finish {

--- a/test/integration/test_k23si.sh
+++ b/test/integration/test_k23si.sh
@@ -45,4 +45,4 @@ trap finish EXIT
 
 sleep 2
 
-./build/test/k23si/k23si_test ${COMMON_ARGS} --cpo_endpoint ${CPO} --prometheus_port 63100
+./build/test/k23si/k23si_test ${COMMON_ARGS} --cpo ${CPO} --prometheus_port 63100

--- a/test/integration/test_k23si.sh
+++ b/test/integration/test_k23si.sh
@@ -5,7 +5,7 @@ source ${topname}/common_defs.sh
 cd ${topname}/../..
 
 # start nodepool
-./build/src/k2/cmd/nodepool/nodepool ${COMMON_ARGS} --log_level INFO k2::skv_server=INFO -c${#EPS[@]} --tcp_endpoints ${EPS[@]} --k23si_persistence_endpoint ${PERSISTENCE} --prometheus_port 63001 --k23si_cpo_endpoint ${CPO} --tso_endpoint ${TSO} &
+./build/src/k2/cmd/nodepool/nodepool ${COMMON_ARGS} --log_level INFO k2::skv_server=INFO -c${#EPS[@]} --tcp_endpoints ${EPS[@]} --k23si_persistence_endpoint ${PERSISTENCE} --prometheus_port 63001 &
 nodepool_child_pid=$!
 
 # start persistence
@@ -45,4 +45,4 @@ trap finish EXIT
 
 sleep 2
 
-./build/test/k23si/k23si_test ${COMMON_ARGS} --cpo_endpoint ${CPO} --k2_endpoints ${EPS[@]} --prometheus_port 63100 --tso_endpoint ${TSO}
+./build/test/k23si/k23si_test ${COMMON_ARGS} --cpo_endpoint ${CPO} --prometheus_port 63100

--- a/test/integration/test_k23si_tpcc.sh
+++ b/test/integration/test_k23si_tpcc.sh
@@ -5,7 +5,7 @@ source ${topname}/common_defs.sh
 cd ${topname}/../..
 
 # start nodepool
-./build/src/k2/cmd/nodepool/nodepool ${COMMON_ARGS} -c${#EPS[@]} --tcp_endpoints ${EPS[@]} --k23si_persistence_endpoint ${PERSISTENCE} --prometheus_port 63001 --k23si_cpo_endpoint ${CPO} --tso_endpoint ${TSO} --memory=3G --partition_request_timeout=6s &
+./build/src/k2/cmd/nodepool/nodepool ${COMMON_ARGS} -c${#EPS[@]} --tcp_endpoints ${EPS[@]} --k23si_persistence_endpoint ${PERSISTENCE} --prometheus_port 63001 --memory=3G --partition_request_timeout=6s &
 nodepool_child_pid=$!
 
 # start persistence
@@ -49,7 +49,7 @@ sleep 2
 NUMWH=1
 NUMDIST=1
 echo ">>> Starting load ..."
-./build/src/k2/cmd/tpcc/tpcc_client ${COMMON_ARGS} -c1 --tcp_remotes ${EPS[@]} --cpo ${CPO} --tso_endpoint ${TSO} --data_load true --num_warehouses ${NUMWH} --districts_per_warehouse ${NUMDIST} --prometheus_port 63100 --memory=512M --partition_request_timeout=6s --dataload_txn_timeout=600s --do_verification true --num_concurrent_txns=2 --item_table_num_nodes=1 --txn_weights={43,4,4,45,4}
+./build/src/k2/cmd/tpcc/tpcc_client ${COMMON_ARGS} -c1 --cpo ${CPO} --data_load true --num_warehouses ${NUMWH} --districts_per_warehouse ${NUMDIST} --prometheus_port 63100 --memory=512M --partition_request_timeout=6s --dataload_txn_timeout=600s --do_verification true --num_concurrent_txns=2 --item_table_num_nodes=1 --txn_weights={43,4,4,45,4}
 
 sleep 1
 
@@ -57,4 +57,4 @@ echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"
 echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"
 echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"
 echo ">>> Starting benchmark ..."
-./build/src/k2/cmd/tpcc/tpcc_client ${COMMON_ARGS} -c1 --tcp_remotes ${EPS[@]} --cpo ${CPO} --tso_endpoint ${TSO} --num_warehouses ${NUMWH} --districts_per_warehouse ${NUMDIST} --prometheus_port 63101 --memory=512M --partition_request_timeout=6s  --num_concurrent_txns=1 --do_verification true --delivery_txn_batch_size=10 --txn_weights={43,4,4,45,4}
+./build/src/k2/cmd/tpcc/tpcc_client ${COMMON_ARGS} -c1 --cpo ${CPO} --num_warehouses ${NUMWH} --districts_per_warehouse ${NUMDIST} --prometheus_port 63101 --memory=512M --partition_request_timeout=6s  --num_concurrent_txns=1 --do_verification true --delivery_txn_batch_size=10 --txn_weights={43,4,4,45,4}

--- a/test/integration/test_k23si_tpcc.sh
+++ b/test/integration/test_k23si_tpcc.sh
@@ -49,7 +49,7 @@ sleep 2
 NUMWH=1
 NUMDIST=1
 echo ">>> Starting load ..."
-./build/src/k2/cmd/tpcc/tpcc_client ${COMMON_ARGS} -c1 --cpo ${CPO} --data_load true --num_warehouses ${NUMWH} --districts_per_warehouse ${NUMDIST} --prometheus_port 63100 --memory=512M --partition_request_timeout=6s --dataload_txn_timeout=600s --do_verification true --num_concurrent_txns=2 --item_table_num_nodes=1 --txn_weights={43,4,4,45,4}
+./build/src/k2/cmd/tpcc/tpcc_client ${COMMON_ARGS} -c1 --cpo ${CPO} --data_load true --num_warehouses ${NUMWH} --districts_per_warehouse ${NUMDIST} --prometheus_port 63100 --memory=512M --partition_request_timeout=6s --dataload_txn_timeout=600s --do_verification true --num_concurrent_txns=2 --item_table_num_nodes=1 --txn_weights={43,4,4,45,4} --warehouse_tables_num_nodes=2
 
 sleep 1
 

--- a/test/integration/test_k23si_ycsb.sh
+++ b/test/integration/test_k23si_ycsb.sh
@@ -47,7 +47,7 @@ trap finish EXIT
 sleep 2
 
 echo ">>> Starting load ..."
-./build/src/k2/cmd/ycsb/ycsb_client ${COMMON_ARGS} -c1 --cpo ${CPO} --data_load true --prometheus_port 63100 --memory=512M --partition_request_timeout=6s --dataload_txn_timeout=600s --num_concurrent_txns=2 --num_records=500 --num_records_insert=100 --request_dist="latest"
+./build/src/k2/cmd/ycsb/ycsb_client ${COMMON_ARGS} -c1 --cpo ${CPO} --data_load true --prometheus_port 63100 --memory=512M --partition_request_timeout=6s --dataload_txn_timeout=600s --num_concurrent_txns=2 --num_records=500 --num_records_insert=100 --request_dist="latest" --num_partitions=3
 
 sleep 1
 

--- a/test/integration/test_k23si_ycsb.sh
+++ b/test/integration/test_k23si_ycsb.sh
@@ -5,7 +5,7 @@ source ${topname}/common_defs.sh
 cd ${topname}/../..
 
 # start nodepool
-./build/src/k2/cmd/nodepool/nodepool ${COMMON_ARGS} -c${#EPS[@]} --tcp_endpoints ${EPS[@]} --k23si_persistence_endpoint ${PERSISTENCE} --prometheus_port 63001 --k23si_cpo_endpoint ${CPO} --tso_endpoint ${TSO} --memory=3G --partition_request_timeout=6s &
+./build/src/k2/cmd/nodepool/nodepool ${COMMON_ARGS} -c${#EPS[@]} --tcp_endpoints ${EPS[@]} --k23si_persistence_endpoint ${PERSISTENCE} --prometheus_port 63001 --memory=3G --partition_request_timeout=6s &
 nodepool_child_pid=$!
 
 # start persistence
@@ -47,7 +47,7 @@ trap finish EXIT
 sleep 2
 
 echo ">>> Starting load ..."
-./build/src/k2/cmd/ycsb/ycsb_client ${COMMON_ARGS} -c1 --tcp_remotes ${EPS[@]} --cpo ${CPO} --tso_endpoint ${TSO} --data_load true --prometheus_port 63100 --memory=512M --partition_request_timeout=6s --dataload_txn_timeout=600s --num_concurrent_txns=2 --num_records=500 --num_records_insert=100 --request_dist="latest"
+./build/src/k2/cmd/ycsb/ycsb_client ${COMMON_ARGS} -c1 --cpo ${CPO} --data_load true --prometheus_port 63100 --memory=512M --partition_request_timeout=6s --dataload_txn_timeout=600s --num_concurrent_txns=2 --num_records=500 --num_records_insert=100 --request_dist="latest"
 
 sleep 1
 
@@ -55,4 +55,4 @@ echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"
 echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"
 echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"
 echo ">>> Starting benchmark Workload D..."
-./build/src/k2/cmd/ycsb/ycsb_client ${COMMON_ARGS} -c1 --tcp_remotes ${EPS[@]} --cpo ${CPO} --tso_endpoint ${TSO} --data_load false --prometheus_port 63100 --memory=512M --partition_request_timeout=6s --num_concurrent_txns=1 --num_records=500 --num_records_insert=100 --test_duration=200ms --ops_per_txn=1 --read_proportion=95 --update_proportion=0 --scan_proportion=0 --insert_proportion=5 --request_dist="latest"
+./build/src/k2/cmd/ycsb/ycsb_client ${COMMON_ARGS} -c1 --cpo ${CPO} --data_load false --prometheus_port 63100 --memory=512M --partition_request_timeout=6s --num_concurrent_txns=1 --num_records=500 --num_records_insert=100 --test_duration=200ms --ops_per_txn=1 --read_proportion=95 --update_proportion=0 --scan_proportion=0 --insert_proportion=5 --request_dist="latest"

--- a/test/integration/test_partition.sh
+++ b/test/integration/test_partition.sh
@@ -9,7 +9,7 @@ cd ${topname}/../..
 cpo_child_pid=$!
 
 # start nodepool
-./build/src/k2/cmd/nodepool/nodepool ${COMMON_ARGS} -c${#EPS[@]} --tcp_endpoints ${EPS[@]} --k23si_persistence_endpoint ${PERSISTENCE} --prometheus_port 63001 --k23si_cpo_endpoint ${CPO} --tso_endpoint ${TSO} &
+./build/src/k2/cmd/nodepool/nodepool ${COMMON_ARGS} -c${#EPS[@]} --tcp_endpoints ${EPS[@]} --k23si_persistence_endpoint ${PERSISTENCE} --prometheus_port 63001 &
 nodepool_child_pid=$!
 
 # start persistence
@@ -46,4 +46,4 @@ trap finish EXIT
 
 sleep 2
 
-./build/test/dto/partition_test ${COMMON_ARGS} --cpo ${CPO} --tcp_remotes ${EPS[@]} --tso_endpoint ${TSO} --prometheus_port 63100
+./build/test/dto/partition_test ${COMMON_ARGS} --cpo ${CPO} --prometheus_port 63100

--- a/test/integration/test_partition.sh
+++ b/test/integration/test_partition.sh
@@ -5,7 +5,7 @@ source ${topname}/common_defs.sh
 cd ${topname}/../..
 
 # start CPO
-./build/src/k2/cmd/controlPlaneOracle/cpo_main ${COMMON_ARGS} -c1 --tcp_endpoints ${CPO} --data_dir ${CPODIR} --prometheus_port 63000 --assignment_timeout=1s &
+./build/src/k2/cmd/controlPlaneOracle/cpo_main ${COMMON_ARGS} -c1 --tcp_endpoints ${CPO} --data_dir ${CPODIR} --prometheus_port 63000 --assignment_timeout=1s --nodepool_endpoints ${EPS[@]} --tso_endpoints ${TSO} &
 cpo_child_pid=$!
 
 # start nodepool

--- a/test/integration/test_query.sh
+++ b/test/integration/test_query.sh
@@ -5,7 +5,7 @@ source ${topname}/common_defs.sh
 cd ${topname}/../..
 
 # start nodepool
-./build/src/k2/cmd/nodepool/nodepool ${COMMON_ARGS} -c2 --tcp_endpoints ${EPS[@]:0:2} --k23si_persistence_endpoint ${PERSISTENCE} --prometheus_port 63001 --k23si_cpo_endpoint ${CPO} --tso_endpoint ${TSO} --k23si_query_pagination_limit 2 &
+./build/src/k2/cmd/nodepool/nodepool ${COMMON_ARGS} -c2 --tcp_endpoints ${EPS[@]:0:2} --k23si_persistence_endpoint ${PERSISTENCE} --prometheus_port 63001 --k23si_query_pagination_limit 2 &
 nodepool_child_pid=$!
 
 # start persistence
@@ -45,4 +45,4 @@ trap finish EXIT
 
 sleep 2
 
-./build/test/k23si/query_test ${COMMON_ARGS} --cpo ${CPO} --tcp_remotes ${EPS[@]:0:2} --prometheus_port 63100 --tso_endpoint ${TSO}
+./build/test/k23si/query_test ${COMMON_ARGS} --cpo ${CPO} --prometheus_port 63100

--- a/test/integration/test_schema_create.sh
+++ b/test/integration/test_schema_create.sh
@@ -5,7 +5,7 @@ source ${topname}/common_defs.sh
 cd ${topname}/../..
 
 # start nodepool
-./build/src/k2/cmd/nodepool/nodepool ${COMMON_ARGS} -c${#EPS[@]} --tcp_endpoints ${EPS[@]} --k23si_persistence_endpoint ${PERSISTENCE} --prometheus_port 63001 --k23si_cpo_endpoint ${CPO} --tso_endpoint ${TSO} &
+./build/src/k2/cmd/nodepool/nodepool ${COMMON_ARGS} -c${#EPS[@]} --tcp_endpoints ${EPS[@]} --k23si_persistence_endpoint ${PERSISTENCE} --prometheus_port 63001 &
 nodepool_child_pid=$!
 
 # start persistence
@@ -45,4 +45,4 @@ trap finish EXIT
 
 sleep 2
 
-./build/test/k23si/schema_creation_test ${COMMON_ARGS} --cpo_endpoint ${CPO} --k2_endpoints ${EPS[@]} --prometheus_port 63100
+./build/test/k23si/schema_creation_test ${COMMON_ARGS} --cpo_endpoint ${CPO} --prometheus_port 63100

--- a/test/integration/test_skv_client.sh
+++ b/test/integration/test_skv_client.sh
@@ -5,7 +5,7 @@ source ${topname}/common_defs.sh
 cd ${topname}/../..
 
 # start nodepool
-./build/src/k2/cmd/nodepool/nodepool ${COMMON_ARGS} --log_level INFO k2::skv_server=INFO -c${#EPS[@]} --tcp_endpoints ${EPS[@]} --k23si_persistence_endpoint ${PERSISTENCE} --prometheus_port 63001 --k23si_cpo_endpoint ${CPO} --tso_endpoint ${TSO} &
+./build/src/k2/cmd/nodepool/nodepool ${COMMON_ARGS} --log_level INFO k2::skv_server=INFO -c${#EPS[@]} --tcp_endpoints ${EPS[@]} --k23si_persistence_endpoint ${PERSISTENCE} --prometheus_port 63001 &
 nodepool_child_pid=$!
 
 # start persistence
@@ -45,4 +45,4 @@ trap finish EXIT
 
 sleep 2
 
-./build/test/k23si/skv_client_test ${COMMON_ARGS} --cpo ${CPO} --tcp_remotes ${EPS[@]} --prometheus_port 63100 --tso_endpoint ${TSO}
+./build/test/k23si/skv_client_test ${COMMON_ARGS} --cpo ${CPO} --prometheus_port 63100

--- a/test/k23si/3SITxnTest.cpp
+++ b/test/k23si/3SITxnTest.cpp
@@ -102,11 +102,6 @@ public: // application
     seastar::future<> start(){
         K2LOG_I(log::k23si, "start txn_testing..");
 
-        K2EXPECT(log::k23si, _k2ConfigEps().size(), 3);
-        for (auto& ep: _k2ConfigEps()) {
-            _k2Endpoints.push_back(RPC().getTXEndpoint(ep));
-        }
-
         _cpoEndpoint = RPC().getTXEndpoint(_cpoConfigEp());
         _testTimer.set_callback([this] {
             _testFuture = testScenario00()
@@ -145,11 +140,12 @@ public: // application
 
 
 private:
-    ConfigVar<String> _cpoConfigEp{"cpo_endpoint"};
+    ConfigVar<String> _cpoConfigEp{"cpo"};
 
     seastar::future<> _testFuture = seastar::make_ready_future();
     seastar::timer<> _testTimer;
 
+    std::unique_ptr<k2::TXEndpoint> _dummyEP; // Used for the scenario00 tests that expect timeout
     std::vector<std::unique_ptr<k2::TXEndpoint>> _k2Endpoints;
     std::unique_ptr<k2::TXEndpoint> _cpoEndpoint;
 
@@ -461,6 +457,8 @@ seastar::future<> testScenario00() {
     K2LOG_I(log::k23si, "+++++++ TestScenario 00: unassigned nodes +++++++");
     K2LOG_I(log::k23si, "--->Test SETUP: start a cluster but don't create a collection. Any requests observe a timeout.");
 
+    _dummyEP = RPC().getTXEndpoint("tcp+k2rpc://0.0.0.0:10000");
+
     return seastar::make_ready_future()
     .then([this] {
         // command: K23SI_WRITE
@@ -489,7 +487,7 @@ seastar::future<> testScenario00() {
                         .value{},
                         .fieldsForPartialUpdate{}
                     };
-                    return RPC().callRPC<dto::K23SIWriteRequest, dto::K23SIWriteResponse>(dto::Verbs::K23SI_WRITE, request, *_k2Endpoints[0], 100ms)
+                    return RPC().callRPC<dto::K23SIWriteRequest, dto::K23SIWriteResponse>(dto::Verbs::K23SI_WRITE, request, *_dummyEP, 100ms)
                     .then([this](auto&& response) {
                         // response: K23SI_WRITE
                         auto& [status, resp] = response;
@@ -509,7 +507,7 @@ seastar::future<> testScenario00() {
             .key{"schema", "SC00_pKey1", "SC00_rKey1"}
         };
         return RPC().callRPC<dto::K23SIReadRequest, dto::K23SIReadResponse>
-                (dto::Verbs::K23SI_READ, request, *_k2Endpoints[0], 100ms)
+                (dto::Verbs::K23SI_READ, request, *_dummyEP, 100ms)
         .then([](auto&& response) {
             auto& [status, resp] = response;
             K2EXPECT(log::k23si, status, Statuses::S503_Service_Unavailable);
@@ -526,7 +524,7 @@ seastar::future<> testScenario00() {
             .challengerMTR{dto::Timestamp(20200101, 1, 1000), dto::TxnPriority::Medium}
         };
         return RPC().callRPC<dto::K23SITxnPushRequest, dto::K23SITxnPushResponse>
-                (dto::Verbs::K23SI_TXN_PUSH, request, *_k2Endpoints[0], 100ms)
+                (dto::Verbs::K23SI_TXN_PUSH, request, *_dummyEP, 100ms)
         .then([](auto&& response) {
             auto& [status, resp] = response;
             K2EXPECT(log::k23si, status, Statuses::S503_Service_Unavailable);
@@ -547,7 +545,7 @@ seastar::future<> testScenario00() {
             .syncFinalize = false
         };
         return RPC().callRPC<dto::K23SITxnEndRequest, dto::K23SITxnEndResponse>
-                (dto::Verbs::K23SI_TXN_END, request, *_k2Endpoints[0], 100ms)
+                (dto::Verbs::K23SI_TXN_END, request, *_dummyEP, 100ms)
         .then([](auto&& response) {
             auto& [status, resp] = response;
             K2EXPECT(log::k23si, status, Statuses::S503_Service_Unavailable);
@@ -563,7 +561,7 @@ seastar::future<> testScenario00() {
             .action = dto::EndAction::Abort
         };
         return RPC().callRPC<dto::K23SITxnFinalizeRequest, dto::K23SITxnFinalizeResponse>
-                (dto::Verbs::K23SI_TXN_FINALIZE, request, *_k2Endpoints[0], 100ms)
+                (dto::Verbs::K23SI_TXN_FINALIZE, request, *_dummyEP, 100ms)
         .then([](auto&& response) {
             auto& [status, resp] = response;
             K2EXPECT(log::k23si, status, Statuses::S503_Service_Unavailable);
@@ -579,7 +577,7 @@ seastar::future<> testScenario00() {
             .mtr{dto::Timestamp(20200828, 1, 1000), dto::TxnPriority::Medium},
         };
         return RPC().callRPC<dto::K23SITxnHeartbeatRequest, dto::K23SITxnHeartbeatResponse>
-                (dto::Verbs::K23SI_TXN_HEARTBEAT, request, *_k2Endpoints[0], 100ms)
+                (dto::Verbs::K23SI_TXN_HEARTBEAT, request, *_dummyEP, 100ms)
         .then([](auto&& response) {
             auto& [status, resp] = response;
             K2EXPECT(log::k23si, status, Statuses::S503_Service_Unavailable);
@@ -603,11 +601,11 @@ seastar::future<> testScenario01() {
                 .capacity{
                     .dataCapacityMegaBytes = 100,
                     .readIOPs = 100000,
-                    .writeIOPs = 100000
+                    .writeIOPs = 100000,
+                    .minNodes = 3
                 },
                 .retentionPeriod = Duration(1s)
             },
-            .clusterEndpoints = _k2ConfigEps(),
             .rangeEnds{}
         };
         return RPC().callRPC<dto::CollectionCreateRequest, dto::CollectionCreateResponse>
@@ -629,6 +627,12 @@ seastar::future<> testScenario01() {
             // check collection was assigned
             auto& [status, resp] = response;
             K2EXPECT(log::k23si, status, dto::K23SIStatus::OK);
+
+            for (size_t i = 0; i < resp.collection.partitionMap.partitions.size(); ++i) {
+                auto& p = resp.collection.partitionMap.partitions[i];
+                _k2Endpoints.push_back(RPC().getTXEndpoint(*p.endpoints.begin()));
+            }
+
             _pgetter = dto::PartitionGetter(std::move(resp.collection));
         })
         .then([this] () {
@@ -1306,7 +1310,8 @@ seastar::future<> testScenario02() {
         .then([](auto&& response) {
             // response for collection create
             auto& [status, resp] = response;
-            K2EXPECT(log::k23si, status, dto::K23SIStatus::Forbidden);
+            // No free nodes available so we expect CPO to give us an error
+            K2EXPECT(log::k23si, status, k2::Statuses::S403_Forbidden);
         });
     })
     .then([this] {
@@ -2871,7 +2876,7 @@ seastar::future<> testScenario08() {
 
 int main(int argc, char** argv){
     k2::App app("txn_testing");
-    app.addOptions()("cpo_endpoint", bpo::value<k2::String>(), "The endpoint of the CPO service");
+    app.addOptions()("cpo", bpo::value<k2::String>(), "The endpoint of the CPO service");
     app.addApplet<k2::txn_testing>();
     app.addApplet<k2::tso::TSOClient>();
 

--- a/test/k23si/K23SITest.cpp
+++ b/test/k23si/K23SITest.cpp
@@ -88,11 +88,11 @@ public:  // application lifespan
                         .capacity{
                             .dataCapacityMegaBytes = 1000,
                             .readIOPs = 100000,
-                            .writeIOPs = 100000
+                            .writeIOPs = 100000,
+                            .minNodes = 3 // Integration tests are set up with a three-core nodepool
                         },
                         .retentionPeriod = Duration(1h)*90*24
                     },
-                    .clusterEndpoints = _k2ConfigEps(),
                     .rangeEnds{}
                 };
                 return RPC().callRPC<dto::CollectionCreateRequest, dto::CollectionCreateResponse>
@@ -170,7 +170,6 @@ public:  // application lifespan
 
 private:
     int exitcode = -1;
-    ConfigVar<std::vector<String>> _k2ConfigEps{"k2_endpoints"};
     ConfigVar<String> _cpoConfigEp{"cpo_endpoint"};
 
     std::vector<std::unique_ptr<k2::TXEndpoint>> _k2Endpoints;
@@ -592,8 +591,6 @@ seastar::future<> runScenario05() {
 
 int main(int argc, char** argv) {
     k2::App app("K23SITest");
-    app.addOptions()("k2_endpoints", bpo::value<std::vector<k2::String>>()->multitoken(), "The endpoints of the k2 cluster");
-    app.addOptions()("tso_endpoint", bpo::value<k2::String>(), "URL of Timestamp Oracle (TSO), e.g. 'tcp+k2rpc://192.168.1.2:12345'");
     app.addOptions()("cpo_endpoint", bpo::value<k2::String>(), "The endpoint of the CPO");
     app.addApplet<k2::K23SITest>();
     app.addApplet<k2::tso::TSOClient>();

--- a/test/k23si/K23SITest.cpp
+++ b/test/k23si/K23SITest.cpp
@@ -69,11 +69,6 @@ public:  // application lifespan
     seastar::future<> start(){
         K2LOG_I(log::k23si, "start");
 
-        K2EXPECT(log::k23si, _k2ConfigEps().size(), 3);
-        for (auto& ep: _k2ConfigEps()) {
-            _k2Endpoints.push_back(RPC().getTXEndpoint(ep));
-        }
-
         _cpo_client.init(_cpoConfigEp());
         _cpoEndpoint = RPC().getTXEndpoint(_cpoConfigEp());
         _testTimer.set_callback([this] {
@@ -115,6 +110,7 @@ public:  // application lifespan
                 // check collection was assigned
                 auto& [status, resp] = response;
                 K2EXPECT(log::k23si, status, Statuses::S200_OK);
+
                 _pgetter = dto::PartitionGetter(std::move(resp.collection));
             })
             .then([this] () {
@@ -170,9 +166,8 @@ public:  // application lifespan
 
 private:
     int exitcode = -1;
-    ConfigVar<String> _cpoConfigEp{"cpo_endpoint"};
+    ConfigVar<String> _cpoConfigEp{"cpo"};
 
-    std::vector<std::unique_ptr<k2::TXEndpoint>> _k2Endpoints;
     std::unique_ptr<k2::TXEndpoint> _cpoEndpoint;
 
     seastar::timer<> _testTimer;
@@ -591,7 +586,7 @@ seastar::future<> runScenario05() {
 
 int main(int argc, char** argv) {
     k2::App app("K23SITest");
-    app.addOptions()("cpo_endpoint", bpo::value<k2::String>(), "The endpoint of the CPO");
+    app.addOptions()("cpo", bpo::value<k2::String>(), "The endpoint of the CPO");
     app.addApplet<k2::K23SITest>();
     app.addApplet<k2::tso::TSOClient>();
 

--- a/test/k23si/SKVClientTest.cpp
+++ b/test/k23si/SKVClientTest.cpp
@@ -53,34 +53,48 @@ public:  // application lifespan
                 return _client.start();
             })
             .then([this] {
-                auto eps = ConfigVar<std::vector<String>>("tcp_remotes");
-                K2LOG_I(log::k23si, "Creating test collection with eps {}", eps());
+                K2LOG_I(log::k23si, "Creating test collection with eps");
 
                 dto::CollectionMetadata md1{
                     .name = collname1,
                     .hashScheme = dto::HashScheme::HashCRC32C,
                     .storageDriver = dto::StorageDriver::K23SI,
-                    .capacity = {},
+                    .capacity = {
+                        .dataCapacityMegaBytes = 0,
+                        .readIOPs = 0,
+                        .writeIOPs = 0,
+                        .minNodes = 1
+                    },
                     .retentionPeriod = 2h
                 };
                 dto::CollectionMetadata md2{
                     .name = collname2,
                     .hashScheme = dto::HashScheme::HashCRC32C,
                     .storageDriver = dto::StorageDriver::K23SI,
-                    .capacity = {},
+                    .capacity = {
+                        .dataCapacityMegaBytes = 0,
+                        .readIOPs = 0,
+                        .writeIOPs = 0,
+                        .minNodes = 1
+                    },
                     .retentionPeriod = 2h
                 };
                 dto::CollectionMetadata md3{
                     .name = collname3,
                     .hashScheme = dto::HashScheme::HashCRC32C,
                     .storageDriver = dto::StorageDriver::K23SI,
-                    .capacity = {},
+                    .capacity = {
+                        .dataCapacityMegaBytes = 0,
+                        .readIOPs = 0,
+                        .writeIOPs = 0,
+                        .minNodes = 1
+                    },
                     .retentionPeriod = 2h
                 };
                 return seastar::when_all_succeed(
-                    _client.makeCollection(std::move(md1), {eps()[0]}),
-                    _client.makeCollection(std::move(md2), {eps()[1]}),
-                    _client.makeCollection(std::move(md3), {eps()[2]}),
+                    _client.makeCollection(std::move(md1)),
+                    _client.makeCollection(std::move(md2)),
+                    _client.makeCollection(std::move(md3)),
                     seastar::sleep(1s)
                 );
             })
@@ -1499,8 +1513,6 @@ seastar::future<> runScenario11() {
 int main(int argc, char** argv) {
     App app("SKVClientTest");
     app.addOptions()
-        ("tcp_remotes", bpo::value<std::vector<String>>()->multitoken()->default_value(std::vector<String>()), "A list(space-delimited) of endpoints to assign in the test collection")
-        ("tso_endpoint", bpo::value<String>(), "URL of Timestamp Oracle (TSO), e.g. 'tcp+k2rpc://192.168.1.2:12345'")
         ("cpo", bpo::value<String>(), "URL of Control Plane Oracle (CPO), e.g. 'tcp+k2rpc://192.168.1.2:12345'");
     app.addApplet<tso::TSOClient>();
     app.addApplet<SKVClientTest>();

--- a/test/k23si/SchemaCreationTest.cpp
+++ b/test/k23si/SchemaCreationTest.cpp
@@ -153,7 +153,7 @@ private:
                 K2EXPECT(log::k23si, resp.collection.partitionMap.partitions.size(), 3);
 
                 // how many partitions we have
-                uint64_t numparts = _k2ConfigEps().size();
+                uint64_t numparts = resp.collection.partitionMap.partitions.size();
                 auto max = std::numeric_limits<uint64_t>::max();
                 // how big is each one
                 uint64_t partSize = max / numparts;
@@ -165,8 +165,7 @@ private:
                     K2EXPECT(log::k23si, p.keyRangeV.pvid.assignmentVersion, 1);
                     K2EXPECT(log::k23si, p.keyRangeV.pvid.id, i);
                     K2EXPECT(log::k23si, p.keyRangeV.startKey, std::to_string(i * partSize));
-                    K2EXPECT(log::k23si, p.keyRangeV.endKey, std::to_string(i == _k2ConfigEps().size() - 1 ? max : (i + 1) * partSize - 1));
-                    K2EXPECT(log::k23si, *p.endpoints.begin(), _k2ConfigEps()[i]);
+                    K2EXPECT(log::k23si, p.keyRangeV.endKey, std::to_string(i == numparts - 1 ? max : (i + 1) * partSize - 1));
                 }
             });
     }

--- a/test/k23si/SchemaCreationTest.cpp
+++ b/test/k23si/SchemaCreationTest.cpp
@@ -100,7 +100,6 @@ public: // application lifespan
 
 private:
     std::unique_ptr<k2::TXEndpoint> _cpoEndpoint;
-    k2::ConfigVar<std::vector<k2::String>> _k2ConfigEps{"k2_endpoints"};
     seastar::future<> _testFuture = seastar::make_ready_future();
     seastar::timer<> _testTimer;
     int exitcode = -1;
@@ -116,11 +115,11 @@ private:
                 .capacity{
                     .dataCapacityMegaBytes = 100,
                     .readIOPs = 100000,
-                    .writeIOPs = 100000
+                    .writeIOPs = 100000,
+                    .minNodes = 3 // Integration tests are set up with a three-core nodepool
                 },
                 .retentionPeriod = 5h
             },
-            .clusterEndpoints = _k2ConfigEps(),
             .rangeEnds{}
         };
         return RPC()
@@ -635,7 +634,6 @@ seastar::future<> runScenario11(){
 
 int main(int argc, char** argv) {
     k2::App app("schemaCreationTest");
-    app.addOptions()("k2_endpoints", bpo::value<std::vector<k2::String>>()->multitoken(), "The endpoints of the k2 cluster");
     app.addOptions()("cpo_endpoint", bpo::value<k2::String>(), "The endpoint of the CPO");
     app.addApplet<k2::schemaCreation>();
     return app.start(argc, argv);


### PR DESCRIPTION
CPO will select nodepool nodes for collection assignment (drawn from "nodepool_endpoints" cli arg), rather than clients specifying endpoints. For hash collections the number of nodes comes from the "minNodes" field of the collection metadata. For range collections the number of nodes is equal to the number of range ends passed in.

The nodepool process now gets the CPO endpoint from the partition assignment request instead of from the cli arg.

The TSO client will now also get the TSO server endpoint from the CPO. The CPO gets the endpoints from the "tso_endpoints" cli arg.

The nodepool still gets its persistence endpoints directly from its command line, because we need a way to distribute the load among persistence servers, which is currently handled by the cluster running scripts using the command line options.

Tested with unit tests and integration tests. Repos using the platform may need to be updated since some command line arguments have been changed or removed, and the interface for creating collections from the k23si client has changed.