### PR TITLE
Cleanup idle transactions after timeout

### DIFF
--- a/src/k2/cmd/httpproxy/http_proxy_main.cpp
+++ b/src/k2/cmd/httpproxy/http_proxy_main.cpp
@@ -37,6 +37,7 @@ int main(int argc, char** argv) {
         ("partition_request_timeout", bpo::value<k2::ParseableDuration>(), "Timeout of K23SI operations, as chrono literals")
         ("cpo", bpo::value<k2::String>(), "URL of Control Plane Oracle (CPO), e.g. 'tcp+k2rpc://192.168.1.2:12345'")
         ("cpo_request_timeout", bpo::value<k2::ParseableDuration>(), "CPO request timeout")
-        ("cpo_request_backoff", bpo::value<k2::ParseableDuration>(), "CPO request backoff");
+        ("cpo_request_backoff", bpo::value<k2::ParseableDuration>(), "CPO request backoff")
+        ("httpproxy_txn_timeout", bpo::value<k2::ParseableDuration>(), "HTTP Proxy Txn idle timeout");
     return app.start(argc, argv);
 }

--- a/src/k2/common/MapWithExpiry.h
+++ b/src/k2/common/MapWithExpiry.h
@@ -132,12 +132,14 @@ public:
             });
     }
 
+    typedef typename TimestampOrderedMap<KeyT, ValT>::iterator iterator;
+
     // Check if key is present, with optionally push back expiry if present
-    bool isPresent(const KeyT &key, bool reorder) {
-        auto iter =  _elems.find(key);
-        if (iter == _elems.end()) return false;
+    iterator find(const KeyT &key, bool reorder) {
+        auto iter = _elems.find(key);
+        if (iter == _elems.end()) return iter;
         if (reorder) _elems.resetTs(iter, getExpiry());
-        return true;
+        return iter;
     }
 
     TimePoint getExpiry() {return ClockT::now() + _timeout;}
@@ -145,6 +147,8 @@ public:
     void erase(const KeyT &key) {_elems.erase(key);}
     auto size() {return _elems.size(); }
     ValT& at(const KeyT &key) {return _elems.at(key);}
+    iterator end() {return _elems.end();}
+    ValT& getValue(iterator it) {return it->second.getValue();}
 
 private:
     TimestampOrderedMap<KeyT, ValT> _elems;
@@ -153,5 +157,4 @@ private:
     Duration _timeout = 10s;
 
 };
-
 }

--- a/src/k2/common/MapWithExpiry.h
+++ b/src/k2/common/MapWithExpiry.h
@@ -1,0 +1,157 @@
+/*
+MIT License
+
+Copyright(c) 2022 Futurewei Cloud
+
+    Permission is hereby granted,
+    free of charge, to any person obtaining a copy of this software and associated documentation files(the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and / or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions :
+
+    The above copyright notice and this permission notice shall be included in all copies
+    or
+    substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS",
+    WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+    DAMAGES OR OTHER
+    LIABILITY,
+    WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+*/
+
+#pragma once
+#include "Timer.h"
+
+namespace k2 {
+namespace nsbi = boost::intrusive;
+
+// Utility map class that also keeps a timestamp ordered elements list
+template <class KeyT, class ValT> class TimestampOrderedMap {
+public:
+    class MapElem {
+    public:
+        ValT& getValue() {return entry;}
+        TimePoint timestamp() {return ts;}
+        KeyT key;
+        ValT entry;
+        TimePoint ts;
+        nsbi::list_member_hook<> tsLink;
+    };
+
+    typedef typename std::unordered_map<KeyT, MapElem>::iterator iterator;
+    typedef nsbi::list<MapElem, nsbi::member_hook<MapElem, nsbi::list_member_hook<>, &MapElem::tsLink>> TsOrderedList;
+
+
+    auto insert(const KeyT &key, ValT&& val, TimePoint ts) {
+        auto pair = elems.emplace(key, MapElem  {
+            .key = key,
+            .entry = std::move(val),
+            .ts = ts,
+            .tsLink = {},
+        });
+        MapElem& elem = pair.first->second;
+        tsOrderedList.push_back(elem);
+    }
+
+    // TODO: Implement using boost iterator helpers to reduce boilerplate code.
+    iterator end() {return elems.end();}
+    iterator begin() { return elems.begin();}
+    iterator find(const KeyT &key) {return  elems.find(key);}
+    ValT& at(const KeyT &key) {return elems.at(key).getValue();}
+    auto size() {return elems.size();}
+    void unlink(iterator iter) {
+        tsOrderedList.erase(tsOrderedList.iterator_to(iter->second));
+    }
+    auto extract(iterator iter) {
+        unlink(iter);
+        // Remove from map
+        return elems.extract(iter);
+    }
+    auto erase(const KeyT &key) {
+        iterator iter = elems.find(key);
+        unlink(iter);
+        return elems.erase(iter);
+    }
+
+    void resetTs(iterator iter, TimePoint ts) {
+        // new TS needs to be >= current maximum TS
+        if (ts < tsOrderedList.back().ts) {
+            assert(false);
+            throw std::invalid_argument("too small ts");
+        }
+        unlink(iter);
+        iter->second.ts = ts;
+        tsOrderedList.push_back(iter->second);
+    }
+
+    iterator getFirst() {
+        if (tsOrderedList.empty())
+            return elems.end();
+        return find(tsOrderedList.front().key);
+    }
+
+    TsOrderedList tsOrderedList;
+    std::unordered_map<KeyT, MapElem> elems;
+};
+
+template <class KeyT, class ValT, class ClockT=Clock>
+class MapWithExpiry {
+public:
+    template <typename Func>
+    void start(Duration timeout, Func&& func) {
+        _timeout = timeout;
+        _expiryTimer.setCallback([this, func = std::move(func)] {
+            return seastar::do_until(
+                [this] {
+                    auto iter = _elems.getFirst();
+                    return (iter == _elems.end() || iter->second.timestamp() > ClockT::now());
+                },
+                [this, func] {
+                    auto iter = _elems.getFirst();
+                    // First Remove element from map before calling callback
+                    auto node = _elems.extract(iter);
+                    if (!node) return seastar::make_ready_future();
+                    return func(node.key(), node.mapped().getValue());
+                });
+
+        });
+        _expiryTimer.armPeriodic(_timeout/2);
+     }
+
+    seastar::future<> stop() {
+        return _expiryTimer.stop()
+            .then([this] {
+                std::vector<seastar::future<>> bgFuts;
+                for(auto iter = _elems.begin(); iter != _elems.end(); iter++) {
+                    _elems.unlink(iter);
+                    bgFuts.push_back(iter->second.getValue().cleanup().discard_result());
+                }
+                return seastar::when_all_succeed(bgFuts.begin(), bgFuts.end());
+            });
+    }
+
+    // Check if key is present, with optionally push back expiry if present
+    bool isPresent(const KeyT &key, bool reorder) {
+        auto iter =  _elems.find(key);
+        if (iter == _elems.end()) return false;
+        if (reorder) _elems.resetTs(iter, getExpiry());
+        return true;
+    }
+
+    TimePoint getExpiry() {return ClockT::now() + _timeout;}
+    void insert(const KeyT &key, ValT&& val) {_elems.insert(key, std::move(val), getExpiry());}
+    void erase(const KeyT &key) {_elems.erase(key);}
+    auto size() {return _elems.size(); }
+    ValT& at(const KeyT &key) {return _elems.at(key);}
+
+private:
+    TimestampOrderedMap<KeyT, ValT> _elems;
+    // heartbeats checks are driven off single timer.
+    PeriodicTimer _expiryTimer;
+    Duration _timeout = 10s;
+
+};
+
+}

--- a/src/k2/common/MapWithExpiry.h
+++ b/src/k2/common/MapWithExpiry.h
@@ -69,10 +69,11 @@ public:
         // Remove from map
         return elems.extract(iter);
     }
-    auto erase(const KeyT &key) {
+    void erase(const KeyT &key) {
         iterator iter = elems.find(key);
+        if (iter == elems.end()) return;
         unlink(iter);
-        return elems.erase(iter);
+        elems.erase(iter);
     }
 
     void resetTs(iterator iter, TimePoint ts) {

--- a/src/k2/common/MapWithExpiry.h
+++ b/src/k2/common/MapWithExpiry.h
@@ -134,14 +134,9 @@ public:
 
     typedef typename TimestampOrderedMap<KeyT, ValT>::iterator iterator;
 
-    // Check if key is present, with optionally push back expiry if present
-    iterator find(const KeyT &key, bool reorder) {
-        auto iter = _elems.find(key);
-        if (iter == _elems.end()) return iter;
-        if (reorder) _elems.resetTs(iter, getExpiry());
-        return iter;
-    }
-
+    // Move elment to the end of the TS ordered list
+    void reorder(iterator iter) {_elems.resetTs(iter, getExpiry());}
+    iterator find(const KeyT &key) {return _elems.find(key);}
     TimePoint getExpiry() {return ClockT::now() + _timeout;}
     void insert(const KeyT &key, ValT&& val) {_elems.insert(key, std::move(val), getExpiry());}
     void erase(const KeyT &key) {_elems.erase(key);}

--- a/test/integration/test_http.py
+++ b/test/integration/test_http.py
@@ -494,8 +494,8 @@ class TestBasicTxn(unittest.TestCase):
 
         prev = mclient.refresh()
         status, txn = db.begin_txn()
-        # Sleep 1.2s for txn to timeout
-        sleep(1.2)
+        # Sleep 1.7s for txn to timeout
+        sleep(1.7)
         status = txn.end()
         self.assertEqual(status.code, 400, msg=status.message)
         curr = mclient.refresh()

--- a/test/integration/test_http_client.sh
+++ b/test/integration/test_http_client.sh
@@ -22,7 +22,7 @@ tso_child_pid=$!
 
 sleep 2
 
-./build/src/k2/cmd/httpproxy/http_proxy ${COMMON_ARGS} -c1 --tcp_endpoints ${HTTP} --memory=1G --cpo ${CPO} &
+./build/src/k2/cmd/httpproxy/http_proxy ${COMMON_ARGS} -c1 --tcp_endpoints ${HTTP} --memory=1G --cpo ${CPO} --httpproxy_txn_timeout=1s&
 http_child_pid=$!
 
 function finish {


### PR DESCRIPTION
Also associate queries with transaction in api and data structure.

Followed pattern of https://github.com/futurewei-cloud/chogori-platform/blob/master/src/k2/transport/RPCDispatcher.h#L268 to implement.

https://github.com/futurewei-cloud/chogori-platform/issues/286
