### PR TITLE
Remove test sleep

### DIFF
--- a/src/k2/cmd/httpproxy/http_proxy_main.cpp
+++ b/src/k2/cmd/httpproxy/http_proxy_main.cpp
@@ -37,6 +37,8 @@ int main(int argc, char** argv) {
         ("partition_request_timeout", bpo::value<k2::ParseableDuration>(), "Timeout of K23SI operations, as chrono literals")
         ("cpo", bpo::value<k2::String>(), "URL of Control Plane Oracle (CPO), e.g. 'tcp+k2rpc://192.168.1.2:12345'")
         ("cpo_request_timeout", bpo::value<k2::ParseableDuration>(), "CPO request timeout")
-        ("cpo_request_backoff", bpo::value<k2::ParseableDuration>(), "CPO request backoff");
+        ("cpo_request_backoff", bpo::value<k2::ParseableDuration>(), "CPO request backoff")
+        ("httpproxy_txn_timeout", bpo::value<k2::ParseableDuration>(), "Txn idle timeout")
+        ("httpproxy_expiry_timer_interval", bpo::value<k2::ParseableDuration>(), "Periodic timer interval to check expired Txns");
     return app.start(argc, argv);
 }

--- a/src/k2/cmd/txbench/txbench_client.cpp
+++ b/src/k2/cmd/txbench/txbench_client.cpp
@@ -139,7 +139,7 @@ private:
         }
         auto myRemote = RPC().getTXEndpoint(_tcpRemotes[myID]);
         auto retryStrategy = seastar::make_lw_shared<ExponentialBackoffStrategy>();
-        retryStrategy->withRetries(10).withStartTimeout(1s).withRate(5);
+        retryStrategy->withRetries(10).withStartTimeout(10ms).withRate(3);
         return retryStrategy->run([this, myRemote=std::move(myRemote)](size_t, Duration timeout) {
             if (_stopped) {
                 K2LOG_I(log::txbench, "Stopping retry since we were stopped");

--- a/src/k2/cmd/txbench/txbench_combine.cpp
+++ b/src/k2/cmd/txbench/txbench_combine.cpp
@@ -272,7 +272,7 @@ private:
         }
         auto myRemote = RPC().getTXEndpoint(_tcpRemotes[myID]);
         auto retryStrategy = seastar::make_lw_shared<ExponentialBackoffStrategy>();
-        retryStrategy->withRetries(10).withStartTimeout(1s).withRate(5);
+        retryStrategy->withRetries(10).withStartTimeout(10ms).withRate(3);
         return retryStrategy->run([this, myRemote=std::move(myRemote)](size_t, Duration timeout) {
             if (_stopped) {
                 return seastar::make_exception_future<>(std::runtime_error("we were stopped"));

--- a/src/k2/common/ExpiryList.h
+++ b/src/k2/common/ExpiryList.h
@@ -1,0 +1,100 @@
+/*
+MIT License
+
+Copyright(c) 2022 Futurewei Cloud
+
+    Permission is hereby granted,
+    free of charge, to any person obtaining a copy of this software and associated documentation files(the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and / or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions :
+
+    The above copyright notice and this permission notice shall be included in all copies
+    or
+    substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS",
+    WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+    DAMAGES OR OTHER
+    LIABILITY,
+    WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+*/
+
+#pragma once
+#include <boost/intrusive/list.hpp>
+#include "Timer.h"
+#include "Log.h"
+
+namespace k2 {
+namespace nsbi = boost::intrusive;
+
+// Utility class to keep elements orderded by expiry time and cleanup elements upon expiry.
+//
+// Template members:
+//
+//  ElemT: Element type, it required to have a  member expiry() returning expiry time.
+//  Field: boost::intrusive::list_member_hook<> type field.
+//  ClockT: Clock used to get current time.
+//
+template <class ElemT, nsbi::list_member_hook<> ElemT::* Field, class ClockT=Clock>
+class ExpiryList {
+public:
+    typedef std::function<seastar::future<>(ElemT&)> Func;
+
+    // Start a periodic timer to cleanup elements upon expiry.
+    // Args:
+    // interval:  Periodic timer interval, Elemnets may take upto interval after
+    //            expiry for clean up depending on when the timer is fired.
+    // cleanupFn: Supplied function to clean up the element.
+    void start(Duration interval, Func&& cleanupFn) {
+        _expiryTimer.setCallback([this,  func=std::move(cleanupFn)] {
+            return seastar::do_until(
+                [this] {
+                    return _list.empty() || _list.front().expiry() > ClockT::now();
+                },
+                [this, func=std::move(func)] {
+                    auto& elem = _list.front();
+                    _list.pop_front();
+                    return func(elem);
+                });
+
+        });
+        _expiryTimer.armPeriodic(interval);
+     }
+
+    // Stop the timer.
+    seastar::future<> stop() {
+        return _expiryTimer.stop()
+            .then([this] {
+                _list.clear();
+             });
+    }
+
+    // Move elment to the end of the time ordered list
+    void moveToEnd(ElemT& elem) {
+        // The list is supposed to be ordered by time, as it only checks front
+        // element for expiry. Adding smaller time at end
+        // indicates logic error somewhere.
+        K2ASSERT(log::common, elem.expiry() >= _list.back().expiry(), "too small ts");
+        if (((elem.*Field).is_linked())) _list.erase(_list.iterator_to(elem));
+        _list.push_back(elem);
+    }
+
+    void erase(ElemT& elem) {
+        if (!((elem.*Field).is_linked())) return;
+        _list.erase(_list.iterator_to(elem));
+    }
+
+    void add(ElemT& elem) {
+        _list.push_back(elem);
+    }
+
+
+private:
+    typedef nsbi::list<ElemT, nsbi::member_hook<ElemT, nsbi::list_member_hook<>, Field>> IntrusiveList;
+    IntrusiveList _list;
+    // Expiry checks are driven off single timer.
+    PeriodicTimer _expiryTimer;
+};
+}

--- a/src/k2/common/Log.h
+++ b/src/k2/common/Log.h
@@ -1,0 +1,29 @@
+/*
+MIT License
+
+Copyright(c) 2022 Futurewei Cloud
+
+    Permission is hereby granted,
+    free of charge, to any person obtaining a copy of this software and associated documentation files(the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and / or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions :
+
+    The above copyright notice and this permission notice shall be included in all copies
+    or
+    substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS",
+    WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+    DAMAGES OR OTHER
+    LIABILITY,
+    WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+*/
+#pragma once
+
+#include <k2/logging/Log.h>
+
+namespace k2::log {
+inline thread_local k2::logging::Logger common("k2::common");
+}

--- a/src/k2/cpo/service/Service.h
+++ b/src/k2/cpo/service/Service.h
@@ -79,7 +79,7 @@ private:
     int _makeHashPartitionMap(dto::Collection& collection, uint32_t numNodes);
     int _makeRangePartitionMap(dto::Collection& collection, const std::vector<String>& rangeEnds);
     seastar::future<bool> _assignAllTSOs();
-    seastar::future<> _assignTSO(const String &ep, size_t tsoID, int retry);
+    seastar::future<> _assignTSO(const String &ep, size_t tsoID);
     seastar::future<> _doAssignTSO(const String &ep, size_t tsoID);
     // Collection name -> schemas
     std::unordered_map<String, std::vector<dto::Schema>> schemas;

--- a/src/k2/cpo/service/Service.h
+++ b/src/k2/cpo/service/Service.h
@@ -59,11 +59,12 @@ private:
     String _getCollectionPath(String name);
     String _getPersistenceClusterPath(String clusterName);
     String _getSchemasPath(String collectionName);
+    seastar::future<> _doAssignCollection(dto::AssignmentCreateRequest request, const String &name, const String &ep);
     void _assignCollection(dto::Collection& collection);
     seastar::future<bool> _offloadCollection(dto::Collection& collection);
     ConfigDuration _assignTimeout{"assignment_timeout", 10ms};
     ConfigDuration _collectionHeartbeatDeadline{"txn_heartbeat_deadline", 100ms};
-    ConfigVar<int> _maxAssignRetries{"max_assign_retries", 3};
+    ConfigVar<int> _maxAssignRetries{"max_assign_retries", 5};
 
     std::unordered_map<String, seastar::future<>> _assignments;
     std::unordered_map<String, std::vector<dto::PartitionMetdataRecord>> _metadataRecords;

--- a/src/k2/cpo/service/Service.h
+++ b/src/k2/cpo/service/Service.h
@@ -59,7 +59,7 @@ private:
     String _getCollectionPath(String name);
     String _getPersistenceClusterPath(String clusterName);
     String _getSchemasPath(String collectionName);
-    seastar::future<> _doAssignCollection(dto::AssignmentCreateRequest request, const String &name, const String &ep);
+    seastar::future<> _doAssignCollection(dto::AssignmentCreateRequest &request, const String &name, const String &ep);
     void _assignCollection(dto::Collection& collection);
     seastar::future<bool> _offloadCollection(dto::Collection& collection);
     ConfigDuration _assignTimeout{"assignment_timeout", 10ms};

--- a/src/k2/httpproxy/HTTPProxy.cpp
+++ b/src/k2/httpproxy/HTTPProxy.cpp
@@ -38,22 +38,27 @@ static const inline auto Txn_S410_Gone = sh::Statuses::S410_Gone("transaction do
 static const inline auto Query_S410_Gone = sh::Statuses::S410_Gone("Query does not exist");
 
 void _shdRecToK2(shd::SKVRecord& shdrec, dto::SKVRecord& k2rec) {
-    shdrec.visitRemainingFields([&k2rec](const auto&, auto&& value) mutable {
-        if (value) {
-            using T = typename std::remove_reference_t<decltype(value)>::value_type;
-            if constexpr (std::is_same_v<T, shd::FieldType>) {
-                auto kval = static_cast<dto::FieldType>(to_integral(*value));
-                k2rec.serializeNext<dto::FieldType>(kval);
-            } else if constexpr (std::is_same_v<T, sh::String>) {
-                String k2str(value->data(), value->size());
-                k2rec.serializeNext<String>(std::move(k2str));
+    uint32_t serializedCursor = shdrec.storage.serializedCursor;
+    for (uint32_t field = 0; field < serializedCursor; ++field) {
+        shdrec.visitNextField([&k2rec](const auto&, auto&& value) {
+            if (value) {
+                using T = typename std::remove_reference_t<decltype(value)>::value_type;
+                if constexpr (std::is_same_v<T, shd::FieldType>) {
+                    auto kval = static_cast<dto::FieldType>(to_integral(*value));
+                    k2rec.serializeNext<dto::FieldType>(kval);
+                } else if constexpr (std::is_same_v<T, sh::String>) {
+                    String k2str(value->data(), value->size());
+                    k2rec.serializeNext<String>(std::move(k2str));
+                } else {
+                    k2rec.serializeNext<T>(*value);
+                }
             } else {
-                k2rec.serializeNext<T>(*value);
+                k2rec.serializeNull();
             }
-        } else {
-            k2rec.serializeNull();
-        }
-    });
+        });
+    }
+
+    shdrec.seekField(0);
     k2rec.seekField(0);
 }
 
@@ -307,7 +312,6 @@ HTTPProxy::_handleGetSchema(shd::GetSchemaRequest&& request) {
 }
 
 void HTTPProxy::shdStorageToK2Record(const sh::String& collectionName, shd::SKVRecord::Storage&& key, dto::SKVRecord& k2record) {
-    if (key.fieldData.size() == 0) return;
     auto shdSchema = getSchemaFromCache(collectionName, k2record.schema);
     shd::SKVRecord shdrecord(collectionName, shdSchema, std::move(key), true);
     _shdRecToK2(shdrecord, k2record);

--- a/src/k2/httpproxy/HTTPProxy.h
+++ b/src/k2/httpproxy/HTTPProxy.h
@@ -71,6 +71,13 @@ private:
     seastar::future<std::tuple<sh::Status, sh::dto::WriteResponse>>
         _handleWrite(sh::dto::WriteRequest&& request);
 
+    seastar::future<std::tuple<sh::Status, shd::WriteResponse>>
+        _handleWrite(K2TxnHandle& txn, shd::WriteRequest&& request, dto::SKVRecord&& k2record);
+
+    seastar::future<std::tuple<sh::Status, shd::WriteResponse>>
+        _handlePartialUpdate(K2TxnHandle& txn, shd::WriteRequest&& request, dto::SKVRecord&& k2record);
+
+
     seastar::future<std::tuple<sh::Status, sh::dto::ReadResponse>>
         _handleRead(sh::dto::ReadRequest&& request);
 

--- a/src/k2/module/k23si/Module.cpp
+++ b/src/k2/module/k23si/Module.cpp
@@ -424,6 +424,9 @@ seastar::future<> K23SIPartitionModule::gracefulStop() {
             return _indexer.stop();
         })
         .then([this] {
+            if (_persistence == nullptr) {
+                return seastar::make_ready_future();
+            }
             return _persistence->stop();
         })
         .then([this] {

--- a/src/k2/module/k23si/Module.cpp
+++ b/src/k2/module/k23si/Module.cpp
@@ -1193,7 +1193,10 @@ K23SIPartitionModule::handleTxnEnd(dto::K23SITxnEndRequest&& request) {
         K2LOG_D(log::skvsvr, "transaction end too old for txn={}", request.mtr);
         return RPCResponse(dto::K23SIStatus::RefreshCollection("collection refresh needed in end"), dto::K23SITxnEndResponse{});
     }
-
+    if (!_validateRetentionWindow(request.mtr.timestamp)) {
+        // the request is outside the retention window
+        return RPCResponse(dto::K23SIStatus::AbortRequestTooOld("transaction too old in end"), dto::K23SITxnEndResponse());
+    }
     return _txnMgr.endTxn(std::move(request));
 }
 

--- a/src/k2/module/k23si/Module.cpp
+++ b/src/k2/module/k23si/Module.cpp
@@ -1476,4 +1476,7 @@ seastar::future<> K23SIPartitionModule::_recovery() {
     return seastar::make_ready_future();
 }
 
+dto::OwnerPartition& K23SIPartitionModule::getOwnerPartition() {
+    return this->_partition;
+}
 }  // ns k2

--- a/src/k2/module/k23si/Module.h
+++ b/src/k2/module/k23si/Module.h
@@ -100,6 +100,8 @@ public:
     seastar::future<std::tuple<Status, dto::K23SIInspectAllKeysResponse>>
     handleInspectAllKeys(dto::K23SIInspectAllKeysRequest&& request);
 
+    dto::OwnerPartition& getOwnerPartition();
+
 private: // methods
     // this method executes a push operation at the TRH for the given incumbent in order to
     // determine if the challengerMTR should be allowed to proceed.

--- a/src/k2/transport/RetryStrategy.cpp
+++ b/src/k2/transport/RetryStrategy.cpp
@@ -33,7 +33,7 @@ ExponentialBackoffStrategy& ExponentialBackoffStrategy::withRetries(int retries)
 }
 
 // Set the exponential increase rate
-ExponentialBackoffStrategy& ExponentialBackoffStrategy::withRate(int rate) {
+ExponentialBackoffStrategy& ExponentialBackoffStrategy::withRate(double rate) {
     K2LOG_D(log::tx, "rate: {}", rate);
     _rate = rate;
     return *this;

--- a/src/k2/transport/RetryStrategy.h
+++ b/src/k2/transport/RetryStrategy.h
@@ -25,6 +25,7 @@ Copyright(c) 2020 Futurewei Cloud
 
 // third-party
 #include <seastar/core/future.hh>
+#include <seastar/core/sleep.hh>
 #include <seastar/core/future-util.hh>
 
 // k2
@@ -51,7 +52,7 @@ public:
     ExponentialBackoffStrategy& withRetries(int retries);
 
     // Set the exponential increase rate
-    ExponentialBackoffStrategy& withRate(int rate);
+    ExponentialBackoffStrategy& withRate(double rate);
 
     // Set the desired starting value
     ExponentialBackoffStrategy& withStartTimeout(Duration startTimeout);
@@ -73,9 +74,10 @@ public: // API
             [this] { return _success || this->_try >= this->_retries; },
             [this, func=std::move(func), resultPtr] ()mutable{
                 this->_try++;
-                this->_currentTimeout*=this->_try;
+                this->_currentTimeout = Duration((uint64_t)(nsec(_currentTimeout).count() * _rate));
+                k2::Deadline deadline(this->_currentTimeout);
                 K2LOG_D(log::tx, "running try {}, with timeout {}ms", this->_try, k2::msec(_currentTimeout).count());
-                return func(this->_retries - this->_try, this->_currentTimeout).
+                return func(this->_retries - this->_try, deadline.getRemaining()).
                     handle_exception_type([this](RPCDispatcher::DispatcherShutdown&) {
                         K2LOG_D(log::tx, "Dispatcher has shut down. Stopping retry");
                         this->_try = this->_retries; // ff to the last retry
@@ -86,13 +88,16 @@ public: // API
                         this->_try = this->_retries; // ff to the last retry
                         return seastar::make_exception_future<>(RPCDispatcher::RequestTimeoutException());
                     }).
-                    then_wrapped([this, resultPtr](auto&& fut) {
+                    then_wrapped([this, resultPtr, deadline](auto&& fut) {
                         // the func future is done.
                         // if we exited with success, then we shouldn't run anymore
                         _success = !fut.failed();
                         resultPtr->ignore_ready_future(); // ignore previous result stored in the result
                         (*resultPtr.get()) = std::move(fut);
                         K2LOG_D(log::tx, "round ended with success={}", _success);
+                        if (!_success && !deadline.isOver()) {
+                            return seastar::sleep(deadline.getRemaining());
+                        }
                         return seastar::make_ready_future<>();
                     });
         }).then_wrapped([this, resultPtr](auto&& fut){
@@ -108,7 +113,7 @@ private: // fields
     // which try we're on
     int _try{0};
     // the exponential growth rate
-    int _rate{5};
+    double _rate{2};
     // the value of the current timeout
     Duration _currentTimeout{1us};
     // indicate if the latest round has succeeded (so that we can break the retry loop)

--- a/src/k2/tso/client/Client.cpp
+++ b/src/k2/tso/client/Client.cpp
@@ -59,9 +59,9 @@ seastar::future<> TSOClient::start() {
     return bootstrap(_cpoEndpoint());
 }
 
-seastar::future<> TSOClient::_doGetTSOEndpoints(dto::GetTSOEndpointsRequest& request, TXEndpoint cpoEP) {
+seastar::future<> TSOClient::_doGetTSOEndpoints(dto::GetTSOEndpointsRequest& request, TXEndpoint cpoEP, Duration timeout) {
     return RPC().callRPC<dto::GetTSOEndpointsRequest, dto::GetTSOEndpointsResponse>
-            (dto::Verbs::CPO_GET_TSO_ENDPOINTS, request, cpoEP, 1s)
+            (dto::Verbs::CPO_GET_TSO_ENDPOINTS, request, cpoEP, timeout)
     .then([this](auto&& response) {
         auto& [status, resp] = response;
         if (!status.is2xxOK() || resp.endpoints.size() == 0) {
@@ -81,7 +81,7 @@ seastar::future<> TSOClient::bootstrap(const String& cpoEndpoint) {
     _stopped = false;
     _registerMetrics();
     // retry TSO connection if cannot be established
-    return seastar::do_with(ExponentialBackoffStrategy().withRetries(_maxTSORetries()).withStartTimeout(1s).withRate(5), [&request,cpoEndpoint,this](auto &retryStrategy) {
+    return seastar::do_with(ExponentialBackoffStrategy().withRetries(_maxTSORetries()).withStartTimeout(_tsoTimeout()).withRate(2), [&request,cpoEndpoint,this](auto &retryStrategy) {
         return retryStrategy.run([&request,cpoEndpoint,this] (size_t retriesLeft, Duration timeout) {
             K2LOG_I(log::tsoclient, "Sending GET_TSO_ENDPOINTS with retriesLeft={}, and timeout={}, with {}", retriesLeft, timeout, cpoEndpoint);
             auto cpoEP = RPC().getTXEndpoint(cpoEndpoint);
@@ -89,7 +89,7 @@ seastar::future<> TSOClient::bootstrap(const String& cpoEndpoint) {
                 K2LOG_E(log::tsoclient, "CPO endpoint is invalid: {}", cpoEndpoint);
                 return seastar::make_exception_future<>(std::runtime_error("Could not bootstrap TSO client"));
             }
-            return _doGetTSOEndpoints(request, *cpoEP);
+            return _doGetTSOEndpoints(request, *cpoEP, timeout);
         })
         .handle_exception([cpoEndpoint,this] (auto exc) {
             K2LOG_W_EXC(log::tsoclient, exc, "Failed to assign TSO for endpoint after retry: {}", cpoEndpoint);
@@ -169,7 +169,7 @@ seastar::future<> TSOClient::_getServiceNodeURLs(Duration timeout){
 seastar::future<> TSOClient::_discoverServiceNodes() {
     OperationLatencyReporter reporter(_discoveryLatency);  // for reporting metrics
 
-    return seastar::do_with(ExponentialBackoffStrategy().withRetries(5).withStartTimeout(1s).withRate(5), [this](auto& retryStrategy) {
+    return seastar::do_with(ExponentialBackoffStrategy().withRetries(_maxTSORetries()).withStartTimeout(_tsoTimeout()).withRate(2), [this](auto& retryStrategy) {
         return retryStrategy.run([this] (size_t retriesLeft, Duration timeout) {
             if (_stopped) {
                 K2LOG_I(log::tsoclient, "Stopping retry since we were stopped");
@@ -211,7 +211,7 @@ seastar::future<Timestamp> TSOClient::getTimestamp() {
 seastar::future<Timestamp> TSOClient::_getTimestampWithLatency(OperationLatencyReporter&& reporter) {
     // ExponentialBackoffStrategy doesn't support returning values.
     return seastar::do_with(
-        ExponentialBackoffStrategy().withRetries(3).withStartTimeout(100ms).withRate(5),
+        ExponentialBackoffStrategy().withRetries(5).withStartTimeout(10ms).withRate(2),
         GetTimestampRequest{},
         Timestamp(),
         [this] (auto& retryStrategy, auto& request, auto& timestamp) mutable {

--- a/src/k2/tso/client/Client.h
+++ b/src/k2/tso/client/Client.h
@@ -34,6 +34,7 @@ Copyright(c) 2020 Futurewei Cloud
 #include <k2/logging/Chrono.h>
 #include <k2/dto/MessageVerbs.h>
 #include <k2/dto/TSO.h>
+#include <k2/dto/ControlPlaneOracle.h>
 
 namespace k2::tso {
 namespace log {
@@ -72,8 +73,14 @@ private: // methods
     // Helper used to obtain the timestamp from server and report latency
     seastar::future<dto::Timestamp> _getTimestampWithLatency(OperationLatencyReporter&& reporter);
 
+    // Helper to send the RPC GET_TSO_ENDPOINT
+    seastar::future<> _doGetTSOEndpoints(dto::GetTSOEndpointsRequest& request, TXEndpoint cpoEP);
+
 private: // fields
     ConfigVar<String> _cpoEndpoint{"cpo", ""};
+
+    // Config variable for retring TSO connections
+    ConfigVar<int> _maxTSORetries{"max_tso_retries", 10};
 
     // to tell if we've been signaled to stop
     bool _stopped{true};

--- a/src/k2/tso/client/Client.h
+++ b/src/k2/tso/client/Client.h
@@ -81,7 +81,7 @@ private: // fields
 
     // Config variable for retring TSO connections
     ConfigVar<int> _maxTSORetries{"max_tso_retries", 10};
-    ConfigDuration _tsoTimeout{"tso_timeout", 1ms};
+    ConfigDuration _tsoTimeout{"tso_timeout", 10ms};
 
     // to tell if we've been signaled to stop
     bool _stopped{true};

--- a/src/k2/tso/client/Client.h
+++ b/src/k2/tso/client/Client.h
@@ -74,13 +74,14 @@ private: // methods
     seastar::future<dto::Timestamp> _getTimestampWithLatency(OperationLatencyReporter&& reporter);
 
     // Helper to send the RPC GET_TSO_ENDPOINT
-    seastar::future<> _doGetTSOEndpoints(dto::GetTSOEndpointsRequest& request, TXEndpoint cpoEP);
+    seastar::future<> _doGetTSOEndpoints(dto::GetTSOEndpointsRequest& request, TXEndpoint cpoEP, Duration timeout);
 
 private: // fields
     ConfigVar<String> _cpoEndpoint{"cpo", ""};
 
     // Config variable for retring TSO connections
     ConfigVar<int> _maxTSORetries{"max_tso_retries", 10};
+    ConfigDuration _tsoTimeout{"tso_timeout", 1ms};
 
     // to tell if we've been signaled to stop
     bool _stopped{true};

--- a/src/k2/tso/client/Client.h
+++ b/src/k2/tso/client/Client.h
@@ -74,7 +74,7 @@ private: // methods
     seastar::future<dto::Timestamp> _getTimestampWithLatency(OperationLatencyReporter&& reporter);
 
     // Helper to send the RPC GET_TSO_ENDPOINT
-    seastar::future<> _doGetTSOEndpoints(dto::GetTSOEndpointsRequest& request, TXEndpoint cpoEP, Duration timeout);
+    seastar::future<> _doGetTSOEndpoints(dto::GetTSOEndpointsRequest &request, std::unique_ptr<TXEndpoint> cpoEP, Duration timeout);
 
 private: // fields
     ConfigVar<String> _cpoEndpoint{"cpo", ""};

--- a/src/skvhttpclient/src/skvhttp/client/SKVClient.cpp
+++ b/src/skvhttpclient/src/skvhttp/client/SKVClient.cpp
@@ -101,7 +101,7 @@ boost::future<Response<>> TxnHandle::write(dto::SKVRecord& record, bool erase, d
         .isDelete = erase,
         .precondition = precondition,
         .value = record.storage.share(),
-        .fieldsForPartialUpdate = std::vector<uint32_t>{}
+        .fieldsForPartialUpdate = std::vector<uint32_t>{},
     };
 
     return _client->_HTTPClient.POST<dto::WriteRequest>("/api/Write", std::move(request));

--- a/src/skvhttpclient/src/skvhttp/client/SKVClient.cpp
+++ b/src/skvhttpclient/src/skvhttp/client/SKVClient.cpp
@@ -89,6 +89,7 @@ boost::future<Response<TxnHandle>> Client::beginTxn(dto::TxnOptions options) {
     return _HTTPClient.POST<dto::TxnBeginRequest, dto::TxnBeginResponse>("/api/TxnBegin", std::move(request)).then([this](auto&& futResp) {
         auto&& [status, resp] = futResp.get();
         TxnHandle txn(this, resp.timestamp);
+        K2LOG_D(log::shclient, "created txn: {}", txn);
         return Response<TxnHandle>(std::move(status), std::move(txn));
     });
 }
@@ -141,7 +142,7 @@ boost::future<Response<dto::QueryRequest>> TxnHandle::createQuery(dto::SKVRecord
     if (startKey.collectionName != endKey.collectionName || startKey.schema->name != endKey.schema->name) {
         return MakeResponse(Statuses::S400_Bad_Request("Start and end keys must have same collection and schema"), dto::QueryRequest{});
     }
-    
+
     dto::CreateQueryRequest request {
         .timestamp = _id,
         .collectionName = startKey.collectionName,

--- a/src/skvhttpclient/src/skvhttp/client/SKVClient.cpp
+++ b/src/skvhttpclient/src/skvhttp/client/SKVClient.cpp
@@ -108,10 +108,6 @@ boost::future<Response<>> TxnHandle::write(dto::SKVRecord& record, bool erase, d
 }
 
 boost::future<Response<dto::SKVRecord>> TxnHandle::read(dto::SKVRecord record) {
-    if (record.fieldCursor != record.schema->fields.size()) {
-        return MakeResponse(Statuses::S400_Bad_Request("All fields of record must be serialized for read request"), dto::SKVRecord{});
-    }
-
     dto::ReadRequest request{
         .timestamp = _id,
         .collectionName = record.collectionName,

--- a/src/skvhttpclient/src/skvhttp/client/SKVClient.h
+++ b/src/skvhttpclient/src/skvhttp/client/SKVClient.h
@@ -143,9 +143,10 @@ public:
                                        dto::ExistencePrecondition precondition=dto::ExistencePrecondition::None);
     boost::future<Response<>> partialUpdate(dto::SKVRecord& record, std::vector<String> fieldNamesForUpdate);
 
-    boost::future<Response<dto::QueryResponse>> query(dto::QueryRequest& query);
-    boost::future<Response<dto::QueryRequest>> createQuery(const String& collectionName, const String& schemaName);
-
+    boost::future<Response<dto::QueryResponse>> query(dto::QueryRequest query);
+    boost::future<Response<dto::QueryRequest>> createQuery(dto::SKVRecord& startKey, dto::SKVRecord& endKey, dto::expression::Expression&& filter=dto::expression::Expression{},
+                                                           std::vector<String>&& projection=std::vector<String>{}, int32_t recordLimit=-1, bool reverseDirection=false, bool includeVersionMismatch=false);
+ 
 private:
     Client* _client;
     dto::Timestamp _id;

--- a/src/skvhttpclient/src/skvhttp/dto/SKVRecord.cpp
+++ b/src/skvhttpclient/src/skvhttp/dto/SKVRecord.cpp
@@ -50,6 +50,7 @@ void SKVRecordBuilder::serializeNull() {
     }
 
     _record.storage.excludedFields[_record.fieldCursor] = true;
+    _record.storage.serializedCursor++;
     ++_record.fieldCursor;
 }
 
@@ -209,17 +210,19 @@ dto::Key SKVRecord::getKey() {
 
 SKVRecord::Storage SKVRecord::Storage::share() {
     return SKVRecord::Storage {
-        excludedFields,
-        fieldData,
-        schemaVersion
+        .excludedFields = excludedFields,
+        .serializedCursor = serializedCursor,
+        .fieldData = fieldData,
+        .schemaVersion = schemaVersion
     };
 }
 
 SKVRecord::Storage SKVRecord::Storage::copy() {
     return SKVRecord::Storage {
-        excludedFields,
-        fieldData.copy(),
-        schemaVersion
+        .excludedFields = excludedFields,
+        .serializedCursor = serializedCursor,
+        .fieldData = fieldData.copy(),
+        .schemaVersion = schemaVersion
     };
 }
 

--- a/src/skvhttpclient/src/skvhttp/dto/SKVRecord.h
+++ b/src/skvhttpclient/src/skvhttp/dto/SKVRecord.h
@@ -241,8 +241,10 @@ public:
 
     // This method returns the built record
     SKVRecord build() {
-        K2ASSERT(log::dto, _writer.flush(_record.storage.fieldData), "error during record packing");
+        auto flushResult = _writer.flush(_record.storage.fieldData);
+        K2ASSERT(log::dto, flushResult, "error during record packing");
         _record.reader = MPackReader(_record.storage.fieldData);
+        _record.seekField(0);
         return std::move(_record);
     }
 

--- a/src/skvhttpclient/src/skvhttp/dto/SKVRecord.h
+++ b/src/skvhttpclient/src/skvhttp/dto/SKVRecord.h
@@ -130,12 +130,15 @@ public:
     struct Storage {
         // Bitmap of fields that are excluded because they are optional or this is for a partial update
         std::vector<bool> excludedFields;
+        // This is different from excludedFields above and needed because some use cases of the SKVRecord
+        // (e.g. specifying a prefix scan for queries) will not completely serialize the record
+        uint32_t serializedCursor = 0;
         Binary fieldData;
         uint32_t schemaVersion = 0;
 
         Storage share();
         Storage copy();
-        K2_SERIALIZABLE_FMT(Storage, excludedFields, fieldData, schemaVersion);
+        K2_SERIALIZABLE_FMT(Storage, excludedFields, serializedCursor, fieldData, schemaVersion);
     };
 
     // We expose the storage in case the user wants to write it to file or otherwise
@@ -230,6 +233,7 @@ public:
         }
 
         _writer.write(field);
+        _record.storage.serializedCursor++;
         ++_record.fieldCursor;
     }
 

--- a/src/skvhttpclient/test/ClientIntegrationTest.cpp
+++ b/src/skvhttpclient/test/ClientIntegrationTest.cpp
@@ -107,7 +107,6 @@ void testRead() {
   dto::SKVRecordBuilder builder(collectionName, schemaPtr);
   builder.serializeNext<std::string>("A");
   builder.serializeNext<std::string>("B");
-  builder.serializeNull();
   auto&& [readStatus, readRecord] = txn.read(builder.build()).get();
   K2EXPECT(k2::log::httpclient, readStatus.is2xxOK(), true);
 

--- a/test/cpo/CMakeLists.txt
+++ b/test/cpo/CMakeLists.txt
@@ -3,4 +3,4 @@ file(GLOB SOURCES "*.cpp")
 
 add_executable (cpo_test ${HEADERS} ${SOURCES})
 
-target_link_libraries (cpo_test PRIVATE appbase Seastar::seastar dto)
+target_link_libraries (cpo_test PRIVATE appbase Seastar::seastar dto tso_client)

--- a/test/cpo/CPOTest.cpp
+++ b/test/cpo/CPOTest.cpp
@@ -53,9 +53,6 @@ seastar::future<> CPOTest::start() {
     // let start() finish and then run the tests
     _testTimer.set_callback([this, configEp] {
         _testFuture = seastar::make_ready_future()
-        .then([this, configEp] {
-            return _tsoClient.bootstrap(configEp());
-        })
         .then([this] {
             K2LOG_I(log::cpotest, "Getting the timestamp...");
             return _tsoClient.getTimestamp();

--- a/test/cpo/CPOTest.cpp
+++ b/test/cpo/CPOTest.cpp
@@ -31,7 +31,7 @@ Copyright(c) 2020 Futurewei Cloud
 
 using namespace k2;
 
-CPOTest::CPOTest():_tsoClient(AppBase().getDist<tso::TSOClient>().local()) {
+CPOTest::CPOTest() {
     K2LOG_I(log::cpotest, "ctor");
 }
 
@@ -47,6 +47,7 @@ seastar::future<> CPOTest::gracefulStop() {
 seastar::future<> CPOTest::start() {
 
     K2LOG_I(log::cpotest, "start");
+    _tsoClient = AppBase().getDist<tso::TSOClient>().local_shared();
     ConfigVar<String> configEp("cpo_endpoint");
     _cpoEndpoint = RPC().getTXEndpoint(configEp());
 
@@ -55,7 +56,7 @@ seastar::future<> CPOTest::start() {
         _testFuture = seastar::make_ready_future()
         .then([this] {
             K2LOG_I(log::cpotest, "Getting the timestamp...");
-            return _tsoClient.getTimestamp();
+            return _tsoClient->getTimestamp();
         })
         .then([this] (dto::Timestamp&&) {
             return runTest1();

--- a/test/cpo/CPOTest.h
+++ b/test/cpo/CPOTest.h
@@ -24,6 +24,10 @@ Copyright(c) 2020 Futurewei Cloud
 #pragma once
 #include <k2/appbase/Appbase.h>
 #include <k2/appbase/AppEssentials.h>
+#include <k2/dto/Timestamp.h>
+#include <k2/tso/client/Client.h>
+
+
 namespace k2::log {
 inline thread_local k2::logging::Logger cpotest("k2::cpotest");
 }
@@ -53,4 +57,5 @@ private:
     std::unique_ptr<k2::TXEndpoint> _cpoEndpoint;
     seastar::future<> _testFuture = seastar::make_ready_future();
     seastar::timer<> _testTimer;
+    k2::tso::TSOClient& _tsoClient;
 };

--- a/test/cpo/CPOTest.h
+++ b/test/cpo/CPOTest.h
@@ -57,5 +57,5 @@ private:
     std::unique_ptr<k2::TXEndpoint> _cpoEndpoint;
     seastar::future<> _testFuture = seastar::make_ready_future();
     seastar::timer<> _testTimer;
-    k2::tso::TSOClient& _tsoClient;
+    seastar::shared_ptr<k2::tso::TSOClient> _tsoClient;
 };

--- a/test/cpo/Main.cpp
+++ b/test/cpo/Main.cpp
@@ -28,7 +28,7 @@ Copyright(c) 2020 Futurewei Cloud
 int main(int argc, char** argv) {
     k2::App app("CPOTest");
     app.addOptions()("cpo", bpo::value<k2::String>(), "The endpoint of the CPO service");
-    app.addApplet<CPOTest>();
     app.addApplet<k2::tso::TSOClient>();
+    app.addApplet<CPOTest>();
     return app.start(argc, argv);
 }

--- a/test/cpo/Main.cpp
+++ b/test/cpo/Main.cpp
@@ -27,7 +27,7 @@ Copyright(c) 2020 Futurewei Cloud
 
 int main(int argc, char** argv) {
     k2::App app("CPOTest");
-    app.addOptions()("cpo_endpoint", bpo::value<k2::String>(), "The endpoint of the CPO service");
+    app.addOptions()("cpo", bpo::value<k2::String>(), "The endpoint of the CPO service");
     app.addApplet<CPOTest>();
     app.addApplet<k2::tso::TSOClient>();
     return app.start(argc, argv);

--- a/test/cpo/Main.cpp
+++ b/test/cpo/Main.cpp
@@ -22,11 +22,13 @@ Copyright(c) 2020 Futurewei Cloud
 */
 
 #include <k2/appbase/Appbase.h>
+#include <k2/tso/client/Client.h>
 #include "CPOTest.h"
 
 int main(int argc, char** argv) {
     k2::App app("CPOTest");
     app.addOptions()("cpo_endpoint", bpo::value<k2::String>(), "The endpoint of the CPO service");
     app.addApplet<CPOTest>();
+    app.addApplet<k2::tso::TSOClient>();
     return app.start(argc, argv);
 }

--- a/test/dto/PartitionTest.cpp
+++ b/test/dto/PartitionTest.cpp
@@ -57,8 +57,7 @@ public:  // application lifespan
             K2LOG_I(log::ptest, "Getting the timestamp...");
             return getTimeNow();
         })
-        .then([this] (dto::Timestamp&& ts) {
-            K2LOG_I(log::ptest, "The Test starts with ts: {}", ts.print());
+        .then([this] (dto::Timestamp&&) {
             return _client.start();
         })
         .then([this] {

--- a/test/integration/failing_test_logstream.sh
+++ b/test/integration/failing_test_logstream.sh
@@ -26,6 +26,6 @@ function finish {
 }
 trap finish EXIT
 
-sleep 2
+sleep 1
 
 ./build/test/plog/logstream_test ${COMMON_ARGS} -m 500M --cpo_url ${CPO} --tcp_endpoints 12345 --plog_server_endpoints tcp+k2rpc://0.0.0.0:10000 tcp+k2rpc://0.0.0.0:10001 tcp+k2rpc://0.0.0.0:10002 --prometheus_port=63002

--- a/test/integration/skvclient.py
+++ b/test/integration/skvclient.py
@@ -186,7 +186,7 @@ class Txn:
 
         cname, sname, storage = resp
 
-        status, schema = self.client.get_schema(cname, sname, storage[2])
+        status, schema = self.client.get_schema(cname, sname, storage[3])
         if not status.is2xxOK():
             return status, None
 
@@ -216,7 +216,7 @@ class Txn:
             return status, None, None
         records = []
         for storage in result[1]:
-            status, schema = self.client.get_schema(query.cname, query.sname, storage[2])
+            status, schema = self.client.get_schema(query.cname, query.sname, storage[3])
             if not status.is2xxOK():
                 return status, None, None
             record = schema.parse_read(storage, self.timestamp)
@@ -261,7 +261,7 @@ class Record:
 
     def serialize(self):
         fieldData = b''.join([msgpack.packb(field) for field in self._posFields])
-        return [self.excludedFields, fieldData, self.schemaVersion]
+        return [self.excludedFields, len(self.fields.__dict__), fieldData, self.schemaVersion]
 
 class SchemaField:
     def __init__(self, type: FieldType, name: str,
@@ -300,6 +300,22 @@ class Schema:
                 rec.fields.__dict__[dname] = None
         return rec
 
+    # For use in creating key records for a prefix query. The difference is fields that are not set
+    # are not set in excludedFields and are not set to None
+    def make_prefix_record(self, **dataFields):
+        rec = Record(self.name, self.version)
+        for i,field in enumerate(self.fields):
+            dname = field.name.decode('ascii')
+            if dname in dataFields:
+                fieldValue = dataFields.get(dname)
+                rec._posFields.append(fieldValue)
+                rec.fields.__dict__[dname] = fieldValue
+            else:
+                break
+        if len(rec.fields.__dict__) != len(dataFields):
+            raise ValueError("dataFields given are not a prefix")
+        return rec
+
     def parse_read(self, storage, timestamp):
         rec = Record(self.name, self.version)
         rec.timestamp = timestamp
@@ -308,7 +324,7 @@ class Schema:
         excl = rec.excludedFields if rec.excludedFields else [False] * len(self.fields)
 
         unp = msgpack.Unpacker()
-        unp.feed(storage[1])
+        unp.feed(storage[2])
         for i,field in enumerate(self.fields):
             dname = field.name.decode('ascii')
             fv = None

--- a/test/integration/test_3si_txn.sh
+++ b/test/integration/test_3si_txn.sh
@@ -45,6 +45,6 @@ function finish {
 }
 trap finish EXIT
 
-sleep 2
+sleep 1
 
-./build/test/k23si/3si_txn_test ${COMMON_ARGS} --cpo ${CPO} --prometheus_port 63100
+./build/test/k23si/3si_txn_test ${COMMON_ARGS} --cpo ${CPO} --prometheus_port 63100 --log_level=Debug k2::transport=Info k2::tsoclient=Info

--- a/test/integration/test_3si_txn.sh
+++ b/test/integration/test_3si_txn.sh
@@ -47,4 +47,4 @@ trap finish EXIT
 
 sleep 1
 
-./build/test/k23si/3si_txn_test ${COMMON_ARGS} --cpo ${CPO} --prometheus_port 63100 --log_level=Debug k2::transport=Info k2::tsoclient=Info
+./build/test/k23si/3si_txn_test ${COMMON_ARGS} --cpo ${CPO} --prometheus_port 63100

--- a/test/integration/test_collection.sh
+++ b/test/integration/test_collection.sh
@@ -43,4 +43,6 @@ function finish {
 }
 trap finish EXIT
 
+sleep 1
+
 ./build/test/cpo/cpo_test ${COMMON_ARGS} --cpo ${CPO} --prometheus_port 63100

--- a/test/integration/test_collection.sh
+++ b/test/integration/test_collection.sh
@@ -43,6 +43,4 @@ function finish {
 }
 trap finish EXIT
 
-sleep 2
-
 ./build/test/cpo/cpo_test ${COMMON_ARGS} --cpo_endpoint ${CPO} --prometheus_port 63100

--- a/test/integration/test_collection.sh
+++ b/test/integration/test_collection.sh
@@ -43,4 +43,4 @@ function finish {
 }
 trap finish EXIT
 
-./build/test/cpo/cpo_test ${COMMON_ARGS} --cpo_endpoint ${CPO} --prometheus_port 63100
+./build/test/cpo/cpo_test ${COMMON_ARGS} --cpo ${CPO} --prometheus_port 63100

--- a/test/integration/test_heartbeat_monitor.sh
+++ b/test/integration/test_heartbeat_monitor.sh
@@ -41,6 +41,6 @@ function finish {
 }
 trap finish EXIT
 
-sleep 2
+sleep 1
 
 /build/test/integration/heartbeat_monitor.py --nodepool_pid=${nodepool_child_pid} --prometheus_port=63000

--- a/test/integration/test_http.py
+++ b/test/integration/test_http.py
@@ -27,9 +27,10 @@ SOFTWARE.
 import argparse, unittest, sys
 from skvclient import (CollectionMetadata, CollectionCapacity, SKVClient,
     HashScheme, StorageDriver, Schema, SchemaField, FieldType, TimeDelta,
-    Operation, Value, Expression)
+    Operation, Value, Expression, TxnOptions)
 import logging
 from copy import copy
+from time import sleep
 
 class TestHTTP(unittest.TestCase):
     args = None
@@ -222,7 +223,6 @@ class TestHTTP(unittest.TestCase):
         # Commit Txn 2, should succeed
         status = txn2.end()
         self.assertEqual(status.code, 200)
-
 
     def test_collection_schema_basic(self):
         test_coll =  b'HTTPProxy1'
@@ -476,6 +476,33 @@ class TestHTTP(unittest.TestCase):
         # Try to make record that is not a prefix, should be caught by python library
         with self.assertRaises(ValueError):
             bad_record = test_schema.make_prefix_record(partition1=b"h")
+
+    def test_txn_timeout(self):
+        # The tests assume that txn timeout is set to 100ms (httpproxy_txn_timeout)
+        # And periodic timer runs at 50ms interval (httpproxy_expiry_timer_interval)
+        # Begin Txn
+        status, txn = TestHTTP.cl.begin_txn()
+        self.assertTrue(status.is2xxOK())
+
+        # Sleep 160ms for txn to timeout
+        sleep(0.16)
+        status = txn.end()
+        self.assertEqual(status.code, 410)
+
+        status, txn = TestHTTP.cl.begin_txn()
+        self.assertTrue(status.is2xxOK())
+
+        # Sleep 80ms and write, it should succeed because within timeout
+        sleep(0.08)
+        record = TestHTTP.schema.make_record(partitionKey=b"ptest6", rangeKey=b"rtest6", data=b"data6")
+        status = txn.write(TestHTTP.cname, record)
+        self.assertTrue(status.is2xxOK())
+
+        # Sleep additional 80ms and commit, should succeed as timeout pushed back because of write
+        sleep(0.08)
+        # Commit
+        status = txn.end()
+        self.assertTrue(status.is2xxOK())
 
 '''
     def test_key_string(self):

--- a/test/integration/test_http.py
+++ b/test/integration/test_http.py
@@ -129,6 +129,28 @@ class TestHTTP(unittest.TestCase):
         status = txn.end()
         self.assertTrue(status.is2xxOK())
 
+        # Test partial update
+        # Begin Txn
+        status, txn = TestHTTP.cl.begin_txn()
+        self.assertTrue(status.is2xxOK())
+
+        # Write partial upate
+        record = TestHTTP.schema.make_record(partitionKey=b"test1pk", rangeKey=b"test1rk", data=b"mydata_update")
+        record.fieldsForPartialUpdate = [2]
+        status = txn.write(TestHTTP.cname, record)
+        self.assertTrue(status.is2xxOK())
+
+        # read data
+        status, resultRec = txn.read(TestHTTP.cname, record)
+        self.assertTrue(status.is2xxOK());
+        self.assertEqual(resultRec.fields.partitionKey, b"test1pk")
+        self.assertEqual(resultRec.fields.rangeKey, b"test1rk")
+        self.assertEqual(resultRec.fields.data, b"mydata_update")
+
+        # Commit
+        status = txn.end()
+        self.assertTrue(status.is2xxOK())
+
 
     def test_validation(self):
         record = TestHTTP.schema.make_record(partitionKey=b"test2pk", rangeKey=b"test1rk", data=b"mydata")

--- a/test/integration/test_http.py
+++ b/test/integration/test_http.py
@@ -418,6 +418,14 @@ class TestHTTP(unittest.TestCase):
         self.assertTrue(status.is2xxOK())
         self.assertEqual([r.data for r in records], [record1.data, record2.data])
 
+        # Prefix scan on first key field, should return record1 and 2
+        key = test_schema.make_prefix_record(partition=b"default")
+        status, query = txn.create_query(test_coll, test_schema.name, start = key, end = key)
+        self.assertTrue(status.is2xxOK(), msg=status.message)
+        status, records = txn.queryAll(query)
+        self.assertTrue(status.is2xxOK())
+        self.assertEqual([r.data for r in records], [record1.data, record2.data])
+
         # Query all, with reverse = True
         status, query = txn.create_query(test_coll, test_schema.name, reverse = True)
         self.assertTrue(status.is2xxOK())
@@ -464,6 +472,10 @@ class TestHTTP(unittest.TestCase):
 
         status = txn.end()
         self.assertTrue(status.is2xxOK())
+
+        # Try to make record that is not a prefix, should be caught by python library
+        with self.assertRaises(ValueError):
+            bad_record = test_schema.make_prefix_record(partition1=b"h")
 
 '''
     def test_key_string(self):

--- a/test/integration/test_http_client.sh
+++ b/test/integration/test_http_client.sh
@@ -53,7 +53,7 @@ function finish {
   echo ">>>> Test ${0} finished with code ${rv}"
 }
 trap finish EXIT
-sleep 2
+sleep 1
 
 echo ">>> Starting http test ..."
 PYTHONPATH=${PYTHONPATH}:./test/integration ./test/integration/test_http.py --http http://127.0.0.1:30000

--- a/test/integration/test_http_client.sh
+++ b/test/integration/test_http_client.sh
@@ -5,7 +5,7 @@ source ${topname}/common_defs.sh
 cd ${topname}/../..
 
 # start CPO
-./build/src/k2/cmd/controlPlaneOracle/cpo_main ${COMMON_ARGS} -c1 --tcp_endpoints ${CPO} 9001 --data_dir ${CPODIR} --prometheus_port 63000 --assignment_timeout=1s --txn_heartbeat_deadline=1s --nodepool_endpoints ${EPS[@]} --tso_endpoints ${TSO} --persistence_endpoints ${PERSISTENCE}&
+./build/src/k2/cmd/controlPlaneOracle/cpo_main ${COMMON_ARGS} -c1 --tcp_endpoints ${CPO} 9001 --data_dir ${CPODIR} --prometheus_port 63000 --assignment_timeout=1s --txn_heartbeat_deadline=1s --nodepool_endpoints ${EPS[@]} --tso_endpoints ${TSO} --tso_error_bound=100us --persistence_endpoints ${PERSISTENCE}&
 cpo_child_pid=$!
 
 # start nodepool

--- a/test/integration/test_http_client.sh
+++ b/test/integration/test_http_client.sh
@@ -22,7 +22,7 @@ tso_child_pid=$!
 
 sleep 1
 
-./build/src/k2/cmd/httpproxy/http_proxy ${COMMON_ARGS} -c1 --tcp_endpoints ${HTTP} --memory=1G --cpo ${CPO} &
+./build/src/k2/cmd/httpproxy/http_proxy ${COMMON_ARGS} -c1 --tcp_endpoints ${HTTP} --memory=1G --cpo ${CPO} --httpproxy_txn_timeout=100ms --httpproxy_expiry_timer_interval=50ms&
 http_child_pid=$!
 
 function finish {

--- a/test/integration/test_http_cpp_client.sh
+++ b/test/integration/test_http_cpp_client.sh
@@ -52,7 +52,7 @@ function finish {
   echo ">>>> Test ${0} finished with code ${rv}"
 }
 trap finish EXIT
-sleep 2
+sleep 1
 
 echo ">>> Starting http test ..."
 ./src/skvhttpclient/build/test/client_integration_test

--- a/test/integration/test_http_cpp_client.sh
+++ b/test/integration/test_http_cpp_client.sh
@@ -5,7 +5,7 @@ source ${topname}/common_defs.sh
 cd ${topname}/../..
 
 # start CPO
-./build/src/k2/cmd/controlPlaneOracle/cpo_main ${COMMON_ARGS} -c1 --tcp_endpoints ${CPO} 9001 --data_dir ${CPODIR} --prometheus_port 63000 --assignment_timeout=1s --txn_heartbeat_deadline=1s --nodepool_endpoints ${EPS[@]} --tso_endpoints ${TSO} --persistence_endpoints ${PERSISTENCE}&
+./build/src/k2/cmd/controlPlaneOracle/cpo_main ${COMMON_ARGS} -c1 --tcp_endpoints ${CPO} 9001 --data_dir ${CPODIR} --prometheus_port 63000 --assignment_timeout=1s --txn_heartbeat_deadline=1s --nodepool_endpoints ${EPS[@]} --tso_endpoints ${TSO} --tso_error_bound=100us --persistence_endpoints ${PERSISTENCE}&
 cpo_child_pid=$!
 
 # start nodepool

--- a/test/integration/test_k23si.sh
+++ b/test/integration/test_k23si.sh
@@ -43,6 +43,6 @@ function finish {
 }
 trap finish EXIT
 
-sleep 2
+sleep 1
 
 ./build/test/k23si/k23si_test ${COMMON_ARGS} --cpo ${CPO} --prometheus_port 63100

--- a/test/integration/test_k23si_tpcc.sh
+++ b/test/integration/test_k23si_tpcc.sh
@@ -44,7 +44,7 @@ function finish {
 }
 trap finish EXIT
 
-sleep 2
+sleep 1
 
 NUMWH=1
 NUMDIST=1

--- a/test/integration/test_k23si_ycsb.sh
+++ b/test/integration/test_k23si_ycsb.sh
@@ -44,7 +44,7 @@ function finish {
 }
 trap finish EXIT
 
-sleep 2
+sleep 1
 
 echo ">>> Starting load ..."
 ./build/src/k2/cmd/ycsb/ycsb_client ${COMMON_ARGS} -c2 --cpo ${CPO} --data_load true --prometheus_port 63100 --memory=512M --partition_request_timeout=6s --dataload_txn_timeout=600s --num_concurrent_txns=2 --num_records=500 --num_records_insert=100 --request_dist="latest" --num_partitions=3 --num_instances=2 --instance_id=0 &

--- a/test/integration/test_partition.sh
+++ b/test/integration/test_partition.sh
@@ -5,7 +5,7 @@ source ${topname}/common_defs.sh
 cd ${topname}/../..
 
 # start CPO
-./build/src/k2/cmd/controlPlaneOracle/cpo_main ${COMMON_ARGS} -c1 --tcp_endpoints ${CPO} --data_dir ${CPODIR} --prometheus_port 63000 --assignment_timeout=1s --tso_error_bound=100us --nodepool_endpoints ${EPS[@]} --tso_endpoints ${TSO} &
+./build/src/k2/cmd/controlPlaneOracle/cpo_main ${COMMON_ARGS} -c1 --tcp_endpoints ${CPO} --data_dir ${CPODIR} --prometheus_port 63000 --assignment_timeout=100ms --tso_error_bound=100us --nodepool_endpoints ${EPS[@]} --tso_endpoints ${TSO} &
 cpo_child_pid=$!
 
 # start tso

--- a/test/integration/test_partition.sh
+++ b/test/integration/test_partition.sh
@@ -44,6 +44,4 @@ function finish {
 }
 trap finish EXIT
 
-sleep 2
-
 ./build/test/dto/partition_test ${COMMON_ARGS} --cpo ${CPO} --prometheus_port 63100

--- a/test/integration/test_partition.sh
+++ b/test/integration/test_partition.sh
@@ -8,17 +8,17 @@ cd ${topname}/../..
 ./build/src/k2/cmd/controlPlaneOracle/cpo_main ${COMMON_ARGS} -c1 --tcp_endpoints ${CPO} --data_dir ${CPODIR} --prometheus_port 63000 --assignment_timeout=1s --tso_error_bound=100us --nodepool_endpoints ${EPS[@]} --tso_endpoints ${TSO} &
 cpo_child_pid=$!
 
-# start nodepool
-./build/src/k2/cmd/nodepool/nodepool ${COMMON_ARGS} -c${#EPS[@]} --tcp_endpoints ${EPS[@]} --k23si_persistence_endpoint ${PERSISTENCE} --prometheus_port 63001 &
-nodepool_child_pid=$!
+# start tso
+./build/src/k2/cmd/tso/tso ${COMMON_ARGS} -c1 --tcp_endpoints ${TSO} --prometheus_port 63003 --tso.clock_poller_cpu=${TSO_POLLER_CORE} &
+tso_child_pid=$!
 
 # start persistence
 ./build/src/k2/cmd/persistence/persistence ${COMMON_ARGS} -c1 --tcp_endpoints ${PERSISTENCE} --prometheus_port 63002 &
 persistence_child_pid=$!
 
-# start tso
-./build/src/k2/cmd/tso/tso ${COMMON_ARGS} -c1 --tcp_endpoints ${TSO} --prometheus_port 63003 --tso.clock_poller_cpu=${TSO_POLLER_CORE} &
-tso_child_pid=$!
+# start nodepool
+./build/src/k2/cmd/nodepool/nodepool ${COMMON_ARGS} -c${#EPS[@]} --tcp_endpoints ${EPS[@]} --k23si_persistence_endpoint ${PERSISTENCE} --prometheus_port 63001 &
+nodepool_child_pid=$!
 
 function finish {
   rv=$?

--- a/test/integration/test_plog.sh
+++ b/test/integration/test_plog.sh
@@ -28,6 +28,6 @@ function finish {
 }
 trap finish EXIT
 
-sleep 2
+sleep 1
 
 ./build/test/plog/plog_test ${COMMON_ARGS} --cpo_url ${CPO} --tcp_endpoints 12345 --plog_server_endpoints tcp+k2rpc://0.0.0.0:10000 tcp+k2rpc://0.0.0.0:10001 tcp+k2rpc://0.0.0.0:10002 --prometheus_port=63002

--- a/test/integration/test_query.sh
+++ b/test/integration/test_query.sh
@@ -43,6 +43,6 @@ function finish {
 }
 trap finish EXIT
 
-sleep 2
+sleep 1
 
 ./build/test/k23si/query_test ${COMMON_ARGS} --cpo ${CPO} --prometheus_port 63100

--- a/test/integration/test_schema_create.sh
+++ b/test/integration/test_schema_create.sh
@@ -43,4 +43,6 @@ function finish {
 }
 trap finish EXIT
 
+sleep 1
+
 ./build/test/k23si/schema_creation_test ${COMMON_ARGS} --cpo ${CPO} --prometheus_port 63100

--- a/test/integration/test_schema_create.sh
+++ b/test/integration/test_schema_create.sh
@@ -43,4 +43,4 @@ function finish {
 }
 trap finish EXIT
 
-./build/test/k23si/schema_creation_test ${COMMON_ARGS} --cpo_endpoint ${CPO} --prometheus_port 63100
+./build/test/k23si/schema_creation_test ${COMMON_ARGS} --cpo ${CPO} --prometheus_port 63100

--- a/test/integration/test_schema_create.sh
+++ b/test/integration/test_schema_create.sh
@@ -43,6 +43,4 @@ function finish {
 }
 trap finish EXIT
 
-sleep 2
-
 ./build/test/k23si/schema_creation_test ${COMMON_ARGS} --cpo_endpoint ${CPO} --prometheus_port 63100

--- a/test/integration/test_skv_client.sh
+++ b/test/integration/test_skv_client.sh
@@ -43,4 +43,6 @@ function finish {
 }
 trap finish EXIT
 
+sleep 1
+
 ./build/test/k23si/skv_client_test ${COMMON_ARGS} --cpo ${CPO} --prometheus_port 63100

--- a/test/integration/test_skv_client.sh
+++ b/test/integration/test_skv_client.sh
@@ -43,6 +43,4 @@ function finish {
 }
 trap finish EXIT
 
-sleep 2
-
 ./build/test/k23si/skv_client_test ${COMMON_ARGS} --cpo ${CPO} --prometheus_port 63100

--- a/test/integration/test_tso_assignment.sh
+++ b/test/integration/test_tso_assignment.sh
@@ -29,4 +29,6 @@ function finish {
 }
 trap finish EXIT
 
+sleep 1
+
 /build/test/integration/test_cpo_tso_assign.py --tso_child_pid=${tso_child_pid} --prometheus_port=63000 --cmd="./build/src/k2/cmd/tso/tso ${COMMON_ARGS} -c2 --tcp_endpoints \"tcp+k2rpc://0.0.0.0:13001\" \"tcp+k2rpc://0.0.0.0:13002\" --prometheus_port 63004 --tso.clock_poller_cpu=${TSO_POLLER_CORE}"\

--- a/test/integration/test_tso_assignment.sh
+++ b/test/integration/test_tso_assignment.sh
@@ -29,6 +29,4 @@ function finish {
 }
 trap finish EXIT
 
-sleep 2
-
 /build/test/integration/test_cpo_tso_assign.py --tso_child_pid=${tso_child_pid} --prometheus_port=63000 --cmd="./build/src/k2/cmd/tso/tso ${COMMON_ARGS} -c2 --tcp_endpoints \"tcp+k2rpc://0.0.0.0:13001\" \"tcp+k2rpc://0.0.0.0:13002\" --prometheus_port 63004 --tso.clock_poller_cpu=${TSO_POLLER_CORE}"\

--- a/test/integration/test_tso_errorbound.sh
+++ b/test/integration/test_tso_errorbound.sh
@@ -29,4 +29,6 @@ function finish {
 }
 trap finish EXIT
 
+sleep 1
+
 /build/test/integration/test_tso_errorbound_fail.py --prometheus_port=63003

--- a/test/integration/test_tso_errorbound.sh
+++ b/test/integration/test_tso_errorbound.sh
@@ -29,6 +29,4 @@ function finish {
 }
 trap finish EXIT
 
-sleep 2
-
 /build/test/integration/test_tso_errorbound_fail.py --prometheus_port=63003

--- a/test/integration/test_tso_errorbound_fail.py
+++ b/test/integration/test_tso_errorbound_fail.py
@@ -31,22 +31,37 @@ from urllib.parse import urlparse
 parser = argparse.ArgumentParser()
 parser.add_argument("--prometheus_port", help="TSO prometheus_port")
 args = parser.parse_args()
+url = "http://127.0.0.1:" + args.prometheus_port + "/metrics"
+
+TEST_TIMEOUT = 2
+TEST_RETRY_INTERVAL = 0.1
+
+def get_failed_errbound_times():
+    r = requests.get(url)
+    count = 0
+    for line in r.text.splitlines():
+        print(line)
+        if "TSOService_TSO_timestamp_errorbound_count" in line:
+            try:
+                count = int(float(line.split()[1]))
+            except:
+                continue
+    return count
 
 class TestTSOErrorBoundFailure(unittest.TestCase):
     def test_tsoEBFailure(self):
-        url = "http://127.0.0.1:" + args.prometheus_port + "/metrics"
-        r = requests.get(url)
-        for line in r.text.splitlines():
-            if "TSOService_tso_timestamp_errorbound_count" in line:
-                count = 0
-                try:
-                    count = int(float(line.split()[1]))
-                except:
-                    continue
-                print("TSOService_tso_timestamp_errorbound_count: ", count)
-                self.assertTrue(count > 0)
-
-
+        time_start = time.time()
+        count = -1
+        while time.time() < time_start + TEST_TIMEOUT:
+            try:
+                count = get_failed_errbound_times()
+                print("count is: ", count)
+                if count > 0:
+                    break
+                time.sleep(TEST_RETRY_INTERVAL)
+            except:
+                continue
+        self.assertTrue(count > 0)
 
 del sys.argv[1:]
 unittest.main()

--- a/test/k23si/3SITxnTest.cpp
+++ b/test/k23si/3SITxnTest.cpp
@@ -96,11 +96,12 @@ public: // application
     // Returns a vector of timestamps
     seastar::future<std::vector<dto::Timestamp>> getTimestamps(int n) {
     return seastar::do_with(std::vector<dto::Timestamp>(), n, [this] (auto& tsvec, auto& i) {
-        return seastar::do_until( 
-            [&i] { return i == 0;},
-            [&tsvec, this] {
-                return getTimeNow().then([&tsvec] (auto&& ts) {
+        return seastar::do_until(
+            [&i] { return i <= 0;},
+            [&tsvec, &i, this] {
+                return getTimeNow().then([&tsvec, &i] (auto&& ts) {
                     tsvec.push_back(ts);
+                    --i;
                 });
             })
             .then([&tsvec] {
@@ -181,7 +182,7 @@ private:
         record.serializeNext<String>(key.rangeKey);
         record.serializeNext<String>(data.f1);
         record.serializeNext<String>(data.f2);
-        K2LOG_D(log::k23si, "cname={}, key={}, phash={}", cname, key, key.partitionHash());
+        K2LOG_D(log::k23si, "cname={}, key={}, phash={}, mtr={}", cname, key, key.partitionHash(), mtr);
         auto& part = _pgetter.getPartitionForKey(key);
         dto::K23SIWriteRequest request {
             .pvid = part.partition->keyRangeV.pvid,
@@ -225,7 +226,7 @@ private:
 
     seastar::future<std::tuple<Status, DataRec>>
     doRead(const dto::Key& key, const dto::K23SI_MTR& mtr, const String& cname, ErrorCaseOpt errOpt) {
-        K2LOG_D(log::k23si, "key={}, phash={}", key, key.partitionHash());
+        K2LOG_D(log::k23si, "key={}, phash={}, mtr={}, cname={}", key, key.partitionHash(), mtr, cname);
         auto& part = _pgetter.getPartitionForKey(key);
         dto::K23SIReadRequest request {
             .pvid = part.partition->keyRangeV.pvid,
@@ -250,7 +251,7 @@ private:
             break;
         }
         default: {
-            K2ASSERT(log::k23si, false, "doWrite() incorrect parameter ErrorCaseOpt.");
+            K2ASSERT(log::k23si, false, "doRead() incorrect parameter ErrorCaseOpt.");
             break;
         } // end default
         } // end switch
@@ -272,7 +273,7 @@ private:
 
     seastar::future<std::tuple<Status, dto::K23SITxnPushResponse>>
     doPush(dto::Key key, String cname, dto::K23SI_MTR incumbent, dto::K23SI_MTR challenger, ErrorCaseOpt errOpt) {
-        K2LOG_D(log::k23si, "key={}, phash={}", key, key.partitionHash());
+        K2LOG_D(log::k23si, "key={}, phash={}, cname={}, incumbent={}, challenger={}", key, key.partitionHash(), cname, incumbent, challenger);
         auto& part = _pgetter.getPartitionForKey(key);
         dto::K23SITxnPushRequest request;
         request.pvid = part.partition->keyRangeV.pvid;
@@ -297,7 +298,7 @@ private:
             break;
          }
         default: {
-            K2ASSERT(log::k23si, false, "doWrite() incorrect parameter ErrorCaseOpt.");
+            K2ASSERT(log::k23si, false, "doPush() incorrect parameter ErrorCaseOpt.");
             break;
         } // end default
         } // end switch
@@ -307,7 +308,7 @@ private:
 
     seastar::future<std::tuple<Status, dto::K23SITxnEndResponse>>
     doEnd(dto::Key trh, dto::K23SI_MTR mtr, String cname, bool isCommit, std::vector<dto::Key> wkeys, Duration dur, ErrorCaseOpt errOpt) {
-        K2LOG_D(log::k23si, "key={}, phash={}", trh, trh.partitionHash());
+        K2LOG_D(log::k23si, "key={}, phash={}, cname={}, mtr={}, isCommit={}", trh, trh.partitionHash(), cname, mtr, isCommit);
 
         auto& part = _pgetter.getPartitionForKey(trh);
         std::unordered_map<String, std::unordered_set<dto::KeyRangeVersion>> writeRanges;
@@ -348,7 +349,7 @@ private:
             break;
         }
         default: {
-            K2ASSERT(log::k23si, false, "doWrite() incorrect parameter ErrorCaseOpt.");
+            K2ASSERT(log::k23si, false, "doEnd() incorrect parameter ErrorCaseOpt.");
             break;
         } // end default
         } // end switch
@@ -358,7 +359,7 @@ private:
 
     seastar::future<std::tuple<Status, dto::K23SITxnFinalizeResponse>>
     doFinalize(dto::Key key, dto::K23SI_MTR mtr, String cname, bool isCommit, ErrorCaseOpt errOpt) {
-        K2LOG_D(log::k23si, "key={}, phash={}", key, key.partitionHash());
+        K2LOG_D(log::k23si, "key={}, phash={}, cname={}, mtr={}, isCommit={}", key, key.partitionHash(), cname, mtr, isCommit);
         auto& part = _pgetter.getPartitionForKey(key);
         dto::PVID pvid{};
         if (!key.partitionKey.empty() && part.partition != nullptr) {
@@ -387,7 +388,7 @@ private:
             break;
         }
         default: {
-            K2ASSERT(log::k23si, false, "doWrite() incorrect parameter ErrorCaseOpt.");
+            K2ASSERT(log::k23si, false, "doFinalize() incorrect parameter ErrorCaseOpt.");
             break;
         } // end default
         } // end switch
@@ -397,7 +398,7 @@ private:
 
     seastar::future<std::tuple<Status, dto::K23SITxnHeartbeatResponse>>
     doHeartbeat(dto::Key key, dto::K23SI_MTR mtr, String cname, ErrorCaseOpt errOpt) {
-        K2LOG_D(log::k23si, "key={}, phash={}", key, key.partitionHash());
+        K2LOG_D(log::k23si, "key={}, phash={}, mtr={}, cname={}", key, key.partitionHash(), mtr, cname);
         auto& part = _pgetter.getPartitionForKey(key);
         dto::K23SITxnHeartbeatRequest request{
             .pvid = part.partition->keyRangeV.pvid,
@@ -422,7 +423,7 @@ private:
             break;
         }
         default: {
-            K2ASSERT(log::k23si, false, "doWrite() incorrect parameter ErrorCaseOpt.");
+            K2ASSERT(log::k23si, false, "doHeartbeat() incorrect parameter ErrorCaseOpt.");
             break;
         } // end default
         } // end switch
@@ -503,6 +504,7 @@ seastar::future<> testScenario00() {
                         .value{},
                         .fieldsForPartialUpdate{}
                     };
+                    K2LOG_D(log::k23si, "using req={}", request);
                     return RPC().callRPC<dto::K23SIWriteRequest, dto::K23SIWriteResponse>(dto::Verbs::K23SI_WRITE, request, *_dummyEP, 100ms)
                     .then([this](auto&& response) {
                         // response: K23SI_WRITE
@@ -522,6 +524,7 @@ seastar::future<> testScenario00() {
             .mtr{dto::Timestamp{20200828, 1, 1000}, dto::TxnPriority::Medium},
             .key{"schema", "SC00_pKey1", "SC00_rKey1"}
         };
+        K2LOG_D(log::k23si, "using req={}", request);
         return RPC().callRPC<dto::K23SIReadRequest, dto::K23SIReadResponse>
                 (dto::Verbs::K23SI_READ, request, *_dummyEP, 100ms)
         .then([](auto&& response) {
@@ -539,6 +542,7 @@ seastar::future<> testScenario00() {
             .incumbentMTR{dto::Timestamp{20200828, 1, 1000}, dto::TxnPriority::Medium},
             .challengerMTR{dto::Timestamp{20200101, 1, 1000}, dto::TxnPriority::Medium}
         };
+        K2LOG_D(log::k23si, "using pushreq={}", request);
         return RPC().callRPC<dto::K23SITxnPushRequest, dto::K23SITxnPushResponse>
                 (dto::Verbs::K23SI_TXN_PUSH, request, *_dummyEP, 100ms)
         .then([](auto&& response) {
@@ -560,6 +564,7 @@ seastar::future<> testScenario00() {
                         }},
             .syncFinalize = false
         };
+        K2LOG_D(log::k23si, "using req={}", request);
         return RPC().callRPC<dto::K23SITxnEndRequest, dto::K23SITxnEndResponse>
                 (dto::Verbs::K23SI_TXN_END, request, *_dummyEP, 100ms)
         .then([](auto&& response) {
@@ -576,6 +581,7 @@ seastar::future<> testScenario00() {
             .txnTimestamp = dto::Timestamp{20200828, 1, 1000},
             .action = dto::EndAction::Abort
         };
+        K2LOG_D(log::k23si, "using req={}", request);
         return RPC().callRPC<dto::K23SITxnFinalizeRequest, dto::K23SITxnFinalizeResponse>
                 (dto::Verbs::K23SI_TXN_FINALIZE, request, *_dummyEP, 100ms)
         .then([](auto&& response) {
@@ -592,6 +598,7 @@ seastar::future<> testScenario00() {
             .key{"schema", "SC00_pKey1", "SC00_rKey1"},
             .mtr{dto::Timestamp{20200828, 1, 1000}, dto::TxnPriority::Medium},
         };
+        K2LOG_D(log::k23si, "using req={}", request);
         return RPC().callRPC<dto::K23SITxnHeartbeatRequest, dto::K23SITxnHeartbeatResponse>
                 (dto::Verbs::K23SI_TXN_HEARTBEAT, request, *_dummyEP, 100ms)
         .then([](auto&& response) {
@@ -624,6 +631,7 @@ seastar::future<> testScenario01() {
             },
             .rangeEnds{}
         };
+        K2LOG_D(log::k23si, "using req={}", request);
         return RPC().callRPC<dto::CollectionCreateRequest, dto::CollectionCreateResponse>
                 (dto::Verbs::CPO_COLLECTION_CREATE, request, *_cpoEndpoint, 1s)
         .then([](auto&& response) {
@@ -636,6 +644,7 @@ seastar::future<> testScenario01() {
         .then([this] {
             // check to make sure the collection is assigned
             auto request = dto::CollectionGetRequest{.name = collname};
+            K2LOG_D(log::k23si, "using req={}", request);
             return RPC().callRPC<dto::CollectionGetRequest, dto::CollectionGetResponse>
                 (dto::Verbs::CPO_COLLECTION_GET, request, *_cpoEndpoint, 100ms);
         })
@@ -653,6 +662,7 @@ seastar::future<> testScenario01() {
         })
         .then([this] () {
             dto::CreateSchemaRequest request{ collname, _schema };
+            K2LOG_D(log::k23si, "using req={}", request);
             return RPC().callRPC<dto::CreateSchemaRequest, dto::CreateSchemaResponse>(dto::Verbs::CPO_SCHEMA_CREATE, request, *_cpoEndpoint, 1s);
         })
         .then([] (auto&& response) {
@@ -675,6 +685,7 @@ seastar::future<> testScenario01() {
             DataRec {.f1="SC01_field1", .f2="SC01_field2"},
             [this] (dto::K23SI_MTR& mtr, dto::Key& key, dto::Key& trh, DataRec& rec) {
                 // case"bad collection name"  --> OP:WRITE
+                K2LOG_D(log::k23si, "using mtr={}", mtr);
                 return doWrite(key, rec, mtr, trh, badCname, false, true, ErrorCaseOpt::NoInjection)
                 .then([](auto&& response) {
                     auto& [status, resp] = response;
@@ -682,6 +693,7 @@ seastar::future<> testScenario01() {
                 })
                 // case"bad collection name"  --> OP:READ
                 .then([this, &key, &mtr] {
+                    K2LOG_D(log::k23si, "using mtr={}", mtr);
                     return doRead(key, mtr, badCname, ErrorCaseOpt::NoInjection)
                     .then([](auto&& response) {
                         auto& [status, resp] = response;
@@ -690,6 +702,7 @@ seastar::future<> testScenario01() {
                 })
                 // case"bad collection name"  --> OP:PUSH
                 .then([this, &key, &mtr] {
+                    K2LOG_D(log::k23si, "using mtr={}", mtr);
                     return doPush(key, badCname, mtr, mtr, ErrorCaseOpt::NoInjection)
                     .then([](auto&& response) {
                         auto& [status, resp] = response;
@@ -698,6 +711,7 @@ seastar::future<> testScenario01() {
                 })
                 // case"bad collection name"  --> OP:END
                 .then([this, &trh, &key, &mtr] {
+                    K2LOG_D(log::k23si, "using mtr={}", mtr);
                     return doEnd(trh, mtr, badCname, false, {key}, Duration(0s), ErrorCaseOpt::NoInjection)
                     .then([](auto&& response) {
                         auto& [status, resp] = response;
@@ -706,6 +720,7 @@ seastar::future<> testScenario01() {
                 })
                 // case"bad collection name"  --> OP:FINALIZE
                 .then([this, &key, &mtr] {
+                    K2LOG_D(log::k23si, "using mtr={}", mtr);
                     return doFinalize(key, mtr, badCname, true, ErrorCaseOpt::NoInjection)
                     .then([](auto&& response) {
                         auto& [status, resp] = response;
@@ -714,6 +729,7 @@ seastar::future<> testScenario01() {
                 })
                 // case"bad collection name"  --> OP:HEARTBEAT
                 .then([this, &key, &mtr] {
+                    K2LOG_D(log::k23si, "using mtr={}", mtr);
                     return doHeartbeat(key, mtr, badCname, ErrorCaseOpt::NoInjection)
                     .then([](auto&& response) {
                         auto& [status, resp] = response;
@@ -728,13 +744,14 @@ seastar::future<> testScenario01() {
         K2LOG_I(log::k23si, "Get a stale timestamp(1,000,000) as the stale_ts");
         return seastar::do_with(
             dto::K23SI_MTR {
-                .timestamp = {1000001, 123, 1000}, // 1,000,000 is old enough
+                .timestamp = {1000000, 123, 1000}, // 1,000,000 is old enough
                 .priority = dto::TxnPriority::Medium},
             dto::Key {.schemaName = "schema", .partitionKey = "SC01_pKey1", .rangeKey = "SC01_rKey1" },
             dto::Key {.schemaName = "schema", .partitionKey = "SC01_pKey1", .rangeKey = "SC01_rKey1" },
             DataRec {.f1="SC01_field1", .f2="SC01_field2"},
             [this] (dto::K23SI_MTR& mtr, dto::Key& key, dto::Key& trh, DataRec& rec) {
                 // case"stale request"  --> OP:WRITE
+                K2LOG_D(log::k23si, "using mtr={}", mtr);
                 return doWrite(key, rec, mtr, trh, collname, false, true, ErrorCaseOpt::NoInjection)
                 .then([](auto&& response) {
                     auto& [status, resp] = response;
@@ -742,6 +759,7 @@ seastar::future<> testScenario01() {
                 })
                 // case"stale request"  --> OP:READ
                 .then([this, &key, &mtr] {
+                    K2LOG_D(log::k23si, "using mtr={}", mtr);
                     return doRead(key, mtr, collname, ErrorCaseOpt::NoInjection)
                     .then([](auto&& response) {
                         auto& [status, resp] = response;
@@ -750,6 +768,7 @@ seastar::future<> testScenario01() {
                 })
                 // case"stale request"  --> OP:END
                 .then([this, &mtr, &trh, &key] {
+                    K2LOG_D(log::k23si, "using mtr={}", mtr);
                     return doEnd(trh, mtr, collname, false, {key}, Duration(0s), ErrorCaseOpt::NoInjection)
                     .then([](auto&& response) {
                         auto& [status, resp] = response;
@@ -758,6 +777,7 @@ seastar::future<> testScenario01() {
                 })
                 // case"stale request"  --> OP:HEARTBEAT
                 .then([this, &mtr, &key] {
+                    K2LOG_D(log::k23si, "using mtr={}", mtr);
                     return doHeartbeat(key, mtr, collname, ErrorCaseOpt::NoInjection)
                     .then([](auto&& response) {
                         auto& [status, resp] = response;
@@ -766,6 +786,7 @@ seastar::future<> testScenario01() {
                 })
                 // stale request for PUSH, only validate challenger MTRs
                 .then([this, &mtr, &key] {
+                    K2LOG_D(log::k23si, "using mtr={}", mtr);
                     return doPush(key, collname, mtr, mtr, ErrorCaseOpt::NoInjection)
                     .then([](auto&& response) {
                         auto& [status, resp] = response;
@@ -774,12 +795,14 @@ seastar::future<> testScenario01() {
                 })
                 // stale request for FINALIZE, test Finalize-commit & Finalize-abort
                 .then([this, &key, &mtr] {
+                    K2LOG_D(log::k23si, "using mtr={}", mtr);
                     return doFinalize(key, mtr, collname, true, ErrorCaseOpt::NoInjection)
                     .then([](auto&& response) {
                         auto& [status, resp] = response;
                         K2EXPECT(log::k23si, status, dto::K23SIStatus::KeyNotFound)
                     })
                     .then([this, &mtr, &key] {
+                        K2LOG_D(log::k23si, "using mtr={}", mtr);
                         return doFinalize(key, mtr, collname, false, ErrorCaseOpt::NoInjection)
                         .then([](auto&& response) {
                             auto& [status, resp] = response;
@@ -804,6 +827,7 @@ seastar::future<> testScenario01() {
             DataRec {.f1="SC01_field1", .f2="SC01_field2"},
             [this] (dto::K23SI_MTR& mtr, dto::Key& key, dto::Key& trh, DataRec& rec) {
                 // case"wrong partition"  --> OP:WRITE
+                K2LOG_D(log::k23si, "using mtr={}", mtr);
                 return doWrite(key, rec, mtr, trh, collname, false, true, ErrorCaseOpt::WrongPartId)
                 .then([](auto&& response) {
                     auto& [status, resp] = response;
@@ -811,6 +835,7 @@ seastar::future<> testScenario01() {
                 })
                 // case"wrong partition"  --> OP:READ
                 .then([this, &key, &mtr] {
+                    K2LOG_D(log::k23si, "using mtr={}", mtr);
                     return doRead(key, mtr, collname, ErrorCaseOpt::WrongPartId)
                     .then([](auto&& response) {
                         auto& [status, resp] = response;
@@ -819,6 +844,7 @@ seastar::future<> testScenario01() {
                 })
                 // case"wrong partition"  --> OP:PUSH
                 .then([this, &key, &mtr] {
+                    K2LOG_D(log::k23si, "using mtr={}", mtr);
                     return doPush(key, collname, mtr, mtr, ErrorCaseOpt::WrongPartId)
                     .then([](auto&& response) {
                         auto& [status, resp] = response;
@@ -827,6 +853,7 @@ seastar::future<> testScenario01() {
                 })
                 // case"wrong partition"  --> OP:END
                 .then([this, &trh, &key, &mtr] {
+                    K2LOG_D(log::k23si, "using mtr={}", mtr);
                     return doEnd(trh, mtr, collname, false, {key}, Duration(0s), ErrorCaseOpt::WrongPartId)
                     .then([](auto&& response) {
                         auto& [status, resp] = response;
@@ -835,6 +862,7 @@ seastar::future<> testScenario01() {
                 })
                 // case"wrong partition"  --> OP:FINALIZE
                 .then([this, &key, &mtr] {
+                    K2LOG_D(log::k23si, "using mtr={}", mtr);
                     return doFinalize(key, mtr, collname, false, ErrorCaseOpt::WrongPartId)
                     .then([](auto&& response) {
                         auto& [status, resp] = response;
@@ -843,6 +871,7 @@ seastar::future<> testScenario01() {
                 })
                 // case"wrong partition"  --> OP:HEARTBEAT
                 .then([this, &key, &mtr] {
+                    K2LOG_D(log::k23si, "using mtr={}", mtr);
                     return doHeartbeat(key, mtr, collname, ErrorCaseOpt::WrongPartId)
                     .then([](auto&& response) {
                         auto& [status, resp] = response;
@@ -867,6 +896,7 @@ seastar::future<> testScenario01() {
             DataRec {.f1="SC01_field1", .f2="SC01_field2"},
             [this] (dto::K23SI_MTR& mtr, dto::Key& key, dto::Key& trh, DataRec& rec) {
                 // case"wrong partition"  --> OP:WRITE
+                K2LOG_D(log::k23si, "using mtr={}", mtr);
                 return doWrite(key, rec, mtr, trh, collname, false, true, ErrorCaseOpt::PartMismatchKey)
                 .then([](auto&& response) {
                     auto& [status, resp] = response;
@@ -874,6 +904,7 @@ seastar::future<> testScenario01() {
                 })
                 // case"wrong partition"  --> OP:READ
                 .then([this, &key, &mtr] {
+                    K2LOG_D(log::k23si, "using mtr={}", mtr);
                     return doRead(key, mtr, collname, ErrorCaseOpt::PartMismatchKey)
                     .then([](auto&& response) {
                         auto& [status, resp] = response;
@@ -882,6 +913,7 @@ seastar::future<> testScenario01() {
                 })
                 // case"wrong partition"  --> OP:PUSH
                 .then([this, &key, &mtr] {
+                    K2LOG_D(log::k23si, "using mtr={}", mtr);
                     return doPush(key, collname, mtr, mtr, ErrorCaseOpt::PartMismatchKey)
                     .then([](auto&& response) {
                         auto& [status, resp] = response;
@@ -890,6 +922,7 @@ seastar::future<> testScenario01() {
                 })
                 // case"wrong partition"  --> OP:END
                 .then([this, &trh, &key, &mtr] {
+                    K2LOG_D(log::k23si, "using mtr={}", mtr);
                     return doEnd(trh, mtr, collname, false, {key}, Duration(0s), ErrorCaseOpt::PartMismatchKey)
                     .then([](auto&& response) {
                         auto& [status, resp] = response;
@@ -898,6 +931,7 @@ seastar::future<> testScenario01() {
                 })
                 // case"wrong partition"  --> OP:FINALIZE
                 .then([this, &key, &mtr] {
+                    K2LOG_D(log::k23si, "using mtr={}", mtr);
                     return doFinalize(key, mtr, collname, false, ErrorCaseOpt::PartMismatchKey)
                     .then([](auto&& response) {
                         auto& [status, resp] = response;
@@ -906,6 +940,7 @@ seastar::future<> testScenario01() {
                 })
                 // case"wrong partition"  --> OP:HEARTBEAT
                 .then([this, &key, &mtr] {
+                    K2LOG_D(log::k23si, "using mtr={}", mtr);
                     return doHeartbeat(key, mtr, collname, ErrorCaseOpt::PartMismatchKey)
                     .then([](auto&& response) {
                         auto& [status, resp] = response;
@@ -930,6 +965,7 @@ seastar::future<> testScenario01() {
             DataRec {.f1="SC01_field1", .f2="SC01_field2"},
             [this] (dto::K23SI_MTR& mtr, dto::Key& key, dto::Key& trh, DataRec& rec) {
                 // case"wrong partition"  --> OP:WRITE
+                K2LOG_D(log::k23si, "using mtr={}", mtr);
                 return doWrite(key, rec, mtr, trh, collname, false, true, ErrorCaseOpt::ObsoletePart)
                 .then([](auto&& response) {
                     auto& [status, resp] = response;
@@ -937,6 +973,7 @@ seastar::future<> testScenario01() {
                 })
                 // case"wrong partition"  --> OP:READ
                 .then([this, &key, &mtr] {
+                    K2LOG_D(log::k23si, "using mtr={}", mtr);
                     return doRead(key, mtr, collname, ErrorCaseOpt::ObsoletePart)
                     .then([](auto&& response) {
                         auto& [status, resp] = response;
@@ -945,6 +982,7 @@ seastar::future<> testScenario01() {
                 })
                 // case"wrong partition"  --> OP:PUSH
                 .then([this, &key, &mtr] {
+                    K2LOG_D(log::k23si, "using mtr={}", mtr);
                     return doPush(key, collname, mtr, mtr, ErrorCaseOpt::ObsoletePart)
                     .then([](auto&& response) {
                         auto& [status, resp] = response;
@@ -953,6 +991,7 @@ seastar::future<> testScenario01() {
                 })
                 // case"wrong partition"  --> OP:END
                 .then([this, &trh, &key, &mtr] {
+                    K2LOG_D(log::k23si, "using mtr={}", mtr);
                     return doEnd(trh, mtr, collname, false, {key}, Duration(0s), ErrorCaseOpt::ObsoletePart)
                     .then([](auto&& response) {
                         auto& [status, resp] = response;
@@ -961,6 +1000,7 @@ seastar::future<> testScenario01() {
                 })
                 // case"wrong partition"  --> OP:FINALIZE
                 .then([this, &key, &mtr] {
+                    K2LOG_D(log::k23si, "using mtr={}", mtr);
                     return doFinalize(key, mtr, collname, false, ErrorCaseOpt::ObsoletePart)
                     .then([](auto&& response) {
                         auto& [status, resp] = response;
@@ -969,6 +1009,7 @@ seastar::future<> testScenario01() {
                 })
                 // case"wrong partition"  --> OP:HEARTBEAT
                 .then([this, &key, &mtr] {
+                    K2LOG_D(log::k23si, "using mtr={}", mtr);
                     return doHeartbeat(key, mtr, collname, ErrorCaseOpt::ObsoletePart)
                     .then([](auto&& response) {
                         auto& [status, resp] = response;
@@ -990,12 +1031,14 @@ seastar::future<> testScenario01() {
             dto::Key {},
             DataRec {.f1="SC01_field1", .f2="SC01_field2"},
             [this](dto::K23SI_MTR& mtr, dto::Key& key, dto::Key& trh, DataRec& rec) {
+                K2LOG_D(log::k23si, "using mtr={}", mtr);
                 return doWrite(key, rec, mtr, trh, collname, false, true, ErrorCaseOpt::NoInjection)
                 .then([](auto&& response) {
                     auto& [status, resp] = response;
                     K2EXPECT(log::k23si, status, dto::K23SIStatus::BadParameter);
                 })
                 .then([this, &key, &mtr] {
+                    K2LOG_D(log::k23si, "using mtr={}", mtr);
                     return doRead(key, mtr, collname, ErrorCaseOpt::NoInjection)
                     .then([](auto&& response) {
                         auto& [status, resp] = response;
@@ -1003,6 +1046,7 @@ seastar::future<> testScenario01() {
                     });
                 })
                 .then([this, &key, &mtr] {
+                    K2LOG_D(log::k23si, "using mtr={}", mtr);
                     return doFinalize(key, mtr, collname, true, ErrorCaseOpt::NoInjection)
                     .then([](auto&& response) {
                         auto& [status, resp] = response;
@@ -1023,12 +1067,14 @@ seastar::future<> testScenario01() {
             [this](dto::K23SI_MTR& mtr, DataRec& rec) {
                 dto::Key missPartKey;
                 missPartKey.rangeKey = "SC01_rKey1";
+                K2LOG_D(log::k23si, "using mtr={}", mtr);
                 return doWrite(missPartKey, rec, mtr, missPartKey, collname, false, true, ErrorCaseOpt::NoInjection)
                 .then([](auto&& response) {
                     auto& [status, resp] = response;
                     K2EXPECT(log::k23si, status, dto::K23SIStatus::BadParameter);
                 })
                 .then([this, &mtr] {
+                    K2LOG_D(log::k23si, "using mtr={}", mtr);
                     dto::Key missPartKey;
                     missPartKey.rangeKey = "SC01_rKey1";
                     return doRead(missPartKey, mtr, collname, ErrorCaseOpt::NoInjection)
@@ -1038,6 +1084,7 @@ seastar::future<> testScenario01() {
                     });
                 })
                 .then([this, &mtr] {
+                    K2LOG_D(log::k23si, "using mtr={}", mtr);
                     dto::Key missPartKey;
                     missPartKey.rangeKey = "SC01_rKey1";
                     return doFinalize(missPartKey, mtr, collname, true, ErrorCaseOpt::NoInjection)
@@ -1061,12 +1108,14 @@ seastar::future<> testScenario01() {
                 dto::Key onlyPartKey;
                 onlyPartKey.schemaName = "schema";
                 onlyPartKey.partitionKey = "SC01_pKey1";
+                K2LOG_D(log::k23si, "using mtr={}", mtr);
                 return doWrite(onlyPartKey, rec, mtr, onlyPartKey, collname, false, true, ErrorCaseOpt::NoInjection)
                 .then([](auto&& response) {
                     auto& [status, resp] = response;
                     K2EXPECT(log::k23si, status, dto::K23SIStatus::Created);
                 })
                 .then([this, &mtr] {
+                    K2LOG_D(log::k23si, "using mtr={}", mtr);
                     dto::Key onlyPartKey;
                     onlyPartKey.schemaName = "schema";
                     onlyPartKey.partitionKey = "SC01_pKey1";
@@ -1077,6 +1126,7 @@ seastar::future<> testScenario01() {
                     });
                 })
                 .then([this, &mtr] {
+                    K2LOG_D(log::k23si, "using mtr={}", mtr);
                     dto::Key onlyPartKey;
                     onlyPartKey.schemaName = "schema";
                     onlyPartKey.partitionKey = "SC01_pKey1";
@@ -1100,12 +1150,14 @@ seastar::future<> testScenario01() {
             dto::Key {.schemaName = "schema", .partitionKey = "SC01_pKey1", .rangeKey = "SC01_rKey1" },
             DataRec {.f1="SC01_field1", .f2="SC01_field2"},
             [this](dto::K23SI_MTR& mtr, dto::Key& key, dto::Key& trh, DataRec& rec) {
+                K2LOG_D(log::k23si, "using mtr={}", mtr);
                 return doWrite(key, rec, mtr, trh, collname, false, true, ErrorCaseOpt::NoInjection)
                 .then([](auto&& response) {
                     auto& [status, resp] = response;
                     K2EXPECT(log::k23si, status, dto::K23SIStatus::Created);
                 })
                 .then([this, &key, &mtr] {
+                    K2LOG_D(log::k23si, "using mtr={}", mtr);
                     return doRead(key, mtr, collname, ErrorCaseOpt::NoInjection)
                     .then([](auto&& response) {
                         auto& [status, resp] = response;
@@ -1113,6 +1165,7 @@ seastar::future<> testScenario01() {
                     });
                 })
                 .then([this, &key, &mtr] {
+                    K2LOG_D(log::k23si, "using mtr={}", mtr);
                     return doFinalize(key, mtr, collname, true, ErrorCaseOpt::NoInjection)
                     .then([](auto&& response) {
                         auto& [status, resp] = response;
@@ -1137,6 +1190,7 @@ seastar::future<> testScenario01() {
                 // case"wrong partition"  --> OP:WRITE
                 dto::Key missPartKey;
                 missPartKey.rangeKey = "SC01_rKey1";
+                K2LOG_D(log::k23si, "using mtr={}", mtr);
                 return doWrite(missPartKey, rec, mtr, trh, badCname, false, true, ErrorCaseOpt::NoInjection)
                 .then([](auto&& response) {
                     auto& [status, resp] = response;
@@ -1144,6 +1198,7 @@ seastar::future<> testScenario01() {
                 })
                 // case"wrong partition"  --> OP:READ
                 .then([this, &mtr] {
+                    K2LOG_D(log::k23si, "using mtr={}", mtr);
                     dto::Key missPartKey;
                     missPartKey.rangeKey = "SC01_rKey1";
                     return doRead(missPartKey, mtr, badCname, ErrorCaseOpt::NoInjection)
@@ -1154,6 +1209,7 @@ seastar::future<> testScenario01() {
                 })
                 // case"wrong partition"  --> OP:FINALIZE
                 .then([this, &mtr] {
+                    K2LOG_D(log::k23si, "using mtr={}", mtr);
                     dto::Key missPartKey;
                     missPartKey.rangeKey = "SC01_rKey1";
                     return doFinalize(missPartKey, mtr, badCname, false, ErrorCaseOpt::NoInjection)
@@ -1179,12 +1235,14 @@ seastar::future<> testScenario01() {
             DataRec {.f1="SC01_field1", .f2="SC01_field2"},
             DataRec {.f1="SC01_field3", .f2="SC01_field4"},
             [this](dto::K23SI_MTR& mtr, dto::Key& key1, dto::Key& key2, dto::Key& trh, DataRec& rec1, DataRec& rec2) {
+                K2LOG_D(log::k23si, "using mtr={}", mtr);
                 return doWrite(key1, rec1, mtr, trh, collname, false, true, ErrorCaseOpt::NoInjection)
                 .then([](auto&& response) {
                     auto& [status, resp] = response;
                     K2EXPECT(log::k23si, status, dto::K23SIStatus::Created);
                 })
                 .then([this, &key2, &rec2, &mtr, &trh] {
+                    K2LOG_D(log::k23si, "using mtr={}", mtr);
                     return doWrite(key2, rec2, mtr, trh, collname, false, false, ErrorCaseOpt::NoInjection)
                     .then([](auto&& response) {
                         auto& [status, resp] = response;
@@ -1192,6 +1250,7 @@ seastar::future<> testScenario01() {
                     });
                 })
                 .then([this, &trh, &mtr, &key1, &key2] {
+                    K2LOG_D(log::k23si, "using mtr={}", mtr);
                     return doEnd(trh, mtr, collname, true, {key1, key2}, Duration(0s), ErrorCaseOpt::NoInjection)
                     .then([](auto&& response) {
                         auto& [status, resp] = response;
@@ -1214,6 +1273,7 @@ seastar::future<> testScenario01() {
                 DataRec {.f1="SC01_field1", .f2="SC01_field2"},
                 DataRec {.f1="SC01_field3", .f2="SC01_field4"},
                 [this](auto& mtr, auto& key1, auto& key2, auto& cmpRec1, auto& cmpRec2) {
+                    K2LOG_D(log::k23si, "using mtr={}", mtr);
                     return seastar::when_all(doRead(key1, mtr, collname, ErrorCaseOpt::NoInjection), doRead(key2, mtr, collname, ErrorCaseOpt::NoInjection))
                     .then([&](auto&& response) mutable {
                         auto& [resp1, resp2] = response;
@@ -1244,12 +1304,14 @@ seastar::future<> testScenario01() {
             DataRec {.f1="SC01_field_abort1", .f2="SC01_field_abort2"},
             DataRec {.f1="SC01_field_abort3", .f2="SC01_field_abort4"},
             [this](dto::K23SI_MTR& mtr, dto::Key& key1, dto::Key& key2, dto::Key& trh, DataRec& rec1, DataRec& rec2) {
+                K2LOG_D(log::k23si, "using mtr={}", mtr);
                 return doWrite(key1, rec1, mtr, trh, collname, false, true, ErrorCaseOpt::NoInjection)
                 .then([](auto&& response) {
                     auto& [status, resp] = response;
                     K2EXPECT(log::k23si, status, dto::K23SIStatus::Created);
                 })
                 .then([this, &key2, &rec2, &mtr, &trh] {
+                    K2LOG_D(log::k23si, "using mtr={}", mtr);
                     return doWrite(key2, rec2, mtr, trh, collname, false, false, ErrorCaseOpt::NoInjection)
                     .then([](auto&& response) {
                         auto& [status, resp] = response;
@@ -1257,6 +1319,7 @@ seastar::future<> testScenario01() {
                     });
                 })
                 .then([this, &trh, &mtr, &key1, &key2] {
+                    K2LOG_D(log::k23si, "using mtr={}", mtr);
                     return doEnd(trh, mtr, collname, false, {key1, key2}, Duration(0s), ErrorCaseOpt::NoInjection)
                     .then([](auto&& response) {
                         auto& [status, resp] = response;
@@ -1279,6 +1342,7 @@ seastar::future<> testScenario01() {
                 DataRec {.f1="SC01_field1", .f2="SC01_field2"},
                 DataRec {.f1="SC01_field3", .f2="SC01_field4"},
                 [this](auto& mtr, auto& key1, auto& key2, auto& cmpRec1, auto& cmpRec2) {
+                    K2LOG_D(log::k23si, "using mtr={}", mtr);
                     return seastar::when_all(doRead(key1, mtr, collname, ErrorCaseOpt::NoInjection), doRead(key2, mtr, collname, ErrorCaseOpt::NoInjection))
                     .then([&](auto&& response) mutable {
                         auto& [resp1, resp2] = response;
@@ -1321,6 +1385,7 @@ seastar::future<> testScenario02() {
             },
             .rangeEnds{}
         };
+        K2LOG_D(log::k23si, "using req={}", request);
         return RPC().callRPC<dto::CollectionCreateRequest, dto::CollectionCreateResponse>
                 (dto::Verbs::CPO_COLLECTION_CREATE, request, *_cpoEndpoint, 1s)
         .then([](auto&& response) {
@@ -1342,7 +1407,7 @@ seastar::future<> testScenario02() {
             DataRec {.f1="SC02_f1", .f2="SC02_f2"},
             [this, ts=std::move(ts)](auto& k1, auto& k2, auto& k3, auto& k4, auto& v1) mutable {
                 auto mtr = dto::K23SI_MTR{.timestamp = std::move(ts), .priority = dto::TxnPriority::Medium};
-
+                K2LOG_D(log::k23si, "using mtr={}", mtr);
                 return seastar::when_all(
                     doWrite(k1, v1, mtr, k1, collname, false, true, ErrorCaseOpt::NoInjection),
                     doWrite(k2, v1, mtr, k1, collname, false, false, ErrorCaseOpt::NoInjection)
@@ -1356,6 +1421,7 @@ seastar::future<> testScenario02() {
                     K2EXPECT(log::k23si, status2, dto::K23SIStatus::Created);
 
                     // commit k1 and k2
+                    K2LOG_D(log::k23si, "using mtr={}", mtr);
                     return doEnd(k1, mtr, collname, true, {k1,k2}, Duration(0s), ErrorCaseOpt::NoInjection);
                 })
                 .then([this] (auto&& response) mutable {
@@ -1371,6 +1437,7 @@ seastar::future<> testScenario02() {
                             .timestamp = std::move(ts),
                             .priority = dto::TxnPriority::Medium
                         };
+                    K2LOG_D(log::k23si, "using mtr={}", mtr);
                     return doWrite(k3, v1, mtr, k3, collname, false, true, ErrorCaseOpt::NoInjection);
                 })
                 .then([this] (auto&& response) {
@@ -1384,12 +1451,14 @@ seastar::future<> testScenario02() {
                     auto mtr = dto::K23SI_MTR {
                             .timestamp = std::move(ts),
                             .priority = dto::TxnPriority::Medium};
+                    K2LOG_D(log::k23si, "using mtr={}", mtr);
 
                     return doWrite(k4, v1, mtr, k4, collname, false, true, ErrorCaseOpt::NoInjection);
                 })
                 .then([&, mtr] (auto&& response) {
                     auto& [status, resp] = response;
                     K2EXPECT(log::k23si, status, dto::K23SIStatus::Created);
+                    K2LOG_D(log::k23si, "using mtr={}", mtr);
 
                     // abort the k4 write
                     return doEnd(k4, mtr, collname, false, {k4}, Duration(500ms), ErrorCaseOpt::NoInjection);
@@ -1414,6 +1483,7 @@ seastar::future<> testScenario02() {
             dto::Key {.schemaName = "schema", .partitionKey = "SC02_pkey1", .rangeKey = ""},
             DataRec {.f1="SC02_f3", .f2="SC02_f4"},
             [this] (dto::K23SI_MTR& mtr, dto::Key& k1, DataRec& v2) {
+                K2LOG_D(log::k23si, "using mtr={}", mtr);
                 // case"bad collection name"  --> OP:WRITE
                 return doWrite(k1, v2, mtr, k1, badCname, false, true, ErrorCaseOpt::NoInjection)
                 .then([](auto&& response) {
@@ -1422,6 +1492,7 @@ seastar::future<> testScenario02() {
                 })
                 // case"bad collection name"  --> OP:READ
                 .then([this, &k1, &mtr] {
+                    K2LOG_D(log::k23si, "using mtr={}", mtr);
                     return doRead(k1, mtr, badCname, ErrorCaseOpt::NoInjection)
                     .then([](auto&& response) {
                         auto& [status, resp] = response;
@@ -1444,6 +1515,7 @@ seastar::future<> testScenario02() {
             dto::Key {.schemaName = "schema", .partitionKey = "SC02_pkey1", .rangeKey = ""},
             DataRec {.f1="SC02_f3", .f2="SC02_f4"},
             [this] (dto::K23SI_MTR& mtr, dto::Key& k1, DataRec& v2) {
+                K2LOG_D(log::k23si, "using mtr={}", mtr);
                 // case"wrong partition"  --> OP:WRITE
                 return doWrite(k1, v2, mtr, k1, collname, false, true, ErrorCaseOpt::WrongPartId)
                 .then([](auto&& response) {
@@ -1452,6 +1524,7 @@ seastar::future<> testScenario02() {
                 })
                 // case"wrong partition"  --> OP:READ
                 .then([this, &k1, &mtr] {
+                    K2LOG_D(log::k23si, "using mtr={}", mtr);
                     return doRead(k1, mtr, collname, ErrorCaseOpt::WrongPartId)
                     .then([](auto&& response) {
                         auto& [status, resp] = response;
@@ -1472,6 +1545,7 @@ seastar::future<> testScenario02() {
             dto::Key {.schemaName="schema", .partitionKey="SC02_pkey1", .rangeKey=""},
             DataRec {.f1="SC02_f3", .f2="SC02_f4"},
             [this] (dto::K23SI_MTR& mtr, dto::Key& k1, DataRec& v2) {
+                K2LOG_D(log::k23si, "using mtr={}", mtr);
                 // case"wrong partition"  --> OP:WRITE
                 return doWrite(k1, v2, mtr, k1, collname, false, true, ErrorCaseOpt::ObsoletePart)
                 .then([](auto&& response) {
@@ -1480,6 +1554,7 @@ seastar::future<> testScenario02() {
                 })
                 // case"wrong partition"  --> OP:READ
                 .then([this, &k1, &mtr] {
+                    K2LOG_D(log::k23si, "using mtr={}", mtr);
                     return doRead(k1, mtr, collname, ErrorCaseOpt::ObsoletePart)
                     .then([](auto&& response) {
                         auto& [status, resp] = response;
@@ -1503,6 +1578,7 @@ seastar::future<> testScenario02() {
             dto::Key {.schemaName = "schema", .partitionKey = "SC02_pkey4", .rangeKey = ""},
             DataRec {.f1="SC02_f1", .f2="SC02_f2"},
             [this](auto& mtr, auto& k1, auto& k2, auto& k3, auto& k4, auto& v1) {
+                K2LOG_D(log::k23si, "using mtr={}", mtr);
                 return seastar::when_all(
                     doRead(k1, mtr, collname, ErrorCaseOpt::NoInjection),
                     doRead(k2, mtr, collname, ErrorCaseOpt::NoInjection),
@@ -1533,11 +1609,10 @@ seastar::future<> testScenario02() {
     .then([this] {
         // SC02 case05&06: attempt to write in the past and write at same time
         return getTimestamps(2);
-        // return getTimeNow();
     })
     .then([this](auto&& ts) {
         K2LOG_I(log::k23si, "------- SC02.case 05&06 (for an existing key that has never been read, attempt to write in the past and write at same time) -------");
-
+        K2LOG_D(log::k23si, "Got {} timestamps", ts);
         return seastar::do_with(
             dto::K23SI_MTR {.timestamp = ts[0], .priority = dto::TxnPriority::Medium},
             dto::K23SI_MTR {.timestamp = ts[1], .priority = dto::TxnPriority::Medium},
@@ -1545,12 +1620,14 @@ seastar::future<> testScenario02() {
             DataRec {.f1="SC02_f05", .f2="SC02_f06"},
             DataRec {.f1="SC02_f07", .f2="SC02_f08"},
             [this](auto& staleMTR, auto& incumbentMTR, auto& k5, auto& v2, auto& v3) {
+                K2LOG_D(log::k23si, "using incumbentMTR={}", incumbentMTR);
                  return doWrite(k5, v2, incumbentMTR, k5, collname, false, true, ErrorCaseOpt::NoInjection)
                 .then([](auto&& response) {
                     auto& [status, resp] = response;
                     K2EXPECT(log::k23si, status, dto::K23SIStatus::Created);
                 })
                .then([this, &k5, &incumbentMTR] {
+                    K2LOG_D(log::k23si, "using incumbentMTR={}", incumbentMTR);
                     return doEnd(k5, incumbentMTR, collname, true, {k5}, Duration(0us), ErrorCaseOpt::NoInjection)
                     .then([](auto&& response) {
                         auto& [status, resp] = response;
@@ -1558,6 +1635,8 @@ seastar::future<> testScenario02() {
                     });
                 })
                 .then([this, &k5, &v3, &staleMTR] {
+                    K2LOG_D(log::k23si, "using staleMTR={}", staleMTR);
+
                     return doWrite(k5, v3, staleMTR, k5, collname, false, true, ErrorCaseOpt::NoInjection)
                     .then([](auto&& response) {
                         auto& [status, resp] = response;
@@ -1569,6 +1648,7 @@ seastar::future<> testScenario02() {
                         .timestamp = incumbentMTR.timestamp,
                         .priority = dto::TxnPriority::Medium
                     };
+                    K2LOG_D(log::k23si, "using challengerMTR={}", challengerMTR);
                     return doWrite(k5, v3, challengerMTR, k5, collname, false, true, ErrorCaseOpt::NoInjection)
                     .then([](auto&& response) {
                         auto& [status, resp] = response;
@@ -1590,12 +1670,14 @@ seastar::future<> testScenario02() {
             dto::Key {.schemaName = "schema", .partitionKey = "SC02_pkey5", .rangeKey = "range6"},
             DataRec {.f1="SC02_f07", .f2="SC02_f08"},
             [this](auto& futureMTR, auto& k5, auto& v3) {
+                K2LOG_D(log::k23si, "using futureMTR={}", futureMTR);
                  return doWrite(k5, v3, futureMTR, k5, collname, false, true, ErrorCaseOpt::NoInjection)
                 .then([](auto&& response) {
                     auto& [status, resp] = response;
                     K2EXPECT(log::k23si, status, dto::K23SIStatus::Created);
                 })
                 .then([this, &k5, &futureMTR, &v3] {
+                    K2LOG_D(log::k23si, "using futureMTR={}", futureMTR);
                     return doRead(k5, futureMTR, collname, ErrorCaseOpt::NoInjection)
                     .then([&](auto&& response) {
                         auto& [status, resp] = response;

--- a/test/k23si/3SITxnTest.cpp
+++ b/test/k23si/3SITxnTest.cpp
@@ -2502,7 +2502,7 @@ seastar::future<> testScenario06() {
             })
             .then([&] {
                 K2LOG_I(log::k23si, "------- SC06.case13 ( During async end_abort interval, finalize_commit those keys ) -------");
-                return doEnd(k7, mtr, collname, false, {k7, k8}, Duration{200ms}, ErrorCaseOpt::NoInjection)
+                return doEnd(k7, mtr, collname, false, {k7, k8}, Duration{50ms}, ErrorCaseOpt::NoInjection)
                 .then([](auto&& response)  {
                     auto& [status, val] = response;
                     K2EXPECT(log::k23si, status, dto::K23SIStatus::OK);

--- a/test/k23si/SchemaCreationTest.cpp
+++ b/test/k23si/SchemaCreationTest.cpp
@@ -56,7 +56,7 @@ public: // application lifespan
 
     seastar::future<> start() {
     K2LOG_I(log::k23si, "+++++++ start schema creation test +++++++");
-    ConfigVar<String> configEp("cpo_endpoint");
+    ConfigVar<String> configEp("cpo");
     _cpoEndpoint = RPC().getTXEndpoint(configEp());
 
     // let start() finish and then run the tests
@@ -633,8 +633,7 @@ seastar::future<> runScenario11(){
 
 int main(int argc, char** argv) {
     k2::App app("schemaCreationTest");
-    app.addOptions()("cpo_endpoint", bpo::value<k2::String>(), "The endpoint of the CPO");
+    app.addOptions()("cpo", bpo::value<k2::String>(), "The endpoint of the CPO");
     app.addApplet<k2::schemaCreation>();
     return app.start(argc, argv);
 }
-


### PR DESCRIPTION
There are a couple of changes made along with removing test sleeps:
1. adding retry operations for the TSOClient so that it keeps sending get tso requests to the CPO; enables async startup of TSOs and TSOClients.
2. Exponential Backoff strategy now sleeps before execute the next retry
3. Adding retry partition assignment in the CPO (to allow async startup of nodepools).
4. Using successful get timestamp using the TSO client as the signal for starting the tests. (remove sleep time)
5. Changed the inconsistent configuration variable naming (cpo_endpoint -> cpo)
6. Updates the 3sitxn test to use batch generated timestamps instead of manually create the timestamps. (The interval might be too large, depending on the execution speed the previous test's timestamp can cause problem for the next test)
