### PR TITLE
Fix bug for partial updates and writes to same key in same txn

### DIFF
--- a/src/k2/module/k23si/client/k23si_client.cpp
+++ b/src/k2/module/k23si/client/k23si_client.cpp
@@ -189,7 +189,7 @@ std::unique_ptr<dto::K23SIWriteRequest> K2TxnHandle::_makeWriteRequest(dto::SKVR
         .isDelete = erase,
         .designateTRH = isTRH,
         .precondition = precondition,
-        .request_id = _client->write_ops,
+        .request_id = _client->write_ops++,
         .key = key,
         .value = record.storage.share(),
         .fieldsForPartialUpdate = std::vector<uint32_t>()
@@ -213,12 +213,12 @@ std::unique_ptr<dto::K23SIWriteRequest> K2TxnHandle::_makePartialUpdateRequest(d
             false, // Partial update cannot be a delete
             isTRH,
             dto::ExistencePrecondition::Exists, // Partial update must be applied on existing record
-            _client->write_ops,
+            _client->write_ops++,
             std::move(key),
             record.storage.share(),
             fieldsForPartialUpdate
         });
-    }
+}
 
 seastar::future<EndResult> K2TxnHandle::end(bool shouldCommit) {
     k2::OperationLatencyReporter reporter(_client->_txnEndLatency);

--- a/src/k2/module/k23si/client/k23si_client.h
+++ b/src/k2/module/k23si/client/k23si_client.h
@@ -294,7 +294,6 @@ public:
             request = _makeWriteRequest(skv_record, erase, precondition);
         }
 
-        _client->write_ops++;
         _ongoing_ops++;
 
         return _cpo_client->partitionRequest
@@ -356,7 +355,6 @@ public:
         if (_failed) {
             return seastar::make_ready_future<PartialUpdateResult>(PartialUpdateResult(_failed_status));
         }
-        _client->write_ops++;
         _ongoing_ops++;
 
         std::unique_ptr<dto::K23SIWriteRequest> request;


### PR DESCRIPTION
The request id was not incremented in the same way for partial updates and normal writes,  which caused the nodepool idempotency/retry logic to trigger and writes could be ignored while still returning an OK status code.