### PR TITLE
Change decimal library - using memcpy

### DIFF
--- a/docs/design/FILTER_EXPRESSIONS.md
+++ b/docs/design/FILTER_EXPRESSIONS.md
@@ -9,8 +9,8 @@ Operator := EQ | GT | GTE | LT | LTE | IS_NULL | IS_EXACT_TYPE | STARTS_WITH | C
 Operand := Value | Expression
 Value := Reference | Literal
 Literal := FieldType, CPPBuiltInValueOfType
-FieldType := "INT16T" | "INT32T" | "INT64_T" | "FLOAT" | "DOUBLE" | "BOOL" | "STRING" | "DECIMAL64" | "DECIMAL128" | "FIELD_TYPE" | "NULL_T"
-CPPBuiltInValueOfType := int16_t | int32_t | int64_t | float | double | bool | string | std::decimal::decimal64 | std::decimal::decimal128 | k2::dto::FieldType | null
+FieldType := "INT16T" | "INT32T" | "INT64_T" | "FLOAT" | "DOUBLE" | "BOOL" | "STRING" | "DECIMALD50" | "DECIMALD100" | "FIELD_TYPE" | "NULL_T"
+CPPBuiltInValueOfType := int16_t | int32_t | int64_t | float | double | bool | string | boost::multiprecision::cpp_dec_float_50 | boost::multiprecision::cpp_dec_float_100 | k2::dto::FieldType | null
 Reference := FieldName
 FieldName := string
 ```

--- a/docs/design/FILTER_EXPRESSIONS.md
+++ b/docs/design/FILTER_EXPRESSIONS.md
@@ -9,8 +9,8 @@ Operator := EQ | GT | GTE | LT | LTE | IS_NULL | IS_EXACT_TYPE | STARTS_WITH | C
 Operand := Value | Expression
 Value := Reference | Literal
 Literal := FieldType, CPPBuiltInValueOfType
-FieldType := "INT16T" | "INT32T" | "INT64_T" | "FLOAT" | "DOUBLE" | "BOOL" | "STRING" | "DECIMALD50" | "DECIMALD100" | "FIELD_TYPE" | "NULL_T"
-CPPBuiltInValueOfType := int16_t | int32_t | int64_t | float | double | bool | string | boost::multiprecision::cpp_dec_float_50 | boost::multiprecision::cpp_dec_float_100 | k2::dto::FieldType | null
+FieldType := "INT16T" | "INT32T" | "INT64_T" | "FLOAT" | "DOUBLE" | "BOOL" | "STRING" | "DECIMALD25" | "DECIMALD50" | "DECIMALD100" | "FIELD_TYPE" | "NULL_T"
+CPPBuiltInValueOfType := int16_t | int32_t | int64_t | float | double | bool | string | boost::multiprecision::number<cpp_dec_float<25>> | boost::multiprecision::cpp_dec_float_50 | boost::multiprecision::cpp_dec_float_100 | k2::dto::FieldType | null
 Reference := FieldName
 FieldName := string
 ```

--- a/docs/design/FILTER_EXPRESSIONS.md
+++ b/docs/design/FILTER_EXPRESSIONS.md
@@ -10,7 +10,7 @@ Operand := Value | Expression
 Value := Reference | Literal
 Literal := FieldType, CPPBuiltInValueOfType
 FieldType := "INT16T" | "INT32T" | "INT64_T" | "FLOAT" | "DOUBLE" | "BOOL" | "STRING" | "DECIMALD25" | "DECIMALD50" | "DECIMALD100" | "FIELD_TYPE" | "NULL_T"
-CPPBuiltInValueOfType := int16_t | int32_t | int64_t | float | double | bool | string | boost::multiprecision::number<cpp_dec_float<25>> | boost::multiprecision::cpp_dec_float_50 | boost::multiprecision::cpp_dec_float_100 | k2::dto::FieldType | null
+CPPBuiltInValueOfType := int16_t | int32_t | int64_t | float | double | bool | string | boost::multiprecision::number<cpp_dec_float<25> > | boost::multiprecision::cpp_dec_float_50 | boost::multiprecision::cpp_dec_float_100 | k2::dto::FieldType | null
 Reference := FieldName
 FieldName := string
 ```

--- a/src/k2/cmd/tpcc/schema.h
+++ b/src/k2/cmd/tpcc/schema.h
@@ -25,6 +25,8 @@ Copyright(c) 2020 Futurewei Cloud
 
 #include <string>
 
+#include <boost/multiprecision/cpp_dec_float.hpp>
+
 #include <k2/common/Common.h>
 #include <k2/module/k23si/client/k23si_client.h>
 #include <k2/transport/Payload.h>
@@ -111,8 +113,8 @@ public:
         .version = 1,
         .fields = std::vector<dto::SchemaField> {
                 {dto::FieldType::INT16T, "ID", false, false},
-                {dto::FieldType::DECIMALD25, "Tax", false, false}, // Requires 4 digits of precision
-                {dto::FieldType::DECIMALD25, "YTD", false, false}, // Requires 12 digits of precision
+                {dto::FieldType::DECIMALD50, "Tax", false, false}, // Requires 4 digits of precision
+                {dto::FieldType::DECIMALD50, "YTD", false, false}, // Requires 12 digits of precision
                 {dto::FieldType::STRING, "Name", false, false},
                 {dto::FieldType::STRING, "Street1", false, false},
                 {dto::FieldType::STRING, "Street2", false, false},
@@ -137,8 +139,8 @@ public:
     Warehouse() = default;
 
     std::optional<int16_t> WarehouseID;
-    std::optional<boost::multiprecision::cpp_dec_float_25> Tax;
-    std::optional<boost::multiprecision::cpp_dec_float_25> YTD;
+    std::optional<boost::multiprecision::cpp_dec_float_50> Tax;
+    std::optional<boost::multiprecision::cpp_dec_float_50> YTD;
     std::optional<String> Name;
     Address address;
 
@@ -160,8 +162,8 @@ public:
         .fields = std::vector<dto::SchemaField> {
                 {dto::FieldType::INT16T, "ID", false, false},
                 {dto::FieldType::INT16T, "DID", false, false},
-                {dto::FieldType::DECIMALD25, "Tax", false, false}, // Requires 4 digits of precision
-                {dto::FieldType::DECIMALD25, "YTD", false, false}, // Requires 12 digits of precision
+                {dto::FieldType::DECIMALD50, "Tax", false, false}, // Requires 4 digits of precision
+                {dto::FieldType::DECIMALD50, "YTD", false, false}, // Requires 12 digits of precision
                 {dto::FieldType::INT64T, "NextOID", false, false},
                 {dto::FieldType::STRING, "Name", false, false},
                 {dto::FieldType::STRING, "Street1", false, false},
@@ -188,8 +190,8 @@ public:
 
     std::optional<int16_t> WarehouseID;
     std::optional<int16_t> DistrictID;
-    std::optional<boost::multiprecision::cpp_dec_float_25> Tax;
-    std::optional<boost::multiprecision::cpp_dec_float_25> YTD;
+    std::optional<boost::multiprecision::cpp_dec_float_50> Tax;
+    std::optional<boost::multiprecision::cpp_dec_float_50> YTD;
     std::optional<int64_t> NextOrderID;
     std::optional<String> Name;
     Address address;
@@ -213,10 +215,10 @@ public:
                 {dto::FieldType::INT16T, "DID", false, false},
                 {dto::FieldType::INT32T, "CID", false, false},
                 {dto::FieldType::INT64T, "SinceDate", false, false},
-                {dto::FieldType::DECIMALD25, "CreditLimit", false, false}, //Requires 12 digits of precision
-                {dto::FieldType::DECIMALD25, "Discount", false, false}, //Requires 4 digits of precision
-                {dto::FieldType::DECIMALD25, "Balance", false, false}, //Requires 12 digits of precision
-                {dto::FieldType::DECIMALD25, "YTDPayment", false, false}, //Requires 12 digits of precision
+                {dto::FieldType::DECIMALD50, "CreditLimit", false, false}, //Requires 12 digits of precision
+                {dto::FieldType::DECIMALD50, "Discount", false, false}, //Requires 4 digits of precision
+                {dto::FieldType::DECIMALD50, "Balance", false, false}, //Requires 12 digits of precision
+                {dto::FieldType::DECIMALD50, "YTDPayment", false, false}, //Requires 12 digits of precision
                 {dto::FieldType::INT32T, "PaymentCount", false, false}, // Requires max >= 9999
                 {dto::FieldType::INT32T, "DeliveryCount", false, false}, // Requires max >= 9999
                 {dto::FieldType::STRING, "FirstName", false, false},
@@ -274,10 +276,10 @@ public:
     std::optional<int16_t> DistrictID;
     std::optional<int32_t> CustomerID;
     std::optional<int64_t> SinceDate;
-    std::optional<boost::multiprecision::cpp_dec_float_25> CreditLimit;
-    std::optional<boost::multiprecision::cpp_dec_float_25> Discount;
-    std::optional<boost::multiprecision::cpp_dec_float_25> Balance;
-    std::optional<boost::multiprecision::cpp_dec_float_25> YTDPayment;
+    std::optional<boost::multiprecision::cpp_dec_float_50> CreditLimit;
+    std::optional<boost::multiprecision::cpp_dec_float_50> Discount;
+    std::optional<boost::multiprecision::cpp_dec_float_50> Balance;
+    std::optional<boost::multiprecision::cpp_dec_float_50> YTDPayment;
     std::optional<int32_t> PaymentCount;
     std::optional<int32_t> DeliveryCount;
     std::optional<String> FirstName;
@@ -339,7 +341,7 @@ public:
                 {dto::FieldType::INT64T, "Date", false, false},
                 {dto::FieldType::INT32T, "CID", false, false},
                 {dto::FieldType::INT16T, "CWID", false, false},
-                {dto::FieldType::DECIMALD25, "Amount", false, false}, // Requires 6 digits of precision
+                {dto::FieldType::DECIMALD50, "Amount", false, false}, // Requires 6 digits of precision
                 {dto::FieldType::INT16T, "CDID", false, false},
                 {dto::FieldType::INT16T, "DID", false, false},
                 {dto::FieldType::STRING, "Info", false, false}},
@@ -360,7 +362,7 @@ public:
 
     // For payment transaction
     History(int16_t w_id, int16_t d_id, int32_t c_id, int16_t c_w_id, int16_t c_d_id,
-                boost::multiprecision::cpp_dec_float_25 amount, const char w_name[], const char d_name[]) : WarehouseID(w_id) {
+                boost::multiprecision::cpp_dec_float_50 amount, const char w_name[], const char d_name[]) : WarehouseID(w_id) {
         Date = getDate();
         CustomerID = c_id;
         CustomerWarehouseID = c_w_id;
@@ -382,7 +384,7 @@ public:
     std::optional<int64_t> Date;
     std::optional<int32_t> CustomerID;
     std::optional<int16_t> CustomerWarehouseID;
-    std::optional<boost::multiprecision::cpp_dec_float_25> Amount;
+    std::optional<boost::multiprecision::cpp_dec_float_50> Amount;
     std::optional<int16_t> CustomerDistrictID;
     std::optional<int16_t> DistrictID;
     std::optional<String> Info;
@@ -530,7 +532,7 @@ public:
                 {dto::FieldType::INT64T, "DeliveryDate", false, false},
                 {dto::FieldType::INT32T, "ItemID", false, false},
                 {dto::FieldType::INT16T, "SupplyWID", false, false},
-                {dto::FieldType::DECIMALD25, "Amount", false, false}, // Requires 6 digits of precision
+                {dto::FieldType::DECIMALD50, "Amount", false, false}, // Requires 6 digits of precision
                 {dto::FieldType::INT16T, "Quantity", false, false},
                 {dto::FieldType::STRING, "DistInfo", false, false}},
         .partitionKeyFields = std::vector<uint32_t> { 0 },
@@ -588,7 +590,7 @@ public:
     std::optional<int64_t> DeliveryDate;
     std::optional<int32_t> ItemID;
     std::optional<int16_t> SupplyWarehouseID;
-    std::optional<boost::multiprecision::cpp_dec_float_25> Amount;
+    std::optional<boost::multiprecision::cpp_dec_float_50> Amount;
     std::optional<int16_t> Quantity;
     std::optional<String> DistInfo;
 
@@ -607,7 +609,7 @@ public:
         .fields = std::vector<dto::SchemaField> {
                 {dto::FieldType::INT32T, "ID", false, false},
                 {dto::FieldType::INT32T, "ImageID", false, false},
-                {dto::FieldType::DECIMALD25, "Price", false, false}, // Requires 5 digits of precision
+                {dto::FieldType::DECIMALD50, "Price", false, false}, // Requires 5 digits of precision
                 {dto::FieldType::STRING, "Name", false, false},
                 {dto::FieldType::STRING, "Info", false, false}},
         .partitionKeyFields = std::vector<uint32_t> { 0 },
@@ -635,7 +637,7 @@ public:
 
     std::optional<int32_t> ItemID;
     std::optional<int32_t> ImageID;
-    std::optional<boost::multiprecision::cpp_dec_float_25> Price;
+    std::optional<boost::multiprecision::cpp_dec_float_50> Price;
     std::optional<String> Name;
     std::optional<String> Info;
 
@@ -652,7 +654,7 @@ public:
         .fields = std::vector<dto::SchemaField> {
                 {dto::FieldType::INT16T, "ID", false, false},
                 {dto::FieldType::INT32T, "ItemID", false, false},
-                {dto::FieldType::DECIMALD25, "YTD", false, false}, // Requires 8 digits of precision
+                {dto::FieldType::DECIMALD50, "YTD", false, false}, // Requires 8 digits of precision
                 {dto::FieldType::INT16T, "OrderCount", false, false},
                 {dto::FieldType::INT16T, "RemoteCount", false, false},
                 {dto::FieldType::INT16T, "Quantity", false, false},
@@ -729,7 +731,7 @@ public:
 
     std::optional<int16_t> WarehouseID;
     std::optional<int32_t> ItemID;
-    std::optional<boost::multiprecision::cpp_dec_float_25> YTD;
+    std::optional<boost::multiprecision::cpp_dec_float_50> YTD;
     std::optional<int16_t> OrderCount;
     std::optional<int16_t> RemoteCount;
     std::optional<int16_t> Quantity;

--- a/src/k2/cmd/tpcc/schema.h
+++ b/src/k2/cmd/tpcc/schema.h
@@ -113,8 +113,8 @@ public:
         .version = 1,
         .fields = std::vector<dto::SchemaField> {
                 {dto::FieldType::INT16T, "ID", false, false},
-                {dto::FieldType::DECIMALD50, "Tax", false, false}, // Requires 4 digits of precision
-                {dto::FieldType::DECIMALD50, "YTD", false, false}, // Requires 12 digits of precision
+                {dto::FieldType::DECIMALD25, "Tax", false, false}, // Requires 4 digits of precision
+                {dto::FieldType::DECIMALD25, "YTD", false, false}, // Requires 12 digits of precision
                 {dto::FieldType::STRING, "Name", false, false},
                 {dto::FieldType::STRING, "Street1", false, false},
                 {dto::FieldType::STRING, "Street2", false, false},
@@ -139,8 +139,8 @@ public:
     Warehouse() = default;
 
     std::optional<int16_t> WarehouseID;
-    std::optional<boost::multiprecision::cpp_dec_float_50> Tax;
-    std::optional<boost::multiprecision::cpp_dec_float_50> YTD;
+    std::optional<boost::multiprecision::cpp_dec_float_25> Tax;
+    std::optional<boost::multiprecision::cpp_dec_float_25> YTD;
     std::optional<String> Name;
     Address address;
 
@@ -162,8 +162,8 @@ public:
         .fields = std::vector<dto::SchemaField> {
                 {dto::FieldType::INT16T, "ID", false, false},
                 {dto::FieldType::INT16T, "DID", false, false},
-                {dto::FieldType::DECIMALD50, "Tax", false, false}, // Requires 4 digits of precision
-                {dto::FieldType::DECIMALD50, "YTD", false, false}, // Requires 12 digits of precision
+                {dto::FieldType::DECIMALD25, "Tax", false, false}, // Requires 4 digits of precision
+                {dto::FieldType::DECIMALD25, "YTD", false, false}, // Requires 12 digits of precision
                 {dto::FieldType::INT64T, "NextOID", false, false},
                 {dto::FieldType::STRING, "Name", false, false},
                 {dto::FieldType::STRING, "Street1", false, false},
@@ -190,8 +190,8 @@ public:
 
     std::optional<int16_t> WarehouseID;
     std::optional<int16_t> DistrictID;
-    std::optional<boost::multiprecision::cpp_dec_float_50> Tax;
-    std::optional<boost::multiprecision::cpp_dec_float_50> YTD;
+    std::optional<boost::multiprecision::cpp_dec_float_25> Tax;
+    std::optional<boost::multiprecision::cpp_dec_float_25> YTD;
     std::optional<int64_t> NextOrderID;
     std::optional<String> Name;
     Address address;
@@ -215,10 +215,10 @@ public:
                 {dto::FieldType::INT16T, "DID", false, false},
                 {dto::FieldType::INT32T, "CID", false, false},
                 {dto::FieldType::INT64T, "SinceDate", false, false},
-                {dto::FieldType::DECIMALD50, "CreditLimit", false, false}, //Requires 12 digits of precision
-                {dto::FieldType::DECIMALD50, "Discount", false, false}, //Requires 4 digits of precision
-                {dto::FieldType::DECIMALD50, "Balance", false, false}, //Requires 12 digits of precision
-                {dto::FieldType::DECIMALD50, "YTDPayment", false, false}, //Requires 12 digits of precision
+                {dto::FieldType::DECIMALD25, "CreditLimit", false, false}, //Requires 12 digits of precision
+                {dto::FieldType::DECIMALD25, "Discount", false, false}, //Requires 4 digits of precision
+                {dto::FieldType::DECIMALD25, "Balance", false, false}, //Requires 12 digits of precision
+                {dto::FieldType::DECIMALD25, "YTDPayment", false, false}, //Requires 12 digits of precision
                 {dto::FieldType::INT32T, "PaymentCount", false, false}, // Requires max >= 9999
                 {dto::FieldType::INT32T, "DeliveryCount", false, false}, // Requires max >= 9999
                 {dto::FieldType::STRING, "FirstName", false, false},
@@ -276,10 +276,10 @@ public:
     std::optional<int16_t> DistrictID;
     std::optional<int32_t> CustomerID;
     std::optional<int64_t> SinceDate;
-    std::optional<boost::multiprecision::cpp_dec_float_50> CreditLimit;
-    std::optional<boost::multiprecision::cpp_dec_float_50> Discount;
-    std::optional<boost::multiprecision::cpp_dec_float_50> Balance;
-    std::optional<boost::multiprecision::cpp_dec_float_50> YTDPayment;
+    std::optional<boost::multiprecision::cpp_dec_float_25> CreditLimit;
+    std::optional<boost::multiprecision::cpp_dec_float_25> Discount;
+    std::optional<boost::multiprecision::cpp_dec_float_25> Balance;
+    std::optional<boost::multiprecision::cpp_dec_float_25> YTDPayment;
     std::optional<int32_t> PaymentCount;
     std::optional<int32_t> DeliveryCount;
     std::optional<String> FirstName;
@@ -341,7 +341,7 @@ public:
                 {dto::FieldType::INT64T, "Date", false, false},
                 {dto::FieldType::INT32T, "CID", false, false},
                 {dto::FieldType::INT16T, "CWID", false, false},
-                {dto::FieldType::DECIMALD50, "Amount", false, false}, // Requires 6 digits of precision
+                {dto::FieldType::DECIMALD25, "Amount", false, false}, // Requires 6 digits of precision
                 {dto::FieldType::INT16T, "CDID", false, false},
                 {dto::FieldType::INT16T, "DID", false, false},
                 {dto::FieldType::STRING, "Info", false, false}},
@@ -362,7 +362,7 @@ public:
 
     // For payment transaction
     History(int16_t w_id, int16_t d_id, int32_t c_id, int16_t c_w_id, int16_t c_d_id,
-                boost::multiprecision::cpp_dec_float_50 amount, const char w_name[], const char d_name[]) : WarehouseID(w_id) {
+                boost::multiprecision::cpp_dec_float_25 amount, const char w_name[], const char d_name[]) : WarehouseID(w_id) {
         Date = getDate();
         CustomerID = c_id;
         CustomerWarehouseID = c_w_id;
@@ -384,7 +384,7 @@ public:
     std::optional<int64_t> Date;
     std::optional<int32_t> CustomerID;
     std::optional<int16_t> CustomerWarehouseID;
-    std::optional<boost::multiprecision::cpp_dec_float_50> Amount;
+    std::optional<boost::multiprecision::cpp_dec_float_25> Amount;
     std::optional<int16_t> CustomerDistrictID;
     std::optional<int16_t> DistrictID;
     std::optional<String> Info;
@@ -532,7 +532,7 @@ public:
                 {dto::FieldType::INT64T, "DeliveryDate", false, false},
                 {dto::FieldType::INT32T, "ItemID", false, false},
                 {dto::FieldType::INT16T, "SupplyWID", false, false},
-                {dto::FieldType::DECIMALD50, "Amount", false, false}, // Requires 6 digits of precision
+                {dto::FieldType::DECIMALD25, "Amount", false, false}, // Requires 6 digits of precision
                 {dto::FieldType::INT16T, "Quantity", false, false},
                 {dto::FieldType::STRING, "DistInfo", false, false}},
         .partitionKeyFields = std::vector<uint32_t> { 0 },
@@ -590,7 +590,7 @@ public:
     std::optional<int64_t> DeliveryDate;
     std::optional<int32_t> ItemID;
     std::optional<int16_t> SupplyWarehouseID;
-    std::optional<boost::multiprecision::cpp_dec_float_50> Amount;
+    std::optional<boost::multiprecision::cpp_dec_float_25> Amount;
     std::optional<int16_t> Quantity;
     std::optional<String> DistInfo;
 
@@ -609,7 +609,7 @@ public:
         .fields = std::vector<dto::SchemaField> {
                 {dto::FieldType::INT32T, "ID", false, false},
                 {dto::FieldType::INT32T, "ImageID", false, false},
-                {dto::FieldType::DECIMALD50, "Price", false, false}, // Requires 5 digits of precision
+                {dto::FieldType::DECIMALD25, "Price", false, false}, // Requires 5 digits of precision
                 {dto::FieldType::STRING, "Name", false, false},
                 {dto::FieldType::STRING, "Info", false, false}},
         .partitionKeyFields = std::vector<uint32_t> { 0 },
@@ -637,7 +637,7 @@ public:
 
     std::optional<int32_t> ItemID;
     std::optional<int32_t> ImageID;
-    std::optional<boost::multiprecision::cpp_dec_float_50> Price;
+    std::optional<boost::multiprecision::cpp_dec_float_25> Price;
     std::optional<String> Name;
     std::optional<String> Info;
 
@@ -654,7 +654,7 @@ public:
         .fields = std::vector<dto::SchemaField> {
                 {dto::FieldType::INT16T, "ID", false, false},
                 {dto::FieldType::INT32T, "ItemID", false, false},
-                {dto::FieldType::DECIMALD50, "YTD", false, false}, // Requires 8 digits of precision
+                {dto::FieldType::DECIMALD25, "YTD", false, false}, // Requires 8 digits of precision
                 {dto::FieldType::INT16T, "OrderCount", false, false},
                 {dto::FieldType::INT16T, "RemoteCount", false, false},
                 {dto::FieldType::INT16T, "Quantity", false, false},
@@ -731,7 +731,7 @@ public:
 
     std::optional<int16_t> WarehouseID;
     std::optional<int32_t> ItemID;
-    std::optional<boost::multiprecision::cpp_dec_float_50> YTD;
+    std::optional<boost::multiprecision::cpp_dec_float_25> YTD;
     std::optional<int16_t> OrderCount;
     std::optional<int16_t> RemoteCount;
     std::optional<int16_t> Quantity;

--- a/src/k2/cmd/tpcc/schema.h
+++ b/src/k2/cmd/tpcc/schema.h
@@ -25,8 +25,6 @@ Copyright(c) 2020 Futurewei Cloud
 
 #include <string>
 
-#include <boost/multiprecision/cpp_dec_float.hpp>
-
 #include <k2/common/Common.h>
 #include <k2/module/k23si/client/k23si_client.h>
 #include <k2/transport/Payload.h>

--- a/src/k2/cmd/tpcc/schema.h
+++ b/src/k2/cmd/tpcc/schema.h
@@ -23,7 +23,6 @@ Copyright(c) 2020 Futurewei Cloud
 
 #pragma once
 
-#include <decimal/decimal>
 #include <string>
 
 #include <boost/multiprecision/cpp_dec_float.hpp>

--- a/src/k2/cmd/tpcc/schema.h
+++ b/src/k2/cmd/tpcc/schema.h
@@ -25,8 +25,6 @@ Copyright(c) 2020 Futurewei Cloud
 
 #include <string>
 
-#include <boost/multiprecision/cpp_dec_float.hpp>
-
 #include <k2/common/Common.h>
 #include <k2/module/k23si/client/k23si_client.h>
 #include <k2/transport/Payload.h>
@@ -113,8 +111,8 @@ public:
         .version = 1,
         .fields = std::vector<dto::SchemaField> {
                 {dto::FieldType::INT16T, "ID", false, false},
-                {dto::FieldType::DECIMALD50, "Tax", false, false}, // Requires 4 digits of precision
-                {dto::FieldType::DECIMALD50, "YTD", false, false}, // Requires 12 digits of precision
+                {dto::FieldType::DECIMALD25, "Tax", false, false}, // Requires 4 digits of precision
+                {dto::FieldType::DECIMALD25, "YTD", false, false}, // Requires 12 digits of precision
                 {dto::FieldType::STRING, "Name", false, false},
                 {dto::FieldType::STRING, "Street1", false, false},
                 {dto::FieldType::STRING, "Street2", false, false},
@@ -139,8 +137,8 @@ public:
     Warehouse() = default;
 
     std::optional<int16_t> WarehouseID;
-    std::optional<boost::multiprecision::cpp_dec_float_50> Tax;
-    std::optional<boost::multiprecision::cpp_dec_float_50> YTD;
+    std::optional<boost::multiprecision::cpp_dec_float_25> Tax;
+    std::optional<boost::multiprecision::cpp_dec_float_25> YTD;
     std::optional<String> Name;
     Address address;
 
@@ -162,8 +160,8 @@ public:
         .fields = std::vector<dto::SchemaField> {
                 {dto::FieldType::INT16T, "ID", false, false},
                 {dto::FieldType::INT16T, "DID", false, false},
-                {dto::FieldType::DECIMALD50, "Tax", false, false}, // Requires 4 digits of precision
-                {dto::FieldType::DECIMALD50, "YTD", false, false}, // Requires 12 digits of precision
+                {dto::FieldType::DECIMALD25, "Tax", false, false}, // Requires 4 digits of precision
+                {dto::FieldType::DECIMALD25, "YTD", false, false}, // Requires 12 digits of precision
                 {dto::FieldType::INT64T, "NextOID", false, false},
                 {dto::FieldType::STRING, "Name", false, false},
                 {dto::FieldType::STRING, "Street1", false, false},
@@ -190,8 +188,8 @@ public:
 
     std::optional<int16_t> WarehouseID;
     std::optional<int16_t> DistrictID;
-    std::optional<boost::multiprecision::cpp_dec_float_50> Tax;
-    std::optional<boost::multiprecision::cpp_dec_float_50> YTD;
+    std::optional<boost::multiprecision::cpp_dec_float_25> Tax;
+    std::optional<boost::multiprecision::cpp_dec_float_25> YTD;
     std::optional<int64_t> NextOrderID;
     std::optional<String> Name;
     Address address;
@@ -215,10 +213,10 @@ public:
                 {dto::FieldType::INT16T, "DID", false, false},
                 {dto::FieldType::INT32T, "CID", false, false},
                 {dto::FieldType::INT64T, "SinceDate", false, false},
-                {dto::FieldType::DECIMALD50, "CreditLimit", false, false}, //Requires 12 digits of precision
-                {dto::FieldType::DECIMALD50, "Discount", false, false}, //Requires 4 digits of precision
-                {dto::FieldType::DECIMALD50, "Balance", false, false}, //Requires 12 digits of precision
-                {dto::FieldType::DECIMALD50, "YTDPayment", false, false}, //Requires 12 digits of precision
+                {dto::FieldType::DECIMALD25, "CreditLimit", false, false}, //Requires 12 digits of precision
+                {dto::FieldType::DECIMALD25, "Discount", false, false}, //Requires 4 digits of precision
+                {dto::FieldType::DECIMALD25, "Balance", false, false}, //Requires 12 digits of precision
+                {dto::FieldType::DECIMALD25, "YTDPayment", false, false}, //Requires 12 digits of precision
                 {dto::FieldType::INT32T, "PaymentCount", false, false}, // Requires max >= 9999
                 {dto::FieldType::INT32T, "DeliveryCount", false, false}, // Requires max >= 9999
                 {dto::FieldType::STRING, "FirstName", false, false},
@@ -276,10 +274,10 @@ public:
     std::optional<int16_t> DistrictID;
     std::optional<int32_t> CustomerID;
     std::optional<int64_t> SinceDate;
-    std::optional<boost::multiprecision::cpp_dec_float_50> CreditLimit;
-    std::optional<boost::multiprecision::cpp_dec_float_50> Discount;
-    std::optional<boost::multiprecision::cpp_dec_float_50> Balance;
-    std::optional<boost::multiprecision::cpp_dec_float_50> YTDPayment;
+    std::optional<boost::multiprecision::cpp_dec_float_25> CreditLimit;
+    std::optional<boost::multiprecision::cpp_dec_float_25> Discount;
+    std::optional<boost::multiprecision::cpp_dec_float_25> Balance;
+    std::optional<boost::multiprecision::cpp_dec_float_25> YTDPayment;
     std::optional<int32_t> PaymentCount;
     std::optional<int32_t> DeliveryCount;
     std::optional<String> FirstName;
@@ -341,7 +339,7 @@ public:
                 {dto::FieldType::INT64T, "Date", false, false},
                 {dto::FieldType::INT32T, "CID", false, false},
                 {dto::FieldType::INT16T, "CWID", false, false},
-                {dto::FieldType::DECIMALD50, "Amount", false, false}, // Requires 6 digits of precision
+                {dto::FieldType::DECIMALD25, "Amount", false, false}, // Requires 6 digits of precision
                 {dto::FieldType::INT16T, "CDID", false, false},
                 {dto::FieldType::INT16T, "DID", false, false},
                 {dto::FieldType::STRING, "Info", false, false}},
@@ -362,7 +360,7 @@ public:
 
     // For payment transaction
     History(int16_t w_id, int16_t d_id, int32_t c_id, int16_t c_w_id, int16_t c_d_id,
-                boost::multiprecision::cpp_dec_float_50 amount, const char w_name[], const char d_name[]) : WarehouseID(w_id) {
+                boost::multiprecision::cpp_dec_float_25 amount, const char w_name[], const char d_name[]) : WarehouseID(w_id) {
         Date = getDate();
         CustomerID = c_id;
         CustomerWarehouseID = c_w_id;
@@ -384,7 +382,7 @@ public:
     std::optional<int64_t> Date;
     std::optional<int32_t> CustomerID;
     std::optional<int16_t> CustomerWarehouseID;
-    std::optional<boost::multiprecision::cpp_dec_float_50> Amount;
+    std::optional<boost::multiprecision::cpp_dec_float_25> Amount;
     std::optional<int16_t> CustomerDistrictID;
     std::optional<int16_t> DistrictID;
     std::optional<String> Info;
@@ -532,7 +530,7 @@ public:
                 {dto::FieldType::INT64T, "DeliveryDate", false, false},
                 {dto::FieldType::INT32T, "ItemID", false, false},
                 {dto::FieldType::INT16T, "SupplyWID", false, false},
-                {dto::FieldType::DECIMALD50, "Amount", false, false}, // Requires 6 digits of precision
+                {dto::FieldType::DECIMALD25, "Amount", false, false}, // Requires 6 digits of precision
                 {dto::FieldType::INT16T, "Quantity", false, false},
                 {dto::FieldType::STRING, "DistInfo", false, false}},
         .partitionKeyFields = std::vector<uint32_t> { 0 },
@@ -590,7 +588,7 @@ public:
     std::optional<int64_t> DeliveryDate;
     std::optional<int32_t> ItemID;
     std::optional<int16_t> SupplyWarehouseID;
-    std::optional<boost::multiprecision::cpp_dec_float_50> Amount;
+    std::optional<boost::multiprecision::cpp_dec_float_25> Amount;
     std::optional<int16_t> Quantity;
     std::optional<String> DistInfo;
 
@@ -609,7 +607,7 @@ public:
         .fields = std::vector<dto::SchemaField> {
                 {dto::FieldType::INT32T, "ID", false, false},
                 {dto::FieldType::INT32T, "ImageID", false, false},
-                {dto::FieldType::DECIMALD50, "Price", false, false}, // Requires 5 digits of precision
+                {dto::FieldType::DECIMALD25, "Price", false, false}, // Requires 5 digits of precision
                 {dto::FieldType::STRING, "Name", false, false},
                 {dto::FieldType::STRING, "Info", false, false}},
         .partitionKeyFields = std::vector<uint32_t> { 0 },
@@ -637,7 +635,7 @@ public:
 
     std::optional<int32_t> ItemID;
     std::optional<int32_t> ImageID;
-    std::optional<boost::multiprecision::cpp_dec_float_50> Price;
+    std::optional<boost::multiprecision::cpp_dec_float_25> Price;
     std::optional<String> Name;
     std::optional<String> Info;
 
@@ -654,7 +652,7 @@ public:
         .fields = std::vector<dto::SchemaField> {
                 {dto::FieldType::INT16T, "ID", false, false},
                 {dto::FieldType::INT32T, "ItemID", false, false},
-                {dto::FieldType::DECIMALD50, "YTD", false, false}, // Requires 8 digits of precision
+                {dto::FieldType::DECIMALD25, "YTD", false, false}, // Requires 8 digits of precision
                 {dto::FieldType::INT16T, "OrderCount", false, false},
                 {dto::FieldType::INT16T, "RemoteCount", false, false},
                 {dto::FieldType::INT16T, "Quantity", false, false},
@@ -731,7 +729,7 @@ public:
 
     std::optional<int16_t> WarehouseID;
     std::optional<int32_t> ItemID;
-    std::optional<boost::multiprecision::cpp_dec_float_50> YTD;
+    std::optional<boost::multiprecision::cpp_dec_float_25> YTD;
     std::optional<int16_t> OrderCount;
     std::optional<int16_t> RemoteCount;
     std::optional<int16_t> Quantity;

--- a/src/k2/cmd/tpcc/schema.h
+++ b/src/k2/cmd/tpcc/schema.h
@@ -137,8 +137,8 @@ public:
     Warehouse() = default;
 
     std::optional<int16_t> WarehouseID;
-    std::optional<boost::multiprecision::cpp_dec_float_25> Tax;
-    std::optional<boost::multiprecision::cpp_dec_float_25> YTD;
+    std::optional<DecimalD25> Tax;
+    std::optional<DecimalD25> YTD;
     std::optional<String> Name;
     Address address;
 
@@ -188,8 +188,8 @@ public:
 
     std::optional<int16_t> WarehouseID;
     std::optional<int16_t> DistrictID;
-    std::optional<boost::multiprecision::cpp_dec_float_25> Tax;
-    std::optional<boost::multiprecision::cpp_dec_float_25> YTD;
+    std::optional<DecimalD25> Tax;
+    std::optional<DecimalD25> YTD;
     std::optional<int64_t> NextOrderID;
     std::optional<String> Name;
     Address address;
@@ -274,10 +274,10 @@ public:
     std::optional<int16_t> DistrictID;
     std::optional<int32_t> CustomerID;
     std::optional<int64_t> SinceDate;
-    std::optional<boost::multiprecision::cpp_dec_float_25> CreditLimit;
-    std::optional<boost::multiprecision::cpp_dec_float_25> Discount;
-    std::optional<boost::multiprecision::cpp_dec_float_25> Balance;
-    std::optional<boost::multiprecision::cpp_dec_float_25> YTDPayment;
+    std::optional<DecimalD25> CreditLimit;
+    std::optional<DecimalD25> Discount;
+    std::optional<DecimalD25> Balance;
+    std::optional<DecimalD25> YTDPayment;
     std::optional<int32_t> PaymentCount;
     std::optional<int32_t> DeliveryCount;
     std::optional<String> FirstName;
@@ -360,7 +360,7 @@ public:
 
     // For payment transaction
     History(int16_t w_id, int16_t d_id, int32_t c_id, int16_t c_w_id, int16_t c_d_id,
-                boost::multiprecision::cpp_dec_float_25 amount, const char w_name[], const char d_name[]) : WarehouseID(w_id) {
+                DecimalD25 amount, const char w_name[], const char d_name[]) : WarehouseID(w_id) {
         Date = getDate();
         CustomerID = c_id;
         CustomerWarehouseID = c_w_id;
@@ -382,7 +382,7 @@ public:
     std::optional<int64_t> Date;
     std::optional<int32_t> CustomerID;
     std::optional<int16_t> CustomerWarehouseID;
-    std::optional<boost::multiprecision::cpp_dec_float_25> Amount;
+    std::optional<DecimalD25> Amount;
     std::optional<int16_t> CustomerDistrictID;
     std::optional<int16_t> DistrictID;
     std::optional<String> Info;
@@ -588,7 +588,7 @@ public:
     std::optional<int64_t> DeliveryDate;
     std::optional<int32_t> ItemID;
     std::optional<int16_t> SupplyWarehouseID;
-    std::optional<boost::multiprecision::cpp_dec_float_25> Amount;
+    std::optional<DecimalD25> Amount;
     std::optional<int16_t> Quantity;
     std::optional<String> DistInfo;
 
@@ -635,7 +635,7 @@ public:
 
     std::optional<int32_t> ItemID;
     std::optional<int32_t> ImageID;
-    std::optional<boost::multiprecision::cpp_dec_float_25> Price;
+    std::optional<DecimalD25> Price;
     std::optional<String> Name;
     std::optional<String> Info;
 
@@ -729,7 +729,7 @@ public:
 
     std::optional<int16_t> WarehouseID;
     std::optional<int32_t> ItemID;
-    std::optional<boost::multiprecision::cpp_dec_float_25> YTD;
+    std::optional<DecimalD25> YTD;
     std::optional<int16_t> OrderCount;
     std::optional<int16_t> RemoteCount;
     std::optional<int16_t> Quantity;

--- a/src/k2/cmd/tpcc/schema.h
+++ b/src/k2/cmd/tpcc/schema.h
@@ -26,6 +26,8 @@ Copyright(c) 2020 Futurewei Cloud
 #include <decimal/decimal>
 #include <string>
 
+#include <boost/multiprecision/cpp_dec_float.hpp>
+
 #include <k2/common/Common.h>
 #include <k2/module/k23si/client/k23si_client.h>
 #include <k2/transport/Payload.h>
@@ -138,8 +140,8 @@ public:
     Warehouse() = default;
 
     std::optional<int16_t> WarehouseID;
-    std::optional<std::decimal::decimal64> Tax;
-    std::optional<std::decimal::decimal64> YTD;
+    std::optional<boost::multiprecision::cpp_dec_float_50> Tax;
+    std::optional<boost::multiprecision::cpp_dec_float_50> YTD;
     std::optional<String> Name;
     Address address;
 
@@ -189,8 +191,8 @@ public:
 
     std::optional<int16_t> WarehouseID;
     std::optional<int16_t> DistrictID;
-    std::optional<std::decimal::decimal64> Tax;
-    std::optional<std::decimal::decimal64> YTD;
+    std::optional<boost::multiprecision::cpp_dec_float_50> Tax;
+    std::optional<boost::multiprecision::cpp_dec_float_50> YTD;
     std::optional<int64_t> NextOrderID;
     std::optional<String> Name;
     Address address;
@@ -275,10 +277,10 @@ public:
     std::optional<int16_t> DistrictID;
     std::optional<int32_t> CustomerID;
     std::optional<int64_t> SinceDate;
-    std::optional<std::decimal::decimal64> CreditLimit;
-    std::optional<std::decimal::decimal64> Discount;
-    std::optional<std::decimal::decimal64> Balance;
-    std::optional<std::decimal::decimal64> YTDPayment;
+    std::optional<boost::multiprecision::cpp_dec_float_50> CreditLimit;
+    std::optional<boost::multiprecision::cpp_dec_float_50> Discount;
+    std::optional<boost::multiprecision::cpp_dec_float_50> Balance;
+    std::optional<boost::multiprecision::cpp_dec_float_50> YTDPayment;
     std::optional<int32_t> PaymentCount;
     std::optional<int32_t> DeliveryCount;
     std::optional<String> FirstName;
@@ -361,7 +363,7 @@ public:
 
     // For payment transaction
     History(int16_t w_id, int16_t d_id, int32_t c_id, int16_t c_w_id, int16_t c_d_id,
-                std::decimal::decimal64 amount, const char w_name[], const char d_name[]) : WarehouseID(w_id) {
+                boost::multiprecision::cpp_dec_float_50 amount, const char w_name[], const char d_name[]) : WarehouseID(w_id) {
         Date = getDate();
         CustomerID = c_id;
         CustomerWarehouseID = c_w_id;
@@ -383,7 +385,7 @@ public:
     std::optional<int64_t> Date;
     std::optional<int32_t> CustomerID;
     std::optional<int16_t> CustomerWarehouseID;
-    std::optional<std::decimal::decimal64> Amount;
+    std::optional<boost::multiprecision::cpp_dec_float_50> Amount;
     std::optional<int16_t> CustomerDistrictID;
     std::optional<int16_t> DistrictID;
     std::optional<String> Info;
@@ -589,7 +591,7 @@ public:
     std::optional<int64_t> DeliveryDate;
     std::optional<int32_t> ItemID;
     std::optional<int16_t> SupplyWarehouseID;
-    std::optional<std::decimal::decimal64> Amount;
+    std::optional<boost::multiprecision::cpp_dec_float_50> Amount;
     std::optional<int16_t> Quantity;
     std::optional<String> DistInfo;
 
@@ -636,7 +638,7 @@ public:
 
     std::optional<int32_t> ItemID;
     std::optional<int32_t> ImageID;
-    std::optional<std::decimal::decimal64> Price;
+    std::optional<boost::multiprecision::cpp_dec_float_50> Price;
     std::optional<String> Name;
     std::optional<String> Info;
 
@@ -730,7 +732,7 @@ public:
 
     std::optional<int16_t> WarehouseID;
     std::optional<int32_t> ItemID;
-    std::optional<std::decimal::decimal64> YTD;
+    std::optional<boost::multiprecision::cpp_dec_float_50> YTD;
     std::optional<int16_t> OrderCount;
     std::optional<int16_t> RemoteCount;
     std::optional<int16_t> Quantity;

--- a/src/k2/cmd/tpcc/schema.h
+++ b/src/k2/cmd/tpcc/schema.h
@@ -112,8 +112,8 @@ public:
         .version = 1,
         .fields = std::vector<dto::SchemaField> {
                 {dto::FieldType::INT16T, "ID", false, false},
-                {dto::FieldType::DECIMAL64, "Tax", false, false}, // Requires 4 digits of precision
-                {dto::FieldType::DECIMAL64, "YTD", false, false}, // Requires 12 digits of precision
+                {dto::FieldType::DECIMALD50, "Tax", false, false}, // Requires 4 digits of precision
+                {dto::FieldType::DECIMALD50, "YTD", false, false}, // Requires 12 digits of precision
                 {dto::FieldType::STRING, "Name", false, false},
                 {dto::FieldType::STRING, "Street1", false, false},
                 {dto::FieldType::STRING, "Street2", false, false},
@@ -161,8 +161,8 @@ public:
         .fields = std::vector<dto::SchemaField> {
                 {dto::FieldType::INT16T, "ID", false, false},
                 {dto::FieldType::INT16T, "DID", false, false},
-                {dto::FieldType::DECIMAL64, "Tax", false, false}, // Requires 4 digits of precision
-                {dto::FieldType::DECIMAL64, "YTD", false, false}, // Requires 12 digits of precision
+                {dto::FieldType::DECIMALD50, "Tax", false, false}, // Requires 4 digits of precision
+                {dto::FieldType::DECIMALD50, "YTD", false, false}, // Requires 12 digits of precision
                 {dto::FieldType::INT64T, "NextOID", false, false},
                 {dto::FieldType::STRING, "Name", false, false},
                 {dto::FieldType::STRING, "Street1", false, false},
@@ -214,10 +214,10 @@ public:
                 {dto::FieldType::INT16T, "DID", false, false},
                 {dto::FieldType::INT32T, "CID", false, false},
                 {dto::FieldType::INT64T, "SinceDate", false, false},
-                {dto::FieldType::DECIMAL64, "CreditLimit", false, false}, //Requires 12 digits of precision
-                {dto::FieldType::DECIMAL64, "Discount", false, false}, //Requires 4 digits of precision
-                {dto::FieldType::DECIMAL64, "Balance", false, false}, //Requires 12 digits of precision
-                {dto::FieldType::DECIMAL64, "YTDPayment", false, false}, //Requires 12 digits of precision
+                {dto::FieldType::DECIMALD50, "CreditLimit", false, false}, //Requires 12 digits of precision
+                {dto::FieldType::DECIMALD50, "Discount", false, false}, //Requires 4 digits of precision
+                {dto::FieldType::DECIMALD50, "Balance", false, false}, //Requires 12 digits of precision
+                {dto::FieldType::DECIMALD50, "YTDPayment", false, false}, //Requires 12 digits of precision
                 {dto::FieldType::INT32T, "PaymentCount", false, false}, // Requires max >= 9999
                 {dto::FieldType::INT32T, "DeliveryCount", false, false}, // Requires max >= 9999
                 {dto::FieldType::STRING, "FirstName", false, false},
@@ -340,7 +340,7 @@ public:
                 {dto::FieldType::INT64T, "Date", false, false},
                 {dto::FieldType::INT32T, "CID", false, false},
                 {dto::FieldType::INT16T, "CWID", false, false},
-                {dto::FieldType::DECIMAL64, "Amount", false, false}, // Requires 6 digits of precision
+                {dto::FieldType::DECIMALD50, "Amount", false, false}, // Requires 6 digits of precision
                 {dto::FieldType::INT16T, "CDID", false, false},
                 {dto::FieldType::INT16T, "DID", false, false},
                 {dto::FieldType::STRING, "Info", false, false}},
@@ -531,7 +531,7 @@ public:
                 {dto::FieldType::INT64T, "DeliveryDate", false, false},
                 {dto::FieldType::INT32T, "ItemID", false, false},
                 {dto::FieldType::INT16T, "SupplyWID", false, false},
-                {dto::FieldType::DECIMAL64, "Amount", false, false}, // Requires 6 digits of precision
+                {dto::FieldType::DECIMALD50, "Amount", false, false}, // Requires 6 digits of precision
                 {dto::FieldType::INT16T, "Quantity", false, false},
                 {dto::FieldType::STRING, "DistInfo", false, false}},
         .partitionKeyFields = std::vector<uint32_t> { 0 },
@@ -608,7 +608,7 @@ public:
         .fields = std::vector<dto::SchemaField> {
                 {dto::FieldType::INT32T, "ID", false, false},
                 {dto::FieldType::INT32T, "ImageID", false, false},
-                {dto::FieldType::DECIMAL64, "Price", false, false}, // Requires 5 digits of precision
+                {dto::FieldType::DECIMALD50, "Price", false, false}, // Requires 5 digits of precision
                 {dto::FieldType::STRING, "Name", false, false},
                 {dto::FieldType::STRING, "Info", false, false}},
         .partitionKeyFields = std::vector<uint32_t> { 0 },
@@ -653,7 +653,7 @@ public:
         .fields = std::vector<dto::SchemaField> {
                 {dto::FieldType::INT16T, "ID", false, false},
                 {dto::FieldType::INT32T, "ItemID", false, false},
-                {dto::FieldType::DECIMAL64, "YTD", false, false}, // Requires 8 digits of precision
+                {dto::FieldType::DECIMALD50, "YTD", false, false}, // Requires 8 digits of precision
                 {dto::FieldType::INT16T, "OrderCount", false, false},
                 {dto::FieldType::INT16T, "RemoteCount", false, false},
                 {dto::FieldType::INT16T, "Quantity", false, false},

--- a/src/k2/cmd/tpcc/transactions.h
+++ b/src/k2/cmd/tpcc/transactions.h
@@ -322,7 +322,7 @@ private:
     int16_t _w_id;
     int16_t _c_w_id;
     int32_t _c_id;
-    std::decimal::decimal64 _amount;
+    boost::multiprecision::cpp_dec_float_50 _amount;
     int16_t _d_id;
     int16_t _c_d_id;
     k2::String _w_name;
@@ -517,10 +517,10 @@ private:
     std::vector<OrderLine> _lines;
     // The below variables are needed to "display" the order total amount,
     // but are not needed for any DB operations
-    std::decimal::decimal64 _w_tax;
-    std::decimal::decimal64 _d_tax;
-    std::decimal::decimal64 _c_discount;
-    std::decimal::decimal64 _total_amount = 0;
+    boost::multiprecision::cpp_dec_float_50 _w_tax;
+    boost::multiprecision::cpp_dec_float_50 _d_tax;
+    boost::multiprecision::cpp_dec_float_50 _c_discount;
+    boost::multiprecision::cpp_dec_float_50 _total_amount = 0;
 };
 
 class OrderStatusT : public TPCCTxn
@@ -785,7 +785,7 @@ private:
                             std::optional<int64_t> delDateOpt = rec.deserializeField<int64_t>("DeliveryDate");
                             std::optional<int32_t> itemIDOpt = rec.deserializeField<int32_t>("ItemID");
                             std::optional<int16_t> supplyWIDOpt = rec.deserializeField<int16_t>("SupplyWID");
-                            std::optional<std::decimal::decimal64> amountOpt = rec.deserializeField<std::decimal::decimal64>("Amount");
+                            std::optional<boost::multiprecision::cpp_dec_float_50> amountOpt = rec.deserializeField<boost::multiprecision::cpp_dec_float_50>("Amount");
                             std::optional<int16_t> quantityOpt = rec.deserializeField<int16_t>("Quantity");
 
                             _out_ol_delivery_date.push_back(*delDateOpt);
@@ -823,7 +823,7 @@ private:
 private:
     // output data that Order-Status-Transaction wanna get
     // customer info
-    std::decimal::decimal64 _out_c_balance;
+    boost::multiprecision::cpp_dec_float_50 _out_c_balance;
     k2::String _out_c_first_name;
     k2::String _out_c_middle_name;
     k2::String _out_c_last_name;
@@ -835,7 +835,7 @@ private:
     std::vector<int64_t> _out_ol_delivery_date;
     std::vector<int32_t> _out_ol_item_id;
     std::vector<int16_t> _out_ol_supply_wid;
-    std::vector<std::decimal::decimal64> _out_ol_amount;
+    std::vector<boost::multiprecision::cpp_dec_float_50> _out_ol_amount;
     std::vector<int16_t> _out_ol_quantity;
 };
 
@@ -1126,7 +1126,7 @@ private:
                 .then([this, &result_set, &count, idx] () {
                     for (std::vector<dto::SKVRecord>& set : result_set) {
                         for (dto::SKVRecord& rec : set) {
-                            std::optional<std::decimal::decimal64> amountOpt = rec.deserializeField<std::decimal::decimal64>("Amount");
+                            std::optional<boost::multiprecision::cpp_dec_float_50> amountOpt = rec.deserializeField<boost::multiprecision::cpp_dec_float_50>("Amount");
                             _OL_SUM_AMOUNT[idx] += *amountOpt;
                         }
                     }
@@ -1185,7 +1185,7 @@ private:
                     }
 
                     dto::SKVRecord& rec = response.records[0];
-                    std::optional<std::decimal::decimal64> balanceOpt = rec.deserializeField<std::decimal::decimal64>("Balance");
+                    std::optional<boost::multiprecision::cpp_dec_float_50> balanceOpt = rec.deserializeField<boost::multiprecision::cpp_dec_float_50>("Balance");
                     std::optional<int32_t> deliveryCountOpt = rec.deserializeField<int32_t>("DeliveryCount");
 
                     Customer updateCustomer(_w_id, _d_id[idx], _O_C_ID[idx]);
@@ -1219,7 +1219,7 @@ private:
     // output data that DeliveryT wanna get
     std::vector<int64_t> _NO_O_ID = std::vector<int64_t>(10, -1); // NEW-ORDER table info: order ID
     std::vector<int32_t> _O_C_ID = std::vector<int32_t>(10, -1); // ORDER table info: customer ID
-    std::vector<std::decimal::decimal64> _OL_SUM_AMOUNT = std::vector<std::decimal::decimal64>(10, -1); // ORDER-LINE table info: sum of all amount
+    std::vector<boost::multiprecision::cpp_dec_float_50> _OL_SUM_AMOUNT = std::vector<boost::multiprecision::cpp_dec_float_50>(10, -1); // ORDER-LINE table info: sum of all amount
 
     // Save the next expected new order id to avoid scans over deleted records
     static inline int64_t _saved_noid = 0;

--- a/src/k2/cmd/tpcc/transactions.h
+++ b/src/k2/cmd/tpcc/transactions.h
@@ -322,7 +322,7 @@ private:
     int16_t _w_id;
     int16_t _c_w_id;
     int32_t _c_id;
-    boost::multiprecision::cpp_dec_float_50 _amount;
+    boost::multiprecision::cpp_dec_float_25 _amount;
     int16_t _d_id;
     int16_t _c_d_id;
     k2::String _w_name;
@@ -517,10 +517,10 @@ private:
     std::vector<OrderLine> _lines;
     // The below variables are needed to "display" the order total amount,
     // but are not needed for any DB operations
-    boost::multiprecision::cpp_dec_float_50 _w_tax;
-    boost::multiprecision::cpp_dec_float_50 _d_tax;
-    boost::multiprecision::cpp_dec_float_50 _c_discount;
-    boost::multiprecision::cpp_dec_float_50 _total_amount = 0;
+    boost::multiprecision::cpp_dec_float_25 _w_tax;
+    boost::multiprecision::cpp_dec_float_25 _d_tax;
+    boost::multiprecision::cpp_dec_float_25 _c_discount;
+    boost::multiprecision::cpp_dec_float_25 _total_amount = 0;
 };
 
 class OrderStatusT : public TPCCTxn
@@ -785,7 +785,7 @@ private:
                             std::optional<int64_t> delDateOpt = rec.deserializeField<int64_t>("DeliveryDate");
                             std::optional<int32_t> itemIDOpt = rec.deserializeField<int32_t>("ItemID");
                             std::optional<int16_t> supplyWIDOpt = rec.deserializeField<int16_t>("SupplyWID");
-                            std::optional<boost::multiprecision::cpp_dec_float_50> amountOpt = rec.deserializeField<boost::multiprecision::cpp_dec_float_50>("Amount");
+                            std::optional<boost::multiprecision::cpp_dec_float_25> amountOpt = rec.deserializeField<boost::multiprecision::cpp_dec_float_25>("Amount");
                             std::optional<int16_t> quantityOpt = rec.deserializeField<int16_t>("Quantity");
 
                             _out_ol_delivery_date.push_back(*delDateOpt);
@@ -823,7 +823,7 @@ private:
 private:
     // output data that Order-Status-Transaction wanna get
     // customer info
-    boost::multiprecision::cpp_dec_float_50 _out_c_balance;
+    boost::multiprecision::cpp_dec_float_25 _out_c_balance;
     k2::String _out_c_first_name;
     k2::String _out_c_middle_name;
     k2::String _out_c_last_name;
@@ -835,7 +835,7 @@ private:
     std::vector<int64_t> _out_ol_delivery_date;
     std::vector<int32_t> _out_ol_item_id;
     std::vector<int16_t> _out_ol_supply_wid;
-    std::vector<boost::multiprecision::cpp_dec_float_50> _out_ol_amount;
+    std::vector<boost::multiprecision::cpp_dec_float_25> _out_ol_amount;
     std::vector<int16_t> _out_ol_quantity;
 };
 
@@ -1126,7 +1126,7 @@ private:
                 .then([this, &result_set, &count, idx] () {
                     for (std::vector<dto::SKVRecord>& set : result_set) {
                         for (dto::SKVRecord& rec : set) {
-                            std::optional<boost::multiprecision::cpp_dec_float_50> amountOpt = rec.deserializeField<boost::multiprecision::cpp_dec_float_50>("Amount");
+                            std::optional<boost::multiprecision::cpp_dec_float_25> amountOpt = rec.deserializeField<boost::multiprecision::cpp_dec_float_25>("Amount");
                             _OL_SUM_AMOUNT[idx] += *amountOpt;
                         }
                     }
@@ -1185,7 +1185,7 @@ private:
                     }
 
                     dto::SKVRecord& rec = response.records[0];
-                    std::optional<boost::multiprecision::cpp_dec_float_50> balanceOpt = rec.deserializeField<boost::multiprecision::cpp_dec_float_50>("Balance");
+                    std::optional<boost::multiprecision::cpp_dec_float_25> balanceOpt = rec.deserializeField<boost::multiprecision::cpp_dec_float_25>("Balance");
                     std::optional<int32_t> deliveryCountOpt = rec.deserializeField<int32_t>("DeliveryCount");
 
                     Customer updateCustomer(_w_id, _d_id[idx], _O_C_ID[idx]);
@@ -1219,7 +1219,7 @@ private:
     // output data that DeliveryT wanna get
     std::vector<int64_t> _NO_O_ID = std::vector<int64_t>(10, -1); // NEW-ORDER table info: order ID
     std::vector<int32_t> _O_C_ID = std::vector<int32_t>(10, -1); // ORDER table info: customer ID
-    std::vector<boost::multiprecision::cpp_dec_float_50> _OL_SUM_AMOUNT = std::vector<boost::multiprecision::cpp_dec_float_50>(10, -1); // ORDER-LINE table info: sum of all amount
+    std::vector<boost::multiprecision::cpp_dec_float_25> _OL_SUM_AMOUNT = std::vector<boost::multiprecision::cpp_dec_float_25>(10, -1); // ORDER-LINE table info: sum of all amount
 
     // Save the next expected new order id to avoid scans over deleted records
     static inline int64_t _saved_noid = 0;

--- a/src/k2/cmd/tpcc/transactions.h
+++ b/src/k2/cmd/tpcc/transactions.h
@@ -322,7 +322,7 @@ private:
     int16_t _w_id;
     int16_t _c_w_id;
     int32_t _c_id;
-    boost::multiprecision::cpp_dec_float_25 _amount;
+    DecimalD25 _amount;
     int16_t _d_id;
     int16_t _c_d_id;
     k2::String _w_name;
@@ -517,10 +517,10 @@ private:
     std::vector<OrderLine> _lines;
     // The below variables are needed to "display" the order total amount,
     // but are not needed for any DB operations
-    boost::multiprecision::cpp_dec_float_25 _w_tax;
-    boost::multiprecision::cpp_dec_float_25 _d_tax;
-    boost::multiprecision::cpp_dec_float_25 _c_discount;
-    boost::multiprecision::cpp_dec_float_25 _total_amount = 0;
+    DecimalD25 _w_tax;
+    DecimalD25 _d_tax;
+    DecimalD25 _c_discount;
+    DecimalD25 _total_amount = 0;
 };
 
 class OrderStatusT : public TPCCTxn
@@ -785,7 +785,7 @@ private:
                             std::optional<int64_t> delDateOpt = rec.deserializeField<int64_t>("DeliveryDate");
                             std::optional<int32_t> itemIDOpt = rec.deserializeField<int32_t>("ItemID");
                             std::optional<int16_t> supplyWIDOpt = rec.deserializeField<int16_t>("SupplyWID");
-                            std::optional<boost::multiprecision::cpp_dec_float_25> amountOpt = rec.deserializeField<boost::multiprecision::cpp_dec_float_25>("Amount");
+                            std::optional<DecimalD25> amountOpt = rec.deserializeField<DecimalD25>("Amount");
                             std::optional<int16_t> quantityOpt = rec.deserializeField<int16_t>("Quantity");
 
                             _out_ol_delivery_date.push_back(*delDateOpt);
@@ -823,7 +823,7 @@ private:
 private:
     // output data that Order-Status-Transaction wanna get
     // customer info
-    boost::multiprecision::cpp_dec_float_25 _out_c_balance;
+    DecimalD25 _out_c_balance;
     k2::String _out_c_first_name;
     k2::String _out_c_middle_name;
     k2::String _out_c_last_name;
@@ -835,7 +835,7 @@ private:
     std::vector<int64_t> _out_ol_delivery_date;
     std::vector<int32_t> _out_ol_item_id;
     std::vector<int16_t> _out_ol_supply_wid;
-    std::vector<boost::multiprecision::cpp_dec_float_25> _out_ol_amount;
+    std::vector<DecimalD25> _out_ol_amount;
     std::vector<int16_t> _out_ol_quantity;
 };
 
@@ -1126,7 +1126,7 @@ private:
                 .then([this, &result_set, &count, idx] () {
                     for (std::vector<dto::SKVRecord>& set : result_set) {
                         for (dto::SKVRecord& rec : set) {
-                            std::optional<boost::multiprecision::cpp_dec_float_25> amountOpt = rec.deserializeField<boost::multiprecision::cpp_dec_float_25>("Amount");
+                            std::optional<DecimalD25> amountOpt = rec.deserializeField<DecimalD25>("Amount");
                             _OL_SUM_AMOUNT[idx] += *amountOpt;
                         }
                     }
@@ -1185,7 +1185,7 @@ private:
                     }
 
                     dto::SKVRecord& rec = response.records[0];
-                    std::optional<boost::multiprecision::cpp_dec_float_25> balanceOpt = rec.deserializeField<boost::multiprecision::cpp_dec_float_25>("Balance");
+                    std::optional<DecimalD25> balanceOpt = rec.deserializeField<DecimalD25>("Balance");
                     std::optional<int32_t> deliveryCountOpt = rec.deserializeField<int32_t>("DeliveryCount");
 
                     Customer updateCustomer(_w_id, _d_id[idx], _O_C_ID[idx]);
@@ -1219,7 +1219,7 @@ private:
     // output data that DeliveryT wanna get
     std::vector<int64_t> _NO_O_ID = std::vector<int64_t>(10, -1); // NEW-ORDER table info: order ID
     std::vector<int32_t> _O_C_ID = std::vector<int32_t>(10, -1); // ORDER table info: customer ID
-    std::vector<boost::multiprecision::cpp_dec_float_25> _OL_SUM_AMOUNT = std::vector<boost::multiprecision::cpp_dec_float_25>(10, -1); // ORDER-LINE table info: sum of all amount
+    std::vector<DecimalD25> _OL_SUM_AMOUNT = std::vector<DecimalD25>(10, -1); // ORDER-LINE table info: sum of all amount
 
     // Save the next expected new order id to avoid scans over deleted records
     static inline int64_t _saved_noid = 0;

--- a/src/k2/cmd/tpcc/transactions.h
+++ b/src/k2/cmd/tpcc/transactions.h
@@ -322,7 +322,7 @@ private:
     int16_t _w_id;
     int16_t _c_w_id;
     int32_t _c_id;
-    boost::multiprecision::cpp_dec_float_25 _amount;
+    boost::multiprecision::cpp_dec_float_50 _amount;
     int16_t _d_id;
     int16_t _c_d_id;
     k2::String _w_name;
@@ -517,10 +517,10 @@ private:
     std::vector<OrderLine> _lines;
     // The below variables are needed to "display" the order total amount,
     // but are not needed for any DB operations
-    boost::multiprecision::cpp_dec_float_25 _w_tax;
-    boost::multiprecision::cpp_dec_float_25 _d_tax;
-    boost::multiprecision::cpp_dec_float_25 _c_discount;
-    boost::multiprecision::cpp_dec_float_25 _total_amount = 0;
+    boost::multiprecision::cpp_dec_float_50 _w_tax;
+    boost::multiprecision::cpp_dec_float_50 _d_tax;
+    boost::multiprecision::cpp_dec_float_50 _c_discount;
+    boost::multiprecision::cpp_dec_float_50 _total_amount = 0;
 };
 
 class OrderStatusT : public TPCCTxn
@@ -785,7 +785,7 @@ private:
                             std::optional<int64_t> delDateOpt = rec.deserializeField<int64_t>("DeliveryDate");
                             std::optional<int32_t> itemIDOpt = rec.deserializeField<int32_t>("ItemID");
                             std::optional<int16_t> supplyWIDOpt = rec.deserializeField<int16_t>("SupplyWID");
-                            std::optional<boost::multiprecision::cpp_dec_float_25> amountOpt = rec.deserializeField<boost::multiprecision::cpp_dec_float_25>("Amount");
+                            std::optional<boost::multiprecision::cpp_dec_float_50> amountOpt = rec.deserializeField<boost::multiprecision::cpp_dec_float_50>("Amount");
                             std::optional<int16_t> quantityOpt = rec.deserializeField<int16_t>("Quantity");
 
                             _out_ol_delivery_date.push_back(*delDateOpt);
@@ -823,7 +823,7 @@ private:
 private:
     // output data that Order-Status-Transaction wanna get
     // customer info
-    boost::multiprecision::cpp_dec_float_25 _out_c_balance;
+    boost::multiprecision::cpp_dec_float_50 _out_c_balance;
     k2::String _out_c_first_name;
     k2::String _out_c_middle_name;
     k2::String _out_c_last_name;
@@ -835,7 +835,7 @@ private:
     std::vector<int64_t> _out_ol_delivery_date;
     std::vector<int32_t> _out_ol_item_id;
     std::vector<int16_t> _out_ol_supply_wid;
-    std::vector<boost::multiprecision::cpp_dec_float_25> _out_ol_amount;
+    std::vector<boost::multiprecision::cpp_dec_float_50> _out_ol_amount;
     std::vector<int16_t> _out_ol_quantity;
 };
 
@@ -1126,7 +1126,7 @@ private:
                 .then([this, &result_set, &count, idx] () {
                     for (std::vector<dto::SKVRecord>& set : result_set) {
                         for (dto::SKVRecord& rec : set) {
-                            std::optional<boost::multiprecision::cpp_dec_float_25> amountOpt = rec.deserializeField<boost::multiprecision::cpp_dec_float_25>("Amount");
+                            std::optional<boost::multiprecision::cpp_dec_float_50> amountOpt = rec.deserializeField<boost::multiprecision::cpp_dec_float_50>("Amount");
                             _OL_SUM_AMOUNT[idx] += *amountOpt;
                         }
                     }
@@ -1185,7 +1185,7 @@ private:
                     }
 
                     dto::SKVRecord& rec = response.records[0];
-                    std::optional<boost::multiprecision::cpp_dec_float_25> balanceOpt = rec.deserializeField<boost::multiprecision::cpp_dec_float_25>("Balance");
+                    std::optional<boost::multiprecision::cpp_dec_float_50> balanceOpt = rec.deserializeField<boost::multiprecision::cpp_dec_float_50>("Balance");
                     std::optional<int32_t> deliveryCountOpt = rec.deserializeField<int32_t>("DeliveryCount");
 
                     Customer updateCustomer(_w_id, _d_id[idx], _O_C_ID[idx]);
@@ -1219,7 +1219,7 @@ private:
     // output data that DeliveryT wanna get
     std::vector<int64_t> _NO_O_ID = std::vector<int64_t>(10, -1); // NEW-ORDER table info: order ID
     std::vector<int32_t> _O_C_ID = std::vector<int32_t>(10, -1); // ORDER table info: customer ID
-    std::vector<boost::multiprecision::cpp_dec_float_25> _OL_SUM_AMOUNT = std::vector<boost::multiprecision::cpp_dec_float_25>(10, -1); // ORDER-LINE table info: sum of all amount
+    std::vector<boost::multiprecision::cpp_dec_float_50> _OL_SUM_AMOUNT = std::vector<boost::multiprecision::cpp_dec_float_50>(10, -1); // ORDER-LINE table info: sum of all amount
 
     // Save the next expected new order id to avoid scans over deleted records
     static inline int64_t _saved_noid = 0;

--- a/src/k2/cmd/tpcc/verify.cpp
+++ b/src/k2/cmd/tpcc/verify.cpp
@@ -127,8 +127,8 @@ future<> AtomicVerify::run() {
 
 // Consistency condition 1 of spec: Sum of district YTD == warehouse YTD
 future<> ConsistencyVerify::verifyWarehouseYTD() {
-    return do_with((std::decimal::decimal64)0, (int16_t)1,
-        [this] (std::decimal::decimal64& total, int16_t& cur_d_id) {
+    return do_with((boost::multiprecision::cpp_dec_float_50)0, (int16_t)1,
+        [this] (boost::multiprecision::cpp_dec_float_50& total, int16_t& cur_d_id) {
         return do_until(
                 [this, &cur_d_id] () { return cur_d_id > _districts_per_warehouse(); },
                 [this, &cur_d_id, &total] () {
@@ -149,9 +149,9 @@ future<> ConsistencyVerify::verifyWarehouseYTD() {
                 CHECK_READ_STATUS(result);
                 K2ASSERT(log::tpcc, result.value.YTD.has_value(), "Warehouse YTD is null")
 
-                std::decimal::decimal64 w_total = *(result.value.YTD);
-                double w_display = std::decimal::decimal64_to_double(w_total);
-                double total_display = std::decimal::decimal64_to_double(total);
+                boost::multiprecision::cpp_dec_float_50 w_total = *(result.value.YTD);
+                double w_display = w_total.backend().extract_double();
+                double total_display = total.backend().extract_double();
                 K2LOG_I(log::tpcc, "YTD consistency (WARNING: displayed values may not match due to conversion of decimal type, w_total: {}, total: {}", w_display, total_display);
                 K2ASSERT(log::tpcc, w_total == total, "Warehouse and district YTD totals did not match!");
                 return make_ready_future<>();
@@ -547,8 +547,8 @@ future<> ConsistencyVerify::verifyOrderLineDelivery() {
 
 
 // Helper for consistency conditions 8 and 9
-future<std::decimal::decimal64> ConsistencyVerify::historySum(bool useDistrictID) {
-    return do_with((std::decimal::decimal64)0, Query(), [this, useDistrictID] (std::decimal::decimal64& sum, Query& query) {
+future<boost::multiprecision::cpp_dec_float_50> ConsistencyVerify::historySum(bool useDistrictID) {
+    return do_with((boost::multiprecision::cpp_dec_float_50)0, Query(), [this, useDistrictID] (boost::multiprecision::cpp_dec_float_50& sum, Query& query) {
         return _client.createQuery(tpccCollectionName, "history")
         .then([this, &sum, &query, useDistrictID](auto&& response) {
             CHECK_READ_STATUS(response);
@@ -580,7 +580,7 @@ future<std::decimal::decimal64> ConsistencyVerify::historySum(bool useDistrictID
                     CHECK_READ_STATUS(response);
 
                     for (dto::SKVRecord& record : response.records) {
-                        std::optional<std::decimal::decimal64> amount = record.deserializeField<std::decimal::decimal64>("Amount");
+                        std::optional<boost::multiprecision::cpp_dec_float_50> amount = record.deserializeField<boost::multiprecision::cpp_dec_float_50>("Amount");
                         sum += *amount;
                     }
 
@@ -589,7 +589,7 @@ future<std::decimal::decimal64> ConsistencyVerify::historySum(bool useDistrictID
             });
         })
         .then([this, &sum] () {
-            return make_ready_future<std::decimal::decimal64>(sum);
+            return make_ready_future<boost::multiprecision::cpp_dec_float_50>(sum);
         });
     });
 }
@@ -600,9 +600,9 @@ future<> ConsistencyVerify::verifyWarehouseHistorySum() {
     .then([this] (auto&& response) {
         CHECK_READ_STATUS(response);
 
-        std::optional<std::decimal::decimal64> ytd = response.value.YTD;
+        std::optional<boost::multiprecision::cpp_dec_float_50> ytd = response.value.YTD;
         return historySum(false)
-        .then([this, ytd] (std::decimal::decimal64&& sum) {
+        .then([this, ytd] (boost::multiprecision::cpp_dec_float_50&& sum) {
             K2ASSERT(log::tpcc, *ytd == sum, "History sum and Warehouse YTD do not match");
         });
     });
@@ -614,9 +614,9 @@ future<> ConsistencyVerify::verifyDistrictHistorySum() {
     .then([this] (auto&& response) {
         CHECK_READ_STATUS(response);
 
-        std::optional<std::decimal::decimal64> ytd = response.value.YTD;
+        std::optional<boost::multiprecision::cpp_dec_float_50> ytd = response.value.YTD;
         return historySum(true)
-        .then([this, ytd] (std::decimal::decimal64&& sum) {
+        .then([this, ytd] (boost::multiprecision::cpp_dec_float_50&& sum) {
             K2ASSERT(log::tpcc, *ytd == sum, "History sum and District YTD do not match");
         });
     });

--- a/src/k2/cmd/tpcc/verify.cpp
+++ b/src/k2/cmd/tpcc/verify.cpp
@@ -127,8 +127,8 @@ future<> AtomicVerify::run() {
 
 // Consistency condition 1 of spec: Sum of district YTD == warehouse YTD
 future<> ConsistencyVerify::verifyWarehouseYTD() {
-    return do_with((boost::multiprecision::cpp_dec_float_25)0, (int16_t)1,
-        [this] (boost::multiprecision::cpp_dec_float_25& total, int16_t& cur_d_id) {
+    return do_with((boost::multiprecision::cpp_dec_float_50)0, (int16_t)1,
+        [this] (boost::multiprecision::cpp_dec_float_50& total, int16_t& cur_d_id) {
         return do_until(
                 [this, &cur_d_id] () { return cur_d_id > _districts_per_warehouse(); },
                 [this, &cur_d_id, &total] () {
@@ -149,7 +149,7 @@ future<> ConsistencyVerify::verifyWarehouseYTD() {
                 CHECK_READ_STATUS(result);
                 K2ASSERT(log::tpcc, result.value.YTD.has_value(), "Warehouse YTD is null")
 
-                boost::multiprecision::cpp_dec_float_25 w_total = *(result.value.YTD);
+                boost::multiprecision::cpp_dec_float_50 w_total = *(result.value.YTD);
                 double w_display = w_total.backend().extract_double();
                 double total_display = total.backend().extract_double();
                 K2LOG_I(log::tpcc, "YTD consistency (WARNING: displayed values may not match due to conversion of decimal type, w_total: {}, total: {}", w_display, total_display);
@@ -547,8 +547,8 @@ future<> ConsistencyVerify::verifyOrderLineDelivery() {
 
 
 // Helper for consistency conditions 8 and 9
-future<boost::multiprecision::cpp_dec_float_25> ConsistencyVerify::historySum(bool useDistrictID) {
-    return do_with((boost::multiprecision::cpp_dec_float_25)0, Query(), [this, useDistrictID] (boost::multiprecision::cpp_dec_float_25& sum, Query& query) {
+future<boost::multiprecision::cpp_dec_float_50> ConsistencyVerify::historySum(bool useDistrictID) {
+    return do_with((boost::multiprecision::cpp_dec_float_50)0, Query(), [this, useDistrictID] (boost::multiprecision::cpp_dec_float_50& sum, Query& query) {
         return _client.createQuery(tpccCollectionName, "history")
         .then([this, &sum, &query, useDistrictID](auto&& response) {
             CHECK_READ_STATUS(response);
@@ -580,7 +580,7 @@ future<boost::multiprecision::cpp_dec_float_25> ConsistencyVerify::historySum(bo
                     CHECK_READ_STATUS(response);
 
                     for (dto::SKVRecord& record : response.records) {
-                        std::optional<boost::multiprecision::cpp_dec_float_25> amount = record.deserializeField<boost::multiprecision::cpp_dec_float_25>("Amount");
+                        std::optional<boost::multiprecision::cpp_dec_float_50> amount = record.deserializeField<boost::multiprecision::cpp_dec_float_50>("Amount");
                         sum += *amount;
                     }
 
@@ -589,7 +589,7 @@ future<boost::multiprecision::cpp_dec_float_25> ConsistencyVerify::historySum(bo
             });
         })
         .then([this, &sum] () {
-            return make_ready_future<boost::multiprecision::cpp_dec_float_25>(sum);
+            return make_ready_future<boost::multiprecision::cpp_dec_float_50>(sum);
         });
     });
 }
@@ -600,9 +600,9 @@ future<> ConsistencyVerify::verifyWarehouseHistorySum() {
     .then([this] (auto&& response) {
         CHECK_READ_STATUS(response);
 
-        std::optional<boost::multiprecision::cpp_dec_float_25> ytd = response.value.YTD;
+        std::optional<boost::multiprecision::cpp_dec_float_50> ytd = response.value.YTD;
         return historySum(false)
-        .then([this, ytd] (boost::multiprecision::cpp_dec_float_25&& sum) {
+        .then([this, ytd] (boost::multiprecision::cpp_dec_float_50&& sum) {
             K2ASSERT(log::tpcc, *ytd == sum, "History sum and Warehouse YTD do not match");
         });
     });
@@ -614,9 +614,9 @@ future<> ConsistencyVerify::verifyDistrictHistorySum() {
     .then([this] (auto&& response) {
         CHECK_READ_STATUS(response);
 
-        std::optional<boost::multiprecision::cpp_dec_float_25> ytd = response.value.YTD;
+        std::optional<boost::multiprecision::cpp_dec_float_50> ytd = response.value.YTD;
         return historySum(true)
-        .then([this, ytd] (boost::multiprecision::cpp_dec_float_25&& sum) {
+        .then([this, ytd] (boost::multiprecision::cpp_dec_float_50&& sum) {
             K2ASSERT(log::tpcc, *ytd == sum, "History sum and District YTD do not match");
         });
     });

--- a/src/k2/cmd/tpcc/verify.cpp
+++ b/src/k2/cmd/tpcc/verify.cpp
@@ -127,8 +127,8 @@ future<> AtomicVerify::run() {
 
 // Consistency condition 1 of spec: Sum of district YTD == warehouse YTD
 future<> ConsistencyVerify::verifyWarehouseYTD() {
-    return do_with((boost::multiprecision::cpp_dec_float_25)0, (int16_t)1,
-        [this] (boost::multiprecision::cpp_dec_float_25& total, int16_t& cur_d_id) {
+    return do_with((DecimalD25)0, (int16_t)1,
+        [this] (DecimalD25& total, int16_t& cur_d_id) {
         return do_until(
                 [this, &cur_d_id] () { return cur_d_id > _districts_per_warehouse(); },
                 [this, &cur_d_id, &total] () {
@@ -149,7 +149,7 @@ future<> ConsistencyVerify::verifyWarehouseYTD() {
                 CHECK_READ_STATUS(result);
                 K2ASSERT(log::tpcc, result.value.YTD.has_value(), "Warehouse YTD is null")
 
-                boost::multiprecision::cpp_dec_float_25 w_total = *(result.value.YTD);
+                DecimalD25 w_total = *(result.value.YTD);
                 double w_display = w_total.backend().extract_double();
                 double total_display = total.backend().extract_double();
                 K2LOG_I(log::tpcc, "YTD consistency (WARNING: displayed values may not match due to conversion of decimal type, w_total: {}, total: {}", w_display, total_display);
@@ -547,8 +547,8 @@ future<> ConsistencyVerify::verifyOrderLineDelivery() {
 
 
 // Helper for consistency conditions 8 and 9
-future<boost::multiprecision::cpp_dec_float_25> ConsistencyVerify::historySum(bool useDistrictID) {
-    return do_with((boost::multiprecision::cpp_dec_float_25)0, Query(), [this, useDistrictID] (boost::multiprecision::cpp_dec_float_25& sum, Query& query) {
+future<DecimalD25> ConsistencyVerify::historySum(bool useDistrictID) {
+    return do_with((DecimalD25)0, Query(), [this, useDistrictID] (DecimalD25& sum, Query& query) {
         return _client.createQuery(tpccCollectionName, "history")
         .then([this, &sum, &query, useDistrictID](auto&& response) {
             CHECK_READ_STATUS(response);
@@ -580,7 +580,7 @@ future<boost::multiprecision::cpp_dec_float_25> ConsistencyVerify::historySum(bo
                     CHECK_READ_STATUS(response);
 
                     for (dto::SKVRecord& record : response.records) {
-                        std::optional<boost::multiprecision::cpp_dec_float_25> amount = record.deserializeField<boost::multiprecision::cpp_dec_float_25>("Amount");
+                        std::optional<DecimalD25> amount = record.deserializeField<DecimalD25>("Amount");
                         sum += *amount;
                     }
 
@@ -589,7 +589,7 @@ future<boost::multiprecision::cpp_dec_float_25> ConsistencyVerify::historySum(bo
             });
         })
         .then([this, &sum] () {
-            return make_ready_future<boost::multiprecision::cpp_dec_float_25>(sum);
+            return make_ready_future<DecimalD25>(sum);
         });
     });
 }
@@ -600,9 +600,9 @@ future<> ConsistencyVerify::verifyWarehouseHistorySum() {
     .then([this] (auto&& response) {
         CHECK_READ_STATUS(response);
 
-        std::optional<boost::multiprecision::cpp_dec_float_25> ytd = response.value.YTD;
+        std::optional<DecimalD25> ytd = response.value.YTD;
         return historySum(false)
-        .then([this, ytd] (boost::multiprecision::cpp_dec_float_25&& sum) {
+        .then([this, ytd] (DecimalD25&& sum) {
             K2ASSERT(log::tpcc, *ytd == sum, "History sum and Warehouse YTD do not match");
         });
     });
@@ -614,9 +614,9 @@ future<> ConsistencyVerify::verifyDistrictHistorySum() {
     .then([this] (auto&& response) {
         CHECK_READ_STATUS(response);
 
-        std::optional<boost::multiprecision::cpp_dec_float_25> ytd = response.value.YTD;
+        std::optional<DecimalD25> ytd = response.value.YTD;
         return historySum(true)
-        .then([this, ytd] (boost::multiprecision::cpp_dec_float_25&& sum) {
+        .then([this, ytd] (DecimalD25&& sum) {
             K2ASSERT(log::tpcc, *ytd == sum, "History sum and District YTD do not match");
         });
     });

--- a/src/k2/cmd/tpcc/verify.h
+++ b/src/k2/cmd/tpcc/verify.h
@@ -48,10 +48,10 @@ public:
 
 private:
     struct ValuesToCompare {
-        std::decimal::decimal64 w_ytd;
-        std::decimal::decimal64 d_ytd;
-        std::decimal::decimal64 c_ytd;
-        std::decimal::decimal64 c_balance;
+        boost::multiprecision::cpp_dec_float_50 w_ytd;
+        boost::multiprecision::cpp_dec_float_50 d_ytd;
+        boost::multiprecision::cpp_dec_float_50 c_ytd;
+        boost::multiprecision::cpp_dec_float_50 c_balance;
         uint16_t c_payments;
     };
 
@@ -91,7 +91,7 @@ private:
     future<int16_t> countOrderLineRows(int64_t oid);
     future<> verifyOrderLineByOrder();
     future<> verifyOrderLineDelivery();
-    future<std::decimal::decimal64> historySum(bool useDistrictID);
+    future<boost::multiprecision::cpp_dec_float_50> historySum(bool useDistrictID);
     future<> verifyWarehouseHistorySum();
     future<> verifyDistrictHistorySum();
     future<> runForEachWarehouse(consistencyOp op);

--- a/src/k2/cmd/tpcc/verify.h
+++ b/src/k2/cmd/tpcc/verify.h
@@ -48,10 +48,10 @@ public:
 
 private:
     struct ValuesToCompare {
-        boost::multiprecision::cpp_dec_float_25 w_ytd;
-        boost::multiprecision::cpp_dec_float_25 d_ytd;
-        boost::multiprecision::cpp_dec_float_25 c_ytd;
-        boost::multiprecision::cpp_dec_float_25 c_balance;
+        boost::multiprecision::cpp_dec_float_50 w_ytd;
+        boost::multiprecision::cpp_dec_float_50 d_ytd;
+        boost::multiprecision::cpp_dec_float_50 c_ytd;
+        boost::multiprecision::cpp_dec_float_50 c_balance;
         uint16_t c_payments;
     };
 
@@ -91,7 +91,7 @@ private:
     future<int16_t> countOrderLineRows(int64_t oid);
     future<> verifyOrderLineByOrder();
     future<> verifyOrderLineDelivery();
-    future<boost::multiprecision::cpp_dec_float_25> historySum(bool useDistrictID);
+    future<boost::multiprecision::cpp_dec_float_50> historySum(bool useDistrictID);
     future<> verifyWarehouseHistorySum();
     future<> verifyDistrictHistorySum();
     future<> runForEachWarehouse(consistencyOp op);

--- a/src/k2/cmd/tpcc/verify.h
+++ b/src/k2/cmd/tpcc/verify.h
@@ -48,10 +48,10 @@ public:
 
 private:
     struct ValuesToCompare {
-        boost::multiprecision::cpp_dec_float_50 w_ytd;
-        boost::multiprecision::cpp_dec_float_50 d_ytd;
-        boost::multiprecision::cpp_dec_float_50 c_ytd;
-        boost::multiprecision::cpp_dec_float_50 c_balance;
+        boost::multiprecision::cpp_dec_float_25 w_ytd;
+        boost::multiprecision::cpp_dec_float_25 d_ytd;
+        boost::multiprecision::cpp_dec_float_25 c_ytd;
+        boost::multiprecision::cpp_dec_float_25 c_balance;
         uint16_t c_payments;
     };
 
@@ -91,7 +91,7 @@ private:
     future<int16_t> countOrderLineRows(int64_t oid);
     future<> verifyOrderLineByOrder();
     future<> verifyOrderLineDelivery();
-    future<boost::multiprecision::cpp_dec_float_50> historySum(bool useDistrictID);
+    future<boost::multiprecision::cpp_dec_float_25> historySum(bool useDistrictID);
     future<> verifyWarehouseHistorySum();
     future<> verifyDistrictHistorySum();
     future<> runForEachWarehouse(consistencyOp op);

--- a/src/k2/cmd/tpcc/verify.h
+++ b/src/k2/cmd/tpcc/verify.h
@@ -48,10 +48,10 @@ public:
 
 private:
     struct ValuesToCompare {
-        boost::multiprecision::cpp_dec_float_25 w_ytd;
-        boost::multiprecision::cpp_dec_float_25 d_ytd;
-        boost::multiprecision::cpp_dec_float_25 c_ytd;
-        boost::multiprecision::cpp_dec_float_25 c_balance;
+        DecimalD25 w_ytd;
+        DecimalD25 d_ytd;
+        DecimalD25 c_ytd;
+        DecimalD25 c_balance;
         uint16_t c_payments;
     };
 
@@ -91,7 +91,7 @@ private:
     future<int16_t> countOrderLineRows(int64_t oid);
     future<> verifyOrderLineByOrder();
     future<> verifyOrderLineDelivery();
-    future<boost::multiprecision::cpp_dec_float_25> historySum(bool useDistrictID);
+    future<DecimalD25> historySum(bool useDistrictID);
     future<> verifyWarehouseHistorySum();
     future<> verifyDistrictHistorySum();
     future<> runForEachWarehouse(consistencyOp op);

--- a/src/k2/common/Common.h
+++ b/src/k2/common/Common.h
@@ -24,7 +24,6 @@ Copyright(c) 2020 Futurewei Cloud
 #pragma once
 
 #include <algorithm>
-#include <decimal/decimal>
 #include <functional>
 #include <iomanip>
 #include <iostream>

--- a/src/k2/dto/FieldTypes.cpp
+++ b/src/k2/dto/FieldTypes.cpp
@@ -48,7 +48,7 @@ template <> FieldType TToFieldType<float>() { return FieldType::FLOAT; }
 template <> FieldType TToFieldType<double>() { return FieldType::DOUBLE; }
 template <> FieldType TToFieldType<bool>() { return FieldType::BOOL; }
 template <> FieldType TToFieldType<std::decimal::decimal64>() { return FieldType::DECIMALD50; }
-template <> FieldType TToFieldType<std::decimal::decimal128>() { return FieldType::DECIMALD100; }
+template <> FieldType TToFieldType<boost::multiprecision::cpp_dec_float_100>() { return FieldType::DECIMALD100; }
 template <> FieldType TToFieldType<FieldType>() { return FieldType::FIELD_TYPE; }
 
 // All conversion assume ascending ordering

--- a/src/k2/dto/FieldTypes.cpp
+++ b/src/k2/dto/FieldTypes.cpp
@@ -48,7 +48,7 @@ template <> FieldType TToFieldType<float>() { return FieldType::FLOAT; }
 template <> FieldType TToFieldType<double>() { return FieldType::DOUBLE; }
 template <> FieldType TToFieldType<bool>() { return FieldType::BOOL; }
 template <> FieldType TToFieldType<std::decimal::decimal64>() { return FieldType::DECIMAL64; }
-template <> FieldType TToFieldType<std::decimal::decimal128>() { return FieldType::DECIMAL100; }
+template <> FieldType TToFieldType<std::decimal::decimal128>() { return FieldType::DECIMALD100; }
 template <> FieldType TToFieldType<FieldType>() { return FieldType::FIELD_TYPE; }
 
 // All conversion assume ascending ordering

--- a/src/k2/dto/FieldTypes.cpp
+++ b/src/k2/dto/FieldTypes.cpp
@@ -47,6 +47,7 @@ template <> FieldType TToFieldType<int64_t>() { return FieldType::INT64T; }
 template <> FieldType TToFieldType<float>() { return FieldType::FLOAT; }
 template <> FieldType TToFieldType<double>() { return FieldType::DOUBLE; }
 template <> FieldType TToFieldType<bool>() { return FieldType::BOOL; }
+template <> FieldType TToFieldType<boost::multiprecision::cpp_dec_float_25>() { return FieldType::DECIMALD25; }
 template <> FieldType TToFieldType<boost::multiprecision::cpp_dec_float_50>() { return FieldType::DECIMALD50; }
 template <> FieldType TToFieldType<boost::multiprecision::cpp_dec_float_100>() { return FieldType::DECIMALD100; }
 template <> FieldType TToFieldType<FieldType>() { return FieldType::FIELD_TYPE; }

--- a/src/k2/dto/FieldTypes.cpp
+++ b/src/k2/dto/FieldTypes.cpp
@@ -47,7 +47,7 @@ template <> FieldType TToFieldType<int64_t>() { return FieldType::INT64T; }
 template <> FieldType TToFieldType<float>() { return FieldType::FLOAT; }
 template <> FieldType TToFieldType<double>() { return FieldType::DOUBLE; }
 template <> FieldType TToFieldType<bool>() { return FieldType::BOOL; }
-template <> FieldType TToFieldType<std::decimal::decimal64>() { return FieldType::DECIMALD50; }
+template <> FieldType TToFieldType<boost::multiprecision::cpp_dec_float_50>() { return FieldType::DECIMALD50; }
 template <> FieldType TToFieldType<boost::multiprecision::cpp_dec_float_100>() { return FieldType::DECIMALD100; }
 template <> FieldType TToFieldType<FieldType>() { return FieldType::FIELD_TYPE; }
 

--- a/src/k2/dto/FieldTypes.cpp
+++ b/src/k2/dto/FieldTypes.cpp
@@ -47,7 +47,7 @@ template <> FieldType TToFieldType<int64_t>() { return FieldType::INT64T; }
 template <> FieldType TToFieldType<float>() { return FieldType::FLOAT; }
 template <> FieldType TToFieldType<double>() { return FieldType::DOUBLE; }
 template <> FieldType TToFieldType<bool>() { return FieldType::BOOL; }
-template <> FieldType TToFieldType<std::decimal::decimal64>() { return FieldType::DECIMAL64; }
+template <> FieldType TToFieldType<std::decimal::decimal64>() { return FieldType::DECIMALD50; }
 template <> FieldType TToFieldType<std::decimal::decimal128>() { return FieldType::DECIMALD100; }
 template <> FieldType TToFieldType<FieldType>() { return FieldType::FIELD_TYPE; }
 

--- a/src/k2/dto/FieldTypes.cpp
+++ b/src/k2/dto/FieldTypes.cpp
@@ -47,9 +47,9 @@ template <> FieldType TToFieldType<int64_t>() { return FieldType::INT64T; }
 template <> FieldType TToFieldType<float>() { return FieldType::FLOAT; }
 template <> FieldType TToFieldType<double>() { return FieldType::DOUBLE; }
 template <> FieldType TToFieldType<bool>() { return FieldType::BOOL; }
-template <> FieldType TToFieldType<boost::multiprecision::cpp_dec_float_25>() { return FieldType::DECIMALD25; }
-template <> FieldType TToFieldType<boost::multiprecision::cpp_dec_float_50>() { return FieldType::DECIMALD50; }
-template <> FieldType TToFieldType<boost::multiprecision::cpp_dec_float_100>() { return FieldType::DECIMALD100; }
+template <> FieldType TToFieldType<DecimalD25>() { return FieldType::DECIMALD25; }
+template <> FieldType TToFieldType<DecimalD50>() { return FieldType::DECIMALD50; }
+template <> FieldType TToFieldType<DecimalD100>() { return FieldType::DECIMALD100; }
 template <> FieldType TToFieldType<FieldType>() { return FieldType::FIELD_TYPE; }
 
 // All conversion assume ascending ordering

--- a/src/k2/dto/FieldTypes.cpp
+++ b/src/k2/dto/FieldTypes.cpp
@@ -48,7 +48,7 @@ template <> FieldType TToFieldType<float>() { return FieldType::FLOAT; }
 template <> FieldType TToFieldType<double>() { return FieldType::DOUBLE; }
 template <> FieldType TToFieldType<bool>() { return FieldType::BOOL; }
 template <> FieldType TToFieldType<std::decimal::decimal64>() { return FieldType::DECIMAL64; }
-template <> FieldType TToFieldType<std::decimal::decimal128>() { return FieldType::DECIMAL128; }
+template <> FieldType TToFieldType<std::decimal::decimal128>() { return FieldType::DECIMAL100; }
 template <> FieldType TToFieldType<FieldType>() { return FieldType::FIELD_TYPE; }
 
 // All conversion assume ascending ordering

--- a/src/k2/dto/FieldTypes.h
+++ b/src/k2/dto/FieldTypes.h
@@ -68,7 +68,7 @@ enum class FieldType : uint8_t {
     DOUBLE,  // Not supported as key field for now
     BOOL,
     DECIMAL64, // Provides 16 decimal digits of precision
-    DECIMAL128, // Provides 34 decimal digits of precision
+    DECIMAL100, // Provides 100 decimal digits of precision
     FIELD_TYPE, // The value refers to one of these types. Used in query filters.
     NOT_KNOWN = 254,
     NULL_LAST = 255
@@ -151,7 +151,7 @@ bool isNan(const T& field){
             case k2::dto::FieldType::DECIMAL64: {                   \
                 func<std::decimal::decimal64>((a), __VA_ARGS__);    \
             } break;                                                \
-            case k2::dto::FieldType::DECIMAL128: {                  \
+            case k2::dto::FieldType::DECIMAL100: {                  \
                 func<std::decimal::decimal128>((a), __VA_ARGS__);   \
             } break;                                                \
             case k2::dto::FieldType::FIELD_TYPE: {                  \
@@ -185,8 +185,8 @@ namespace std {
             return os << "BOOL";
         case k2::dto::FieldType::DECIMAL64:
             return os << "DECIMAL64";
-        case k2::dto::FieldType::DECIMAL128:
-            return os << "DECIMAL128";
+        case k2::dto::FieldType::DECIMAL100:
+            return os << "DECIMAL100";
         case k2::dto::FieldType::FIELD_TYPE:
             return os << "FIELD_TYPE";
         case k2::dto::FieldType::NOT_KNOWN:

--- a/src/k2/dto/FieldTypes.h
+++ b/src/k2/dto/FieldTypes.h
@@ -26,14 +26,8 @@ Copyright(c) 2020 Futurewei Cloud
 #include <cstdint>
 #include <cstring>
 
-#include <boost/multiprecision/cpp_dec_float.hpp>
-
 #include <k2/logging/Log.h>
 #include <k2/common/Common.h>
-
-namespace boost::multiprecision {
-typedef number<cpp_dec_float<25> > cpp_dec_float_25;
-}
 
 namespace k2 {
 namespace dto {

--- a/src/k2/dto/FieldTypes.h
+++ b/src/k2/dto/FieldTypes.h
@@ -25,7 +25,7 @@ Copyright(c) 2020 Futurewei Cloud
 
 #include <cstdint>
 #include <cstring>
-#include <decimal/decimal>
+
 #include <boost/multiprecision/cpp_dec_float.hpp>
 
 #include <k2/logging/Log.h>

--- a/src/k2/dto/FieldTypes.h
+++ b/src/k2/dto/FieldTypes.h
@@ -26,6 +26,7 @@ Copyright(c) 2020 Futurewei Cloud
 #include <cstdint>
 #include <cstring>
 #include <decimal/decimal>
+#include <boost/multiprecision/cpp_dec_float.hpp>
 
 #include <k2/logging/Log.h>
 #include <k2/common/Common.h>
@@ -112,8 +113,8 @@ bool isNan(const T& field){
         }
     }
 
-    if constexpr (std::is_same_v<T, std::decimal::decimal128> )  { // handle NaN decimal
-        if (std::isnan(std::decimal::decimal128_to_float(field))) {
+    if constexpr (std::is_same_v<T, boost::multiprecision::cpp_dec_float_100> )  { // handle NaN decimal
+        if (std::isnan(double(field))) { // NOT SURE
             return true;
         }
     }
@@ -152,7 +153,7 @@ bool isNan(const T& field){
                 func<std::decimal::decimal64>((a), __VA_ARGS__);    \
             } break;                                                \
             case k2::dto::FieldType::DECIMALD100: {                  \
-                func<std::decimal::decimal128>((a), __VA_ARGS__);   \
+                func<boost::multiprecision::cpp_dec_float_100>((a), __VA_ARGS__);   \
             } break;                                                \
             case k2::dto::FieldType::FIELD_TYPE: {                  \
                 func<k2::dto::FieldType>((a), __VA_ARGS__);         \

--- a/src/k2/dto/FieldTypes.h
+++ b/src/k2/dto/FieldTypes.h
@@ -68,7 +68,7 @@ enum class FieldType : uint8_t {
     DOUBLE,  // Not supported as key field for now
     BOOL,
     DECIMAL64, // Provides 16 decimal digits of precision
-    DECIMAL100, // Provides 100 decimal digits of precision
+    DECIMALD100, // Provides 100 decimal digits of precision
     FIELD_TYPE, // The value refers to one of these types. Used in query filters.
     NOT_KNOWN = 254,
     NULL_LAST = 255
@@ -151,7 +151,7 @@ bool isNan(const T& field){
             case k2::dto::FieldType::DECIMAL64: {                   \
                 func<std::decimal::decimal64>((a), __VA_ARGS__);    \
             } break;                                                \
-            case k2::dto::FieldType::DECIMAL100: {                  \
+            case k2::dto::FieldType::DECIMALD100: {                  \
                 func<std::decimal::decimal128>((a), __VA_ARGS__);   \
             } break;                                                \
             case k2::dto::FieldType::FIELD_TYPE: {                  \
@@ -185,8 +185,8 @@ namespace std {
             return os << "BOOL";
         case k2::dto::FieldType::DECIMAL64:
             return os << "DECIMAL64";
-        case k2::dto::FieldType::DECIMAL100:
-            return os << "DECIMAL100";
+        case k2::dto::FieldType::DECIMALD100:
+            return os << "DECIMALD100";
         case k2::dto::FieldType::FIELD_TYPE:
             return os << "FIELD_TYPE";
         case k2::dto::FieldType::NOT_KNOWN:

--- a/src/k2/dto/FieldTypes.h
+++ b/src/k2/dto/FieldTypes.h
@@ -107,13 +107,8 @@ bool isNan(const T& field){
         }
     }
 
-    if constexpr (std::is_same_v<T, boost::multiprecision::cpp_dec_float_50>)  { // handle NaN decimal
-        if (field.backend().isnan()) {
-            return true;
-        }
-    }
-
-    if constexpr (std::is_same_v<T, boost::multiprecision::cpp_dec_float_100> )  { // handle NaN decimal
+    if constexpr (std::is_same_v<T, boost::multiprecision::cpp_dec_float_50>
+        || std::is_same_v<T, boost::multiprecision::cpp_dec_float_100>)  { // handle NaN decimal
         if (field.backend().isnan()) {
             return true;
         }

--- a/src/k2/dto/FieldTypes.h
+++ b/src/k2/dto/FieldTypes.h
@@ -25,8 +25,15 @@ Copyright(c) 2020 Futurewei Cloud
 
 #include <cstdint>
 #include <cstring>
+
+#include <boost/multiprecision/cpp_dec_float.hpp>
+
 #include <k2/logging/Log.h>
 #include <k2/common/Common.h>
+
+namespace boost::multiprecision {
+typedef number<cpp_dec_float<25> > cpp_dec_float_25;
+}
 
 namespace k2 {
 namespace dto {

--- a/src/k2/dto/FieldTypes.h
+++ b/src/k2/dto/FieldTypes.h
@@ -106,9 +106,9 @@ bool isNan(const T& field){
         }
     }
 
-    if constexpr (std::is_same_v<T, boost::multiprecision::cpp_dec_float_25> 
-        || std::is_same_v<T, boost::multiprecision::cpp_dec_float_50>
-        || std::is_same_v<T, boost::multiprecision::cpp_dec_float_100>)  { // handle NaN decimal
+    if constexpr (std::is_same_v<T, DecimalD25> 
+        || std::is_same_v<T, DecimalD50>
+        || std::is_same_v<T, DecimalD100>)  { // handle NaN decimal
         if (field.backend().isnan()) {
             return true;
         }
@@ -145,13 +145,13 @@ bool isNan(const T& field){
                 func<bool>((a), __VA_ARGS__);                       \
             } break;                                                \
             case k2::dto::FieldType::DECIMALD25: {                  \
-                func<boost::multiprecision::cpp_dec_float_25>((a), __VA_ARGS__);    \
+                func<DecimalD25>((a), __VA_ARGS__);    \
             } break;                                                \
             case k2::dto::FieldType::DECIMALD50: {                  \
-                func<boost::multiprecision::cpp_dec_float_50>((a), __VA_ARGS__);    \
+                func<DecimalD50>((a), __VA_ARGS__);    \
             } break;                                                \
             case k2::dto::FieldType::DECIMALD100: {                 \
-                func<boost::multiprecision::cpp_dec_float_100>((a), __VA_ARGS__);   \
+                func<DecimalD100>((a), __VA_ARGS__);   \
             } break;                                                \
             case k2::dto::FieldType::FIELD_TYPE: {                  \
                 func<k2::dto::FieldType>((a), __VA_ARGS__);         \

--- a/src/k2/dto/FieldTypes.h
+++ b/src/k2/dto/FieldTypes.h
@@ -108,13 +108,13 @@ bool isNan(const T& field){
     }
 
     if constexpr (std::is_same_v<T, boost::multiprecision::cpp_dec_float_50>)  { // handle NaN decimal
-        if (field.backend().isnan()) { // NOT SURE
+        if (field.backend().isnan()) {
             return true;
         }
     }
 
     if constexpr (std::is_same_v<T, boost::multiprecision::cpp_dec_float_100> )  { // handle NaN decimal
-        if (field.backend().isnan()) { // NOT SURE
+        if (field.backend().isnan()) {
             return true;
         }
     }

--- a/src/k2/dto/FieldTypes.h
+++ b/src/k2/dto/FieldTypes.h
@@ -67,7 +67,7 @@ enum class FieldType : uint8_t {
     FLOAT, // Not supported as key field for now
     DOUBLE,  // Not supported as key field for now
     BOOL,
-    DECIMAL64, // Provides 16 decimal digits of precision
+    DECIMALD50, // Provides 16 decimal digits of precision
     DECIMALD100, // Provides 100 decimal digits of precision
     FIELD_TYPE, // The value refers to one of these types. Used in query filters.
     NOT_KNOWN = 254,
@@ -148,7 +148,7 @@ bool isNan(const T& field){
             case k2::dto::FieldType::BOOL: {                        \
                 func<bool>((a), __VA_ARGS__);                       \
             } break;                                                \
-            case k2::dto::FieldType::DECIMAL64: {                   \
+            case k2::dto::FieldType::DECIMALD50: {                   \
                 func<std::decimal::decimal64>((a), __VA_ARGS__);    \
             } break;                                                \
             case k2::dto::FieldType::DECIMALD100: {                  \
@@ -183,8 +183,8 @@ namespace std {
             return os << "DOUBLE";
         case k2::dto::FieldType::BOOL:
             return os << "BOOL";
-        case k2::dto::FieldType::DECIMAL64:
-            return os << "DECIMAL64";
+        case k2::dto::FieldType::DECIMALD50:
+            return os << "DECIMALD50";
         case k2::dto::FieldType::DECIMALD100:
             return os << "DECIMALD100";
         case k2::dto::FieldType::FIELD_TYPE:

--- a/src/k2/dto/FieldTypes.h
+++ b/src/k2/dto/FieldTypes.h
@@ -108,13 +108,13 @@ bool isNan(const T& field){
     }
 
     if constexpr (std::is_same_v<T, boost::multiprecision::cpp_dec_float_50>)  { // handle NaN decimal
-        if (std::isnan(field.backend().extract_double())) {
+        if (field.backend().isnan()) { // NOT SURE
             return true;
         }
     }
 
     if constexpr (std::is_same_v<T, boost::multiprecision::cpp_dec_float_100> )  { // handle NaN decimal
-        if (std::isnan(field.backend().extract_double())) { // NOT SURE
+        if (field.backend().isnan()) { // NOT SURE
             return true;
         }
     }

--- a/src/k2/dto/FieldTypes.h
+++ b/src/k2/dto/FieldTypes.h
@@ -25,15 +25,8 @@ Copyright(c) 2020 Futurewei Cloud
 
 #include <cstdint>
 #include <cstring>
-
-#include <boost/multiprecision/cpp_dec_float.hpp>
-
 #include <k2/logging/Log.h>
 #include <k2/common/Common.h>
-
-namespace boost::multiprecision {
-typedef number<cpp_dec_float<25> > cpp_dec_float_25;
-}
 
 namespace k2 {
 namespace dto {

--- a/src/k2/dto/FieldTypes.h
+++ b/src/k2/dto/FieldTypes.h
@@ -31,6 +31,10 @@ Copyright(c) 2020 Futurewei Cloud
 #include <k2/logging/Log.h>
 #include <k2/common/Common.h>
 
+namespace boost::multiprecision {
+typedef number<cpp_dec_float<25> > cpp_dec_float_25;
+}
+
 namespace k2 {
 namespace dto {
 
@@ -68,6 +72,7 @@ enum class FieldType : uint8_t {
     FLOAT, // Not supported as key field for now
     DOUBLE,  // Not supported as key field for now
     BOOL,
+    DECIMALD25, // Provides 25 decimal digits of precision
     DECIMALD50, // Provides 50 decimal digits of precision
     DECIMALD100, // Provides 100 decimal digits of precision
     FIELD_TYPE, // The value refers to one of these types. Used in query filters.
@@ -107,7 +112,8 @@ bool isNan(const T& field){
         }
     }
 
-    if constexpr (std::is_same_v<T, boost::multiprecision::cpp_dec_float_50>
+    if constexpr (std::is_same_v<T, boost::multiprecision::cpp_dec_float_25> 
+        || std::is_same_v<T, boost::multiprecision::cpp_dec_float_50>
         || std::is_same_v<T, boost::multiprecision::cpp_dec_float_100>)  { // handle NaN decimal
         if (field.backend().isnan()) {
             return true;
@@ -144,10 +150,13 @@ bool isNan(const T& field){
             case k2::dto::FieldType::BOOL: {                        \
                 func<bool>((a), __VA_ARGS__);                       \
             } break;                                                \
-            case k2::dto::FieldType::DECIMALD50: {                   \
+            case k2::dto::FieldType::DECIMALD25: {                  \
+                func<boost::multiprecision::cpp_dec_float_25>((a), __VA_ARGS__);    \
+            } break;                                                \
+            case k2::dto::FieldType::DECIMALD50: {                  \
                 func<boost::multiprecision::cpp_dec_float_50>((a), __VA_ARGS__);    \
             } break;                                                \
-            case k2::dto::FieldType::DECIMALD100: {                  \
+            case k2::dto::FieldType::DECIMALD100: {                 \
                 func<boost::multiprecision::cpp_dec_float_100>((a), __VA_ARGS__);   \
             } break;                                                \
             case k2::dto::FieldType::FIELD_TYPE: {                  \
@@ -179,6 +188,8 @@ namespace std {
             return os << "DOUBLE";
         case k2::dto::FieldType::BOOL:
             return os << "BOOL";
+        case k2::dto::FieldType::DECIMALD25:
+            return os << "DECIMALD25";
         case k2::dto::FieldType::DECIMALD50:
             return os << "DECIMALD50";
         case k2::dto::FieldType::DECIMALD100:

--- a/src/k2/dto/FieldTypes.h
+++ b/src/k2/dto/FieldTypes.h
@@ -68,7 +68,7 @@ enum class FieldType : uint8_t {
     FLOAT, // Not supported as key field for now
     DOUBLE,  // Not supported as key field for now
     BOOL,
-    DECIMALD50, // Provides 16 decimal digits of precision
+    DECIMALD50, // Provides 50 decimal digits of precision
     DECIMALD100, // Provides 100 decimal digits of precision
     FIELD_TYPE, // The value refers to one of these types. Used in query filters.
     NOT_KNOWN = 254,
@@ -107,14 +107,14 @@ bool isNan(const T& field){
         }
     }
 
-    if constexpr (std::is_same_v<T, std::decimal::decimal64>)  { // handle NaN decimal
-        if (std::isnan(std::decimal::decimal64_to_float(field))) {
+    if constexpr (std::is_same_v<T, boost::multiprecision::cpp_dec_float_50>)  { // handle NaN decimal
+        if (std::isnan(field.backend().extract_double())) {
             return true;
         }
     }
 
     if constexpr (std::is_same_v<T, boost::multiprecision::cpp_dec_float_100> )  { // handle NaN decimal
-        if (std::isnan(double(field))) { // NOT SURE
+        if (std::isnan(field.backend().extract_double())) { // NOT SURE
             return true;
         }
     }
@@ -150,7 +150,7 @@ bool isNan(const T& field){
                 func<bool>((a), __VA_ARGS__);                       \
             } break;                                                \
             case k2::dto::FieldType::DECIMALD50: {                   \
-                func<std::decimal::decimal64>((a), __VA_ARGS__);    \
+                func<boost::multiprecision::cpp_dec_float_50>((a), __VA_ARGS__);    \
             } break;                                                \
             case k2::dto::FieldType::DECIMALD100: {                  \
                 func<boost::multiprecision::cpp_dec_float_100>((a), __VA_ARGS__);   \

--- a/src/k2/dto/SKVRecord.h
+++ b/src/k2/dto/SKVRecord.h
@@ -290,7 +290,7 @@ private:
                 std::optional<bool> value = (record).deserializeNext<bool>();                                         \
                 func<bool>(std::move(value), field.name, __VA_ARGS__);                                                \
             } break;                                                                                                  \
-            case k2::dto::FieldType::DECIMAL64: {                                                                     \
+            case k2::dto::FieldType::DECIMALD50: {                                                                     \
                 std::optional<std::decimal::decimal64> value = (record).deserializeNext<std::decimal::decimal64>();   \
                 func<std::decimal::decimal64>(std::move(value), field.name, __VA_ARGS__);                             \
             } break;                                                                                                  \

--- a/src/k2/dto/SKVRecord.h
+++ b/src/k2/dto/SKVRecord.h
@@ -295,8 +295,8 @@ private:
                 func<std::decimal::decimal64>(std::move(value), field.name, __VA_ARGS__);                             \
             } break;                                                                                                  \
             case k2::dto::FieldType::DECIMALD100: {                                                                    \
-                std::optional<std::decimal::decimal128> value = (record).deserializeNext<std::decimal::decimal128>(); \
-                func<std::decimal::decimal128>(std::move(value), field.name, __VA_ARGS__);                            \
+                std::optional<boost::multiprecision::cpp_dec_float_100> value = (record).deserializeNext<boost::multiprecision::cpp_dec_float_100>(); \
+                func<boost::multiprecision::cpp_dec_float_100>(std::move(value), field.name, __VA_ARGS__);                            \
             } break;                                                                                                  \
             case k2::dto::FieldType::FIELD_TYPE: {                                                                    \
                 std::optional<k2::dto::FieldType> value = (record).deserializeNext<k2::dto::FieldType>();             \

--- a/src/k2/dto/SKVRecord.h
+++ b/src/k2/dto/SKVRecord.h
@@ -294,7 +294,7 @@ private:
                 std::optional<std::decimal::decimal64> value = (record).deserializeNext<std::decimal::decimal64>();   \
                 func<std::decimal::decimal64>(std::move(value), field.name, __VA_ARGS__);                             \
             } break;                                                                                                  \
-            case k2::dto::FieldType::DECIMAL100: {                                                                    \
+            case k2::dto::FieldType::DECIMALD100: {                                                                    \
                 std::optional<std::decimal::decimal128> value = (record).deserializeNext<std::decimal::decimal128>(); \
                 func<std::decimal::decimal128>(std::move(value), field.name, __VA_ARGS__);                            \
             } break;                                                                                                  \

--- a/src/k2/dto/SKVRecord.h
+++ b/src/k2/dto/SKVRecord.h
@@ -291,16 +291,16 @@ private:
                 func<bool>(std::move(value), field.name, __VA_ARGS__);                                                \
             } break;                                                                                                  \
             case k2::dto::FieldType::DECIMALD25: {                                                                    \
-                std::optional<boost::multiprecision::cpp_dec_float_25> value = (record).deserializeNext<boost::multiprecision::cpp_dec_float_25>();   \
-                func<boost::multiprecision::cpp_dec_float_25>(std::move(value), field.name, __VA_ARGS__);             \
+                std::optional<k2::DecimalD25> value = (record).deserializeNext<k2::DecimalD25>();   \
+                func<k2::DecimalD25>(std::move(value), field.name, __VA_ARGS__);             \
             } break;                                                                                                  \
             case k2::dto::FieldType::DECIMALD50: {                                                                    \
-                std::optional<boost::multiprecision::cpp_dec_float_50> value = (record).deserializeNext<boost::multiprecision::cpp_dec_float_50>();   \
-                func<boost::multiprecision::cpp_dec_float_50>(std::move(value), field.name, __VA_ARGS__);             \
+                std::optional<k2::DecimalD50> value = (record).deserializeNext<k2::DecimalD50>();   \
+                func<k2::DecimalD50>(std::move(value), field.name, __VA_ARGS__);             \
             } break;                                                                                                  \
             case k2::dto::FieldType::DECIMALD100: {                                                                   \
-                std::optional<boost::multiprecision::cpp_dec_float_100> value = (record).deserializeNext<boost::multiprecision::cpp_dec_float_100>(); \
-                func<boost::multiprecision::cpp_dec_float_100>(std::move(value), field.name, __VA_ARGS__);            \
+                std::optional<k2::DecimalD100> value = (record).deserializeNext<k2::DecimalD100>(); \
+                func<k2::DecimalD100>(std::move(value), field.name, __VA_ARGS__);            \
             } break;                                                                                                  \
             case k2::dto::FieldType::FIELD_TYPE: {                                                                    \
                 std::optional<k2::dto::FieldType> value = (record).deserializeNext<k2::dto::FieldType>();             \

--- a/src/k2/dto/SKVRecord.h
+++ b/src/k2/dto/SKVRecord.h
@@ -291,8 +291,8 @@ private:
                 func<bool>(std::move(value), field.name, __VA_ARGS__);                                                \
             } break;                                                                                                  \
             case k2::dto::FieldType::DECIMALD50: {                                                                     \
-                std::optional<std::decimal::decimal64> value = (record).deserializeNext<std::decimal::decimal64>();   \
-                func<std::decimal::decimal64>(std::move(value), field.name, __VA_ARGS__);                             \
+                std::optional<boost::multiprecision::cpp_dec_float_50> value = (record).deserializeNext<boost::multiprecision::cpp_dec_float_50>();   \
+                func<boost::multiprecision::cpp_dec_float_50>(std::move(value), field.name, __VA_ARGS__);                             \
             } break;                                                                                                  \
             case k2::dto::FieldType::DECIMALD100: {                                                                    \
                 std::optional<boost::multiprecision::cpp_dec_float_100> value = (record).deserializeNext<boost::multiprecision::cpp_dec_float_100>(); \

--- a/src/k2/dto/SKVRecord.h
+++ b/src/k2/dto/SKVRecord.h
@@ -294,7 +294,7 @@ private:
                 std::optional<std::decimal::decimal64> value = (record).deserializeNext<std::decimal::decimal64>();   \
                 func<std::decimal::decimal64>(std::move(value), field.name, __VA_ARGS__);                             \
             } break;                                                                                                  \
-            case k2::dto::FieldType::DECIMAL128: {                                                                    \
+            case k2::dto::FieldType::DECIMAL100: {                                                                    \
                 std::optional<std::decimal::decimal128> value = (record).deserializeNext<std::decimal::decimal128>(); \
                 func<std::decimal::decimal128>(std::move(value), field.name, __VA_ARGS__);                            \
             } break;                                                                                                  \

--- a/src/k2/dto/SKVRecord.h
+++ b/src/k2/dto/SKVRecord.h
@@ -290,13 +290,17 @@ private:
                 std::optional<bool> value = (record).deserializeNext<bool>();                                         \
                 func<bool>(std::move(value), field.name, __VA_ARGS__);                                                \
             } break;                                                                                                  \
-            case k2::dto::FieldType::DECIMALD50: {                                                                     \
-                std::optional<boost::multiprecision::cpp_dec_float_50> value = (record).deserializeNext<boost::multiprecision::cpp_dec_float_50>();   \
-                func<boost::multiprecision::cpp_dec_float_50>(std::move(value), field.name, __VA_ARGS__);                             \
+            case k2::dto::FieldType::DECIMALD25: {                                                                    \
+                std::optional<boost::multiprecision::cpp_dec_float_25> value = (record).deserializeNext<boost::multiprecision::cpp_dec_float_25>();   \
+                func<boost::multiprecision::cpp_dec_float_25>(std::move(value), field.name, __VA_ARGS__);             \
             } break;                                                                                                  \
-            case k2::dto::FieldType::DECIMALD100: {                                                                    \
+            case k2::dto::FieldType::DECIMALD50: {                                                                    \
+                std::optional<boost::multiprecision::cpp_dec_float_50> value = (record).deserializeNext<boost::multiprecision::cpp_dec_float_50>();   \
+                func<boost::multiprecision::cpp_dec_float_50>(std::move(value), field.name, __VA_ARGS__);             \
+            } break;                                                                                                  \
+            case k2::dto::FieldType::DECIMALD100: {                                                                   \
                 std::optional<boost::multiprecision::cpp_dec_float_100> value = (record).deserializeNext<boost::multiprecision::cpp_dec_float_100>(); \
-                func<boost::multiprecision::cpp_dec_float_100>(std::move(value), field.name, __VA_ARGS__);                            \
+                func<boost::multiprecision::cpp_dec_float_100>(std::move(value), field.name, __VA_ARGS__);            \
             } break;                                                                                                  \
             case k2::dto::FieldType::FIELD_TYPE: {                                                                    \
                 std::optional<k2::dto::FieldType> value = (record).deserializeNext<k2::dto::FieldType>();             \

--- a/src/k2/transport/Payload.cpp
+++ b/src/k2/transport/Payload.cpp
@@ -299,10 +299,12 @@ void Payload::write(const String& value) {
 }
 
 void Payload::write(const boost::multiprecision::cpp_dec_float_50& value) {
+    static_assert(sizeof(boost::multiprecision::cpp_dec_float_50) == 56, "check updated implementation for cpp_dec_float_50");
     write(&value, sizeof(boost::multiprecision::cpp_dec_float_50));
 }
 
 void Payload::write(const boost::multiprecision::cpp_dec_float_100& value) {
+    static_assert(sizeof(boost::multiprecision::cpp_dec_float_100) == 80, "check updated implementation for cpp_dec_float_100");
     write(&value, sizeof(boost::multiprecision::cpp_dec_float_100));
 }
 

--- a/src/k2/transport/Payload.cpp
+++ b/src/k2/transport/Payload.cpp
@@ -202,11 +202,11 @@ bool Payload::read(std::decimal::decimal64& value) {
     return true;
 }
 
-bool Payload::read(std::decimal::decimal128& value) {
-    std::decimal::decimal128::__decfloat128 data;
+bool Payload::read(boost::multiprecision::cpp_dec_float_100& value) {
+    boost::multiprecision::float128 data;
     bool success = read((void*)&data, sizeof(data));
     if (!success) return false;
-    value.__setval(data);
+    value = double(data); // NOT SURE
     return true;
 }
 
@@ -311,8 +311,8 @@ void Payload::write(const std::decimal::decimal64& value) {
     write((const void*)&data, sizeof(data));
 }
 
-void Payload::write(const std::decimal::decimal128& value) {
-    std::decimal::decimal128::__decfloat128 data = const_cast<std::decimal::decimal128&>(value).__getval();
+void Payload::write(const boost::multiprecision::cpp_dec_float_100& value) {
+    boost::multiprecision::float128 data = double(value); // NOT SURE
     write((const void*)&data, sizeof(data));
 }
 

--- a/src/k2/transport/Payload.cpp
+++ b/src/k2/transport/Payload.cpp
@@ -194,16 +194,16 @@ bool Payload::read(String& value) {
     return read((void*)value.data(), size);
 }
 
-bool Payload::read(boost::multiprecision::cpp_dec_float_25& value) {
-    return read(&value, sizeof(boost::multiprecision::cpp_dec_float_25));
+bool Payload::read(DecimalD25& value) {
+    return read(&value, sizeof(DecimalD25));
 }
 
-bool Payload::read(boost::multiprecision::cpp_dec_float_50& value) {
-    return read(&value, sizeof(boost::multiprecision::cpp_dec_float_50));
+bool Payload::read(DecimalD50& value) {
+    return read(&value, sizeof(DecimalD50));
 }
 
-bool Payload::read(boost::multiprecision::cpp_dec_float_100& value) {
-    return read(&value, sizeof(boost::multiprecision::cpp_dec_float_100));
+bool Payload::read(DecimalD100& value) {
+    return read(&value, sizeof(DecimalD100));
 }
 
 bool Payload::read(Payload& other) {
@@ -302,19 +302,19 @@ void Payload::write(const String& value) {
     write(value.data(), size);
 }
 
-void Payload::write(const boost::multiprecision::cpp_dec_float_25& value) {
-    static_assert(sizeof(boost::multiprecision::cpp_dec_float_25) == 44, "check updated implementation for cpp_dec_float_25");
-    write(&value, sizeof(boost::multiprecision::cpp_dec_float_25));
+void Payload::write(const DecimalD25& value) {
+    static_assert(sizeof(DecimalD25) == 44, "check updated implementation for cpp_dec_float_25");
+    write(&value, sizeof(DecimalD25));
 }
 
-void Payload::write(const boost::multiprecision::cpp_dec_float_50& value) {
-    static_assert(sizeof(boost::multiprecision::cpp_dec_float_50) == 56, "check updated implementation for cpp_dec_float_50");
-    write(&value, sizeof(boost::multiprecision::cpp_dec_float_50));
+void Payload::write(const DecimalD50& value) {
+    static_assert(sizeof(DecimalD50) == 56, "check updated implementation for cpp_dec_float_50");
+    write(&value, sizeof(DecimalD50));
 }
 
-void Payload::write(const boost::multiprecision::cpp_dec_float_100& value) {
-    static_assert(sizeof(boost::multiprecision::cpp_dec_float_100) == 80, "check updated implementation for cpp_dec_float_100");
-    write(&value, sizeof(boost::multiprecision::cpp_dec_float_100));
+void Payload::write(const DecimalD100& value) {
+    static_assert(sizeof(DecimalD100) == 80, "check updated implementation for cpp_dec_float_100");
+    write(&value, sizeof(DecimalD100));
 }
 
 void Payload::write(const Binary& bin) {

--- a/src/k2/transport/Payload.cpp
+++ b/src/k2/transport/Payload.cpp
@@ -195,27 +195,11 @@ bool Payload::read(String& value) {
 }
 
 bool Payload::read(boost::multiprecision::cpp_dec_float_50& value) {
-    Binary binData;
-    bool success = read(binData);
-    if (!success) return false;
-    try {
-        value = boost::multiprecision::cpp_dec_float_50(binData.get());
-    } catch(std::exception& e) {
-        return false;
-    }
-    return true;
+    return read(&value, sizeof(boost::multiprecision::cpp_dec_float_50));
 }
 
 bool Payload::read(boost::multiprecision::cpp_dec_float_100& value) {
-    Binary binData;
-    bool success = read(binData);
-    if (!success) return false;
-    try {
-        value = boost::multiprecision::cpp_dec_float_100(binData.get());
-    } catch(std::exception& e) {
-        return false;
-    }
-    return true;
+    return read(&value, sizeof(boost::multiprecision::cpp_dec_float_100));
 }
 
 bool Payload::read(Payload& other) {
@@ -315,13 +299,11 @@ void Payload::write(const String& value) {
 }
 
 void Payload::write(const boost::multiprecision::cpp_dec_float_50& value) {
-    auto shp = seastar::make_lw_shared<std::string>(value.str());
-    write(Binary(shp->data(), shp->size() + 1, seastar::make_deleter([shp]() mutable {})));
+    write(&value, sizeof(boost::multiprecision::cpp_dec_float_50));
 }
 
 void Payload::write(const boost::multiprecision::cpp_dec_float_100& value) {
-    auto shp = seastar::make_lw_shared<std::string>(value.str());
-    write(Binary(shp->data(), shp->size() + 1, seastar::make_deleter([shp]() mutable {})));
+    write(&value, sizeof(boost::multiprecision::cpp_dec_float_100));
 }
 
 void Payload::write(const Binary& bin) {

--- a/src/k2/transport/Payload.cpp
+++ b/src/k2/transport/Payload.cpp
@@ -194,6 +194,10 @@ bool Payload::read(String& value) {
     return read((void*)value.data(), size);
 }
 
+bool Payload::read(boost::multiprecision::cpp_dec_float_25& value) {
+    return read(&value, sizeof(boost::multiprecision::cpp_dec_float_25));
+}
+
 bool Payload::read(boost::multiprecision::cpp_dec_float_50& value) {
     return read(&value, sizeof(boost::multiprecision::cpp_dec_float_50));
 }
@@ -296,6 +300,11 @@ void Payload::write(const String& value) {
     _Size size = value.size() + 1; // count the null character too
     write(size);
     write(value.data(), size);
+}
+
+void Payload::write(const boost::multiprecision::cpp_dec_float_25& value) {
+    static_assert(sizeof(boost::multiprecision::cpp_dec_float_25) == 44, "check updated implementation for cpp_dec_float_25");
+    write(&value, sizeof(boost::multiprecision::cpp_dec_float_25));
 }
 
 void Payload::write(const boost::multiprecision::cpp_dec_float_50& value) {

--- a/src/k2/transport/Payload.cpp
+++ b/src/k2/transport/Payload.cpp
@@ -198,9 +198,8 @@ bool Payload::read(boost::multiprecision::cpp_dec_float_50& value) {
     Binary binData;
     bool success = read(binData);
     if (!success) return false;
-    String s(binData.get(), binData.size());
-    boost::multiprecision::cpp_dec_float_50 _val(s.c_str());
-    value = _val;
+    boost::multiprecision::cpp_dec_float_50 val(binData.get());
+    value = val;
     return true;
 }
 
@@ -208,9 +207,8 @@ bool Payload::read(boost::multiprecision::cpp_dec_float_100& value) {
     Binary binData;
     bool success = read(binData);
     if (!success) return false;
-    String s(binData.get(), binData.size());
-    boost::multiprecision::cpp_dec_float_100 _val(s.c_str());
-    value = _val;
+    boost::multiprecision::cpp_dec_float_100 val(binData.get());
+    value = val;
     return true;
 }
 
@@ -312,12 +310,12 @@ void Payload::write(const String& value) {
 
 void Payload::write(const boost::multiprecision::cpp_dec_float_50& value) {
     auto shp = seastar::make_lw_shared<std::string>(value.str());
-    write(Binary(shp->data(), shp->size(), seastar::make_deleter([shp]() mutable {})));
+    write(Binary(shp->data(), shp->size() + 1, seastar::make_deleter([shp]() mutable {})));
 }
 
 void Payload::write(const boost::multiprecision::cpp_dec_float_100& value) {
     auto shp = seastar::make_lw_shared<std::string>(value.str());
-    write(Binary(shp->data(), shp->size(), seastar::make_deleter([shp]() mutable {})));
+    write(Binary(shp->data(), shp->size() + 1, seastar::make_deleter([shp]() mutable {})));
 }
 
 void Payload::write(const Binary& bin) {

--- a/src/k2/transport/Payload.cpp
+++ b/src/k2/transport/Payload.cpp
@@ -195,18 +195,22 @@ bool Payload::read(String& value) {
 }
 
 bool Payload::read(boost::multiprecision::cpp_dec_float_50& value) {
-    boost::multiprecision::cpp_dec_float_50 data;
-    bool success = read((void*)&data, sizeof(data));
+    String data;
+    bool success = read(data);
     if (!success) return false;
-    value = data; // NOT SURE
+    // construct from a c string.
+    boost::multiprecision::cpp_dec_float_100 _val(data.c_str()); 
+    value = _val; // NOT SURE
     return true;
 }
 
 bool Payload::read(boost::multiprecision::cpp_dec_float_100& value) {
-    boost::multiprecision::cpp_dec_float_100 data;
-    bool success = read((void*)&data, sizeof(data));
+    String data;
+    bool success = read(data);
     if (!success) return false;
-    value = data; // NOT SURE
+    // construct from a c string.
+    boost::multiprecision::cpp_dec_float_100 _val(data.c_str());
+    value = _val; // NOT SURE
     return true;
 }
 
@@ -307,13 +311,13 @@ void Payload::write(const String& value) {
 }
 
 void Payload::write(const boost::multiprecision::cpp_dec_float_50& value) {
-    boost::multiprecision::cpp_dec_float_50 data = value; // NOT SURE
-    write((const void*)&data, sizeof(data));
+    String ss(value.str()); // serialize as a String
+    write(ss); // NOT SURE
 }
 
 void Payload::write(const boost::multiprecision::cpp_dec_float_100& value) {
-    boost::multiprecision::cpp_dec_float_100 data = value; // NOT SURE
-    write((const void*)&data, sizeof(data));
+    String ss(value.str()); // serialize as a String
+    write(ss); // NOT SURE
 }
 
 void Payload::write(const Binary& bin) {

--- a/src/k2/transport/Payload.cpp
+++ b/src/k2/transport/Payload.cpp
@@ -195,22 +195,22 @@ bool Payload::read(String& value) {
 }
 
 bool Payload::read(boost::multiprecision::cpp_dec_float_50& value) {
-    String data;
-    bool success = read(data);
+    Binary binData;
+    bool success = read(binData);
     if (!success) return false;
-    // construct from a c string.
-    boost::multiprecision::cpp_dec_float_50 _val(data.c_str()); 
-    value = _val; // NOT SURE
+    String s(binData.get(), binData.size());
+    boost::multiprecision::cpp_dec_float_50 _val(s.c_str());
+    value = _val;
     return true;
 }
 
 bool Payload::read(boost::multiprecision::cpp_dec_float_100& value) {
-    String data;
-    bool success = read(data);
+    Binary binData;
+    bool success = read(binData);
     if (!success) return false;
-    // construct from a c string.
-    boost::multiprecision::cpp_dec_float_100 _val(data.c_str());
-    value = _val; // NOT SURE
+    String s(binData.get(), binData.size());
+    boost::multiprecision::cpp_dec_float_100 _val(s.c_str());
+    value = _val;
     return true;
 }
 
@@ -311,13 +311,13 @@ void Payload::write(const String& value) {
 }
 
 void Payload::write(const boost::multiprecision::cpp_dec_float_50& value) {
-    String ss(value.str()); // serialize as a String
-    write(ss); // NOT SURE
+    auto shp = seastar::make_lw_shared<std::string>(value.str());
+    write(Binary(shp->data(), shp->size(), seastar::make_deleter([shp]() mutable {})));
 }
 
 void Payload::write(const boost::multiprecision::cpp_dec_float_100& value) {
-    String ss(value.str()); // serialize as a String
-    write(ss); // NOT SURE
+    auto shp = seastar::make_lw_shared<std::string>(value.str());
+    write(Binary(shp->data(), shp->size(), seastar::make_deleter([shp]() mutable {})));
 }
 
 void Payload::write(const Binary& bin) {

--- a/src/k2/transport/Payload.cpp
+++ b/src/k2/transport/Payload.cpp
@@ -199,7 +199,7 @@ bool Payload::read(boost::multiprecision::cpp_dec_float_50& value) {
     bool success = read(data);
     if (!success) return false;
     // construct from a c string.
-    boost::multiprecision::cpp_dec_float_100 _val(data.c_str()); 
+    boost::multiprecision::cpp_dec_float_50 _val(data.c_str()); 
     value = _val; // NOT SURE
     return true;
 }

--- a/src/k2/transport/Payload.cpp
+++ b/src/k2/transport/Payload.cpp
@@ -198,8 +198,11 @@ bool Payload::read(boost::multiprecision::cpp_dec_float_50& value) {
     Binary binData;
     bool success = read(binData);
     if (!success) return false;
-    boost::multiprecision::cpp_dec_float_50 val(binData.get());
-    value = val;
+    try {
+        value = boost::multiprecision::cpp_dec_float_50(binData.get());
+    } catch(std::exception& e) {
+        return false;
+    }
     return true;
 }
 
@@ -207,8 +210,11 @@ bool Payload::read(boost::multiprecision::cpp_dec_float_100& value) {
     Binary binData;
     bool success = read(binData);
     if (!success) return false;
-    boost::multiprecision::cpp_dec_float_100 val(binData.get());
-    value = val;
+    try {
+        value = boost::multiprecision::cpp_dec_float_100(binData.get());
+    } catch(std::exception& e) {
+        return false;
+    }
     return true;
 }
 

--- a/src/k2/transport/Payload.cpp
+++ b/src/k2/transport/Payload.cpp
@@ -194,19 +194,19 @@ bool Payload::read(String& value) {
     return read((void*)value.data(), size);
 }
 
-bool Payload::read(std::decimal::decimal64& value) {
-    std::decimal::decimal64::__decfloat64 data;
+bool Payload::read(boost::multiprecision::cpp_dec_float_50& value) {
+    boost::multiprecision::cpp_dec_float_50 data;
     bool success = read((void*)&data, sizeof(data));
     if (!success) return false;
-    value.__setval(data);
+    value = data; // NOT SURE
     return true;
 }
 
 bool Payload::read(boost::multiprecision::cpp_dec_float_100& value) {
-    boost::multiprecision::float128 data;
+    boost::multiprecision::cpp_dec_float_100 data;
     bool success = read((void*)&data, sizeof(data));
     if (!success) return false;
-    value = double(data); // NOT SURE
+    value = data; // NOT SURE
     return true;
 }
 
@@ -306,13 +306,13 @@ void Payload::write(const String& value) {
     write(value.data(), size);
 }
 
-void Payload::write(const std::decimal::decimal64& value) {
-    std::decimal::decimal64::__decfloat64 data = const_cast<std::decimal::decimal64&>(value).__getval();
+void Payload::write(const boost::multiprecision::cpp_dec_float_50& value) {
+    boost::multiprecision::cpp_dec_float_50 data = value; // NOT SURE
     write((const void*)&data, sizeof(data));
 }
 
 void Payload::write(const boost::multiprecision::cpp_dec_float_100& value) {
-    boost::multiprecision::float128 data = double(value); // NOT SURE
+    boost::multiprecision::cpp_dec_float_100 data = value; // NOT SURE
     write((const void*)&data, sizeof(data));
 }
 

--- a/src/k2/transport/Payload.h
+++ b/src/k2/transport/Payload.h
@@ -24,13 +24,13 @@ Copyright(c) 2020 Futurewei Cloud
 #pragma once
 #include "Log.h"
 
-#include <boost/multiprecision/cpp_dec_float.hpp>
-
 #include <map>
 #include <unordered_map>
 #include <unordered_set>
 #include <set>
 #include <limits>
+
+#include <boost/multiprecision/cpp_dec_float.hpp>
 
 #include <k2/common/Common.h>
 #include <k2/logging/Log.h>
@@ -535,13 +535,29 @@ public: // getSerializedSizeOf api
     // for type: boost::multiprecision::cpp_dec_float_50
     template <typename T>
     std::enable_if_t<std::is_same_v<T, boost::multiprecision::cpp_dec_float_50>, size_t> getSerializedSizeOf() {
-        return getSerializedSizeOf<String>(); // NOT SURE
+        auto curPos = getCurrentPosition();
+        size_t size = 0;
+        if (!read(size)) {
+            K2LOG_E(log::tx, "failed to read payload size");
+            seek(curPos);
+            return 0;
+        }
+        seek(curPos);
+        return size + sizeof(size);
     }
 
     // for type: boost::multiprecision::cpp_dec_float_100
     template <typename T>
     std::enable_if_t<std::is_same_v<T, boost::multiprecision::cpp_dec_float_100>, size_t> getSerializedSizeOf() {
-        return getSerializedSizeOf<String>(); // NOT SURE
+        auto curPos = getCurrentPosition();
+        size_t size = 0;
+        if (!read(size)) {
+            K2LOG_E(log::tx, "failed to read payload size");
+            seek(curPos);
+            return 0;
+        }
+        seek(curPos);
+        return size + sizeof(size);
     }
 
     // for type: Duration

--- a/src/k2/transport/Payload.h
+++ b/src/k2/transport/Payload.h
@@ -24,9 +24,7 @@ Copyright(c) 2020 Futurewei Cloud
 #pragma once
 #include "Log.h"
 
-#include <decimal/decimal>
 #include <boost/multiprecision/cpp_dec_float.hpp>
-#include <boost/multiprecision/float128.hpp>
 
 #include <map>
 #include <unordered_map>

--- a/src/k2/transport/Payload.h
+++ b/src/k2/transport/Payload.h
@@ -29,6 +29,9 @@ Copyright(c) 2020 Futurewei Cloud
 #include <unordered_set>
 #include <set>
 #include <limits>
+
+#include <k2/dto/FieldTypes.h>
+
 #include <k2/common/Common.h>
 #include <k2/logging/Log.h>
 

--- a/src/k2/transport/Payload.h
+++ b/src/k2/transport/Payload.h
@@ -30,7 +30,7 @@ Copyright(c) 2020 Futurewei Cloud
 #include <set>
 #include <limits>
 
-#include <boost/multiprecision/cpp_dec_float.hpp>
+#include <k2/dto/FieldTypes.h>
 
 #include <k2/common/Common.h>
 #include <k2/logging/Log.h>
@@ -220,6 +220,7 @@ public:  // Read API
     bool read(String& value);
 
     // read primitive decimal types
+    bool read(boost::multiprecision::cpp_dec_float_25& value);
     bool read(boost::multiprecision::cpp_dec_float_50& value);
     bool read(boost::multiprecision::cpp_dec_float_100& value);
 
@@ -381,6 +382,7 @@ public: // Write API
     void write(const String& value);
 
     // write primitive decimal types
+    void write(const boost::multiprecision::cpp_dec_float_25& value);
     void write(const boost::multiprecision::cpp_dec_float_50& value);
     void write(const boost::multiprecision::cpp_dec_float_100& value);
 
@@ -530,6 +532,12 @@ public: // getSerializedSizeOf api
         }
         seek(curPos);
         return size + sizeof(size);
+    }
+
+    // for type boost::multiprecision::cpp_dec_float_25
+    template <typename T>
+    std::enable_if_t<std::is_same_v<T, boost::multiprecision::cpp_dec_float_25>, size_t> getSerializedSizeOf() {
+        return sizeof(boost::multiprecision::cpp_dec_float_25);
     }
 
     // for type boost::multiprecision::cpp_dec_float_50

--- a/src/k2/transport/Payload.h
+++ b/src/k2/transport/Payload.h
@@ -532,27 +532,14 @@ public: // getSerializedSizeOf api
         return size + sizeof(size);
     }
 
-    // for type: boost::multiprecision::cpp_dec_float_50
+    // for types: boost::multiprecision::cpp_dec_float_50 and boost::multiprecision::cpp_dec_float_100
     template <typename T>
-    std::enable_if_t<std::is_same_v<T, boost::multiprecision::cpp_dec_float_50>, size_t> getSerializedSizeOf() {
+    std::enable_if_t<std::is_same_v<T, boost::multiprecision::cpp_dec_float_50> 
+        || std::is_same_v<T, boost::multiprecision::cpp_dec_float_100>, size_t> getSerializedSizeOf() {
         auto curPos = getCurrentPosition();
         size_t size = 0;
         if (!read(size)) {
-            K2LOG_E(log::tx, "failed to read payload size");
-            seek(curPos);
-            return 0;
-        }
-        seek(curPos);
-        return size + sizeof(size);
-    }
-
-    // for type: boost::multiprecision::cpp_dec_float_100
-    template <typename T>
-    std::enable_if_t<std::is_same_v<T, boost::multiprecision::cpp_dec_float_100>, size_t> getSerializedSizeOf() {
-        auto curPos = getCurrentPosition();
-        size_t size = 0;
-        if (!read(size)) {
-            K2LOG_E(log::tx, "failed to read payload size");
+            K2LOG_E(log::tx, "failed to read decimal size");
             seek(curPos);
             return 0;
         }

--- a/src/k2/transport/Payload.h
+++ b/src/k2/transport/Payload.h
@@ -222,7 +222,7 @@ public:  // Read API
     bool read(String& value);
 
     // read primitive decimal types
-    bool read(std::decimal::decimal64& value);
+    bool read(boost::multiprecision::cpp_dec_float_50& value);
     bool read(boost::multiprecision::cpp_dec_float_100& value);
 
     // read into a payload
@@ -383,7 +383,7 @@ public: // Write API
     void write(const String& value);
 
     // write primitive decimal types
-    void write(const std::decimal::decimal64& value);
+    void write(const boost::multiprecision::cpp_dec_float_50& value);
     void write(const boost::multiprecision::cpp_dec_float_100& value);
 
     // write another Payload
@@ -534,16 +534,16 @@ public: // getSerializedSizeOf api
         return size + sizeof(size);
     }
 
-    // for type: std::decimal::decimal64
+    // for type: boost::multiprecision::cpp_dec_float_50
     template <typename T>
-    std::enable_if_t<std::is_same_v<T, std::decimal::decimal64>, size_t> getSerializedSizeOf() {
-        return sizeof(std::decimal::decimal64::__decfloat64);
+    std::enable_if_t<std::is_same_v<T, boost::multiprecision::cpp_dec_float_50>, size_t> getSerializedSizeOf() {
+        return sizeof(boost::multiprecision::cpp_dec_float_50); // NOT SURE
     }
 
     // for type: boost::multiprecision::cpp_dec_float_100
     template <typename T>
     std::enable_if_t<std::is_same_v<T, boost::multiprecision::cpp_dec_float_100>, size_t> getSerializedSizeOf() {
-        return sizeof(boost::multiprecision::float128); // NOT SURE
+        return sizeof(boost::multiprecision::cpp_dec_float_100); // NOT SURE
     }
 
     // for type: Duration

--- a/src/k2/transport/Payload.h
+++ b/src/k2/transport/Payload.h
@@ -537,13 +537,13 @@ public: // getSerializedSizeOf api
     // for type: boost::multiprecision::cpp_dec_float_50
     template <typename T>
     std::enable_if_t<std::is_same_v<T, boost::multiprecision::cpp_dec_float_50>, size_t> getSerializedSizeOf() {
-        return sizeof(boost::multiprecision::cpp_dec_float_50); // NOT SURE
+        return getSerializedSizeOf<String>(); // NOT SURE
     }
 
     // for type: boost::multiprecision::cpp_dec_float_100
     template <typename T>
     std::enable_if_t<std::is_same_v<T, boost::multiprecision::cpp_dec_float_100>, size_t> getSerializedSizeOf() {
-        return sizeof(boost::multiprecision::cpp_dec_float_100); // NOT SURE
+        return getSerializedSizeOf<String>(); // NOT SURE
     }
 
     // for type: Duration

--- a/src/k2/transport/Payload.h
+++ b/src/k2/transport/Payload.h
@@ -30,8 +30,6 @@ Copyright(c) 2020 Futurewei Cloud
 #include <set>
 #include <limits>
 
-#include <k2/dto/FieldTypes.h>
-
 #include <k2/common/Common.h>
 #include <k2/logging/Log.h>
 

--- a/src/k2/transport/Payload.h
+++ b/src/k2/transport/Payload.h
@@ -532,19 +532,16 @@ public: // getSerializedSizeOf api
         return size + sizeof(size);
     }
 
-    // for types: boost::multiprecision::cpp_dec_float_50 and boost::multiprecision::cpp_dec_float_100
+    // for type boost::multiprecision::cpp_dec_float_50
     template <typename T>
-    std::enable_if_t<std::is_same_v<T, boost::multiprecision::cpp_dec_float_50> 
-        || std::is_same_v<T, boost::multiprecision::cpp_dec_float_100>, size_t> getSerializedSizeOf() {
-        auto curPos = getCurrentPosition();
-        size_t size = 0;
-        if (!read(size)) {
-            K2LOG_E(log::tx, "failed to read decimal size");
-            seek(curPos);
-            return 0;
-        }
-        seek(curPos);
-        return size + sizeof(size);
+    std::enable_if_t<std::is_same_v<T, boost::multiprecision::cpp_dec_float_50>, size_t> getSerializedSizeOf() {
+        return sizeof(boost::multiprecision::cpp_dec_float_50);
+    }
+
+    // for type boost::multiprecision::cpp_dec_float_100
+    template <typename T>
+    std::enable_if_t<std::is_same_v<T, boost::multiprecision::cpp_dec_float_100>, size_t> getSerializedSizeOf() {
+        return sizeof(boost::multiprecision::cpp_dec_float_100);
     }
 
     // for type: Duration

--- a/src/k2/transport/Payload.h
+++ b/src/k2/transport/Payload.h
@@ -218,9 +218,9 @@ public:  // Read API
     bool read(String& value);
 
     // read primitive decimal types
-    bool read(boost::multiprecision::cpp_dec_float_25& value);
-    bool read(boost::multiprecision::cpp_dec_float_50& value);
-    bool read(boost::multiprecision::cpp_dec_float_100& value);
+    bool read(DecimalD25& value);
+    bool read(DecimalD50& value);
+    bool read(DecimalD100& value);
 
     // read into a payload
     bool read(Payload& other);
@@ -380,9 +380,9 @@ public: // Write API
     void write(const String& value);
 
     // write primitive decimal types
-    void write(const boost::multiprecision::cpp_dec_float_25& value);
-    void write(const boost::multiprecision::cpp_dec_float_50& value);
-    void write(const boost::multiprecision::cpp_dec_float_100& value);
+    void write(const DecimalD25& value);
+    void write(const DecimalD50& value);
+    void write(const DecimalD100& value);
 
     // write another Payload
     void write(const Payload& other);
@@ -532,22 +532,22 @@ public: // getSerializedSizeOf api
         return size + sizeof(size);
     }
 
-    // for type boost::multiprecision::cpp_dec_float_25
+    // for type DecimalD25
     template <typename T>
-    std::enable_if_t<std::is_same_v<T, boost::multiprecision::cpp_dec_float_25>, size_t> getSerializedSizeOf() {
-        return sizeof(boost::multiprecision::cpp_dec_float_25);
+    std::enable_if_t<std::is_same_v<T, DecimalD25>, size_t> getSerializedSizeOf() {
+        return sizeof(DecimalD25);
     }
 
-    // for type boost::multiprecision::cpp_dec_float_50
+    // for type DecimalD50
     template <typename T>
-    std::enable_if_t<std::is_same_v<T, boost::multiprecision::cpp_dec_float_50>, size_t> getSerializedSizeOf() {
-        return sizeof(boost::multiprecision::cpp_dec_float_50);
+    std::enable_if_t<std::is_same_v<T, DecimalD50>, size_t> getSerializedSizeOf() {
+        return sizeof(DecimalD50);
     }
 
-    // for type boost::multiprecision::cpp_dec_float_100
+    // for type DecimalD100
     template <typename T>
-    std::enable_if_t<std::is_same_v<T, boost::multiprecision::cpp_dec_float_100>, size_t> getSerializedSizeOf() {
-        return sizeof(boost::multiprecision::cpp_dec_float_100);
+    std::enable_if_t<std::is_same_v<T, DecimalD100>, size_t> getSerializedSizeOf() {
+        return sizeof(DecimalD100);
     }
 
     // for type: Duration

--- a/src/k2/transport/Payload.h
+++ b/src/k2/transport/Payload.h
@@ -29,9 +29,6 @@ Copyright(c) 2020 Futurewei Cloud
 #include <unordered_set>
 #include <set>
 #include <limits>
-
-#include <k2/dto/FieldTypes.h>
-
 #include <k2/common/Common.h>
 #include <k2/logging/Log.h>
 

--- a/src/k2/transport/Payload.h
+++ b/src/k2/transport/Payload.h
@@ -25,6 +25,9 @@ Copyright(c) 2020 Futurewei Cloud
 #include "Log.h"
 
 #include <decimal/decimal>
+#include <boost/multiprecision/cpp_dec_float.hpp>
+#include <boost/multiprecision/float128.hpp>
+
 #include <map>
 #include <unordered_map>
 #include <unordered_set>
@@ -220,7 +223,7 @@ public:  // Read API
 
     // read primitive decimal types
     bool read(std::decimal::decimal64& value);
-    bool read(std::decimal::decimal128& value);
+    bool read(boost::multiprecision::cpp_dec_float_100& value);
 
     // read into a payload
     bool read(Payload& other);
@@ -381,7 +384,7 @@ public: // Write API
 
     // write primitive decimal types
     void write(const std::decimal::decimal64& value);
-    void write(const std::decimal::decimal128& value);
+    void write(const boost::multiprecision::cpp_dec_float_100& value);
 
     // write another Payload
     void write(const Payload& other);
@@ -537,10 +540,10 @@ public: // getSerializedSizeOf api
         return sizeof(std::decimal::decimal64::__decfloat64);
     }
 
-    // for type: std::decimal::decimal128
+    // for type: boost::multiprecision::cpp_dec_float_100
     template <typename T>
-    std::enable_if_t<std::is_same_v<T, std::decimal::decimal128>, size_t> getSerializedSizeOf() {
-        return sizeof(std::decimal::decimal128::__decfloat128);
+    std::enable_if_t<std::is_same_v<T, boost::multiprecision::cpp_dec_float_100>, size_t> getSerializedSizeOf() {
+        return sizeof(boost::multiprecision::float128); // NOT SURE
     }
 
     // for type: Duration

--- a/src/k2/transport/PayloadSerialization.h
+++ b/src/k2/transport/PayloadSerialization.h
@@ -338,7 +338,7 @@ public:
         _payload.write(value);
     }
     void write(const std::decimal::decimal128& value) {
-        K2LOG_V(log::tx, "writing decimal128 type {}", value);
+        K2LOG_V(log::tx, "writing decimal100 type {}", value);
         _payload.write(value);
     }
     void write(const String& value) {

--- a/src/k2/transport/PayloadSerialization.h
+++ b/src/k2/transport/PayloadSerialization.h
@@ -201,7 +201,7 @@ public:
     bool read(Duration& dur) {
         return _payload.read(dur);
     }
-    bool read(std::decimal::decimal64& value) {
+    bool read(boost::multiprecision::cpp_dec_float_50& value) {
         return _payload.read(value);
     }
     bool read(boost::multiprecision::cpp_dec_float_100& value) {
@@ -333,7 +333,7 @@ public:
         K2LOG_V(log::tx, "writing duration type {}", value);
         _payload.write(value);
     }
-    void write(const std::decimal::decimal64& value) {
+    void write(const boost::multiprecision::cpp_dec_float_50& value) {
         K2LOG_V(log::tx, "writing decimald50 type {}", value);
         _payload.write(value);
     }

--- a/src/k2/transport/PayloadSerialization.h
+++ b/src/k2/transport/PayloadSerialization.h
@@ -201,13 +201,13 @@ public:
     bool read(Duration& dur) {
         return _payload.read(dur);
     }
-    bool read(boost::multiprecision::cpp_dec_float_25& value) {
+    bool read(DecimalD25& value) {
         return _payload.read(value);
     }
-    bool read(boost::multiprecision::cpp_dec_float_50& value) {
+    bool read(DecimalD50& value) {
         return _payload.read(value);
     }
-    bool read(boost::multiprecision::cpp_dec_float_100& value) {
+    bool read(DecimalD100& value) {
         return _payload.read(value);
     }
 
@@ -336,15 +336,15 @@ public:
         K2LOG_V(log::tx, "writing duration type {}", value);
         _payload.write(value);
     }
-    void write(const boost::multiprecision::cpp_dec_float_25& value) {
+    void write(const DecimalD25& value) {
         K2LOG_V(log::tx, "writing decimald25 type {}", value);
         _payload.write(value);
     }
-    void write(const boost::multiprecision::cpp_dec_float_50& value) {
+    void write(const DecimalD50& value) {
         K2LOG_V(log::tx, "writing decimald50 type {}", value);
         _payload.write(value);
     }
-    void write(const boost::multiprecision::cpp_dec_float_100& value) {
+    void write(const DecimalD100& value) {
         K2LOG_V(log::tx, "writing decimald100 type {}", value);
         _payload.write(value);
     }

--- a/src/k2/transport/PayloadSerialization.h
+++ b/src/k2/transport/PayloadSerialization.h
@@ -338,7 +338,7 @@ public:
         _payload.write(value);
     }
     void write(const std::decimal::decimal128& value) {
-        K2LOG_V(log::tx, "writing decimal100 type {}", value);
+        K2LOG_V(log::tx, "writing decimald100 type {}", value);
         _payload.write(value);
     }
     void write(const String& value) {

--- a/src/k2/transport/PayloadSerialization.h
+++ b/src/k2/transport/PayloadSerialization.h
@@ -201,6 +201,9 @@ public:
     bool read(Duration& dur) {
         return _payload.read(dur);
     }
+    bool read(boost::multiprecision::cpp_dec_float_25& value) {
+        return _payload.read(value);
+    }
     bool read(boost::multiprecision::cpp_dec_float_50& value) {
         return _payload.read(value);
     }
@@ -331,6 +334,10 @@ public:
     }
     void write(const Duration& value) {
         K2LOG_V(log::tx, "writing duration type {}", value);
+        _payload.write(value);
+    }
+    void write(const boost::multiprecision::cpp_dec_float_25& value) {
+        K2LOG_V(log::tx, "writing decimald25 type {}", value);
         _payload.write(value);
     }
     void write(const boost::multiprecision::cpp_dec_float_50& value) {

--- a/src/k2/transport/PayloadSerialization.h
+++ b/src/k2/transport/PayloadSerialization.h
@@ -334,7 +334,7 @@ public:
         _payload.write(value);
     }
     void write(const std::decimal::decimal64& value) {
-        K2LOG_V(log::tx, "writing decimal64 type {}", value);
+        K2LOG_V(log::tx, "writing decimald50 type {}", value);
         _payload.write(value);
     }
     void write(const std::decimal::decimal128& value) {

--- a/src/k2/transport/PayloadSerialization.h
+++ b/src/k2/transport/PayloadSerialization.h
@@ -204,7 +204,7 @@ public:
     bool read(std::decimal::decimal64& value) {
         return _payload.read(value);
     }
-    bool read(std::decimal::decimal128& value) {
+    bool read(boost::multiprecision::cpp_dec_float_100& value) {
         return _payload.read(value);
     }
 
@@ -337,7 +337,7 @@ public:
         K2LOG_V(log::tx, "writing decimald50 type {}", value);
         _payload.write(value);
     }
-    void write(const std::decimal::decimal128& value) {
+    void write(const boost::multiprecision::cpp_dec_float_100& value) {
         K2LOG_V(log::tx, "writing decimald100 type {}", value);
         _payload.write(value);
     }

--- a/src/logging/src/k2/logging/BoostDecimals.h
+++ b/src/logging/src/k2/logging/BoostDecimals.h
@@ -1,0 +1,35 @@
+/*
+MIT License
+
+Copyright(c) 2021 Futurewei Cloud
+
+    Permission is hereby granted,
+    free of charge, to any person obtaining a copy of this software and associated documentation files(the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and / or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions :
+
+    The above copyright notice and this permission notice shall be included in all copies
+    or
+    substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS",
+    WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+    DAMAGES OR OTHER
+    LIABILITY,
+    WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+*/
+#pragma once
+
+#include <boost/multiprecision/cpp_dec_float.hpp>
+
+namespace boost::multiprecision {
+typedef number<cpp_dec_float<25> > cpp_dec_float_25;
+}
+
+namespace k2 {
+using DecimalD25 = boost::multiprecision::cpp_dec_float_25;
+using DecimalD50 = boost::multiprecision::cpp_dec_float_50;
+using DecimalD100 = boost::multiprecision::cpp_dec_float_100;
+}

--- a/src/logging/src/k2/logging/Decimal.h
+++ b/src/logging/src/k2/logging/Decimal.h
@@ -1,7 +1,7 @@
 /*
 MIT License
 
-Copyright(c) 2021 Futurewei Cloud
+Copyright(c) 2022 Futurewei Cloud
 
     Permission is hereby granted,
     free of charge, to any person obtaining a copy of this software and associated documentation files(the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and / or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions :

--- a/src/logging/src/k2/logging/FormattingUtils.h
+++ b/src/logging/src/k2/logging/FormattingUtils.h
@@ -157,13 +157,15 @@ constexpr auto type_name() {
 // Provide formatting for decimals
 #ifdef _GLIBCXX_USE_DECIMAL_FLOAT
 #include <decimal/decimal>
+#include <boost/multiprecision/cpp_dec_float.hpp>
+#include <boost/multiprecision/float128.hpp>
 namespace std {
 inline ostream& operator<<(ostream& os, const decimal::decimal64& d) {
     decimal::decimal64::__decfloat64 data = const_cast<decimal::decimal64&>(d).__getval();
     return os << (double)data;
 }
-inline ostream& operator<<(ostream& os, const decimal::decimal128& d) {
-    decimal::decimal128::__decfloat128 data = const_cast<decimal::decimal128&>(d).__getval();
+inline ostream& operator<<(ostream& os, const boost::multiprecision::cpp_dec_float_100& d) {
+    boost::multiprecision::float128 data = double (const_cast<boost::multiprecision::cpp_dec_float_100&>(d)); // NOT SURE
     return os << (double)data;
 }
 }

--- a/src/logging/src/k2/logging/FormattingUtils.h
+++ b/src/logging/src/k2/logging/FormattingUtils.h
@@ -43,9 +43,9 @@ Copyright(c) 2021 Futurewei Cloud
 #include <vector>
 
 #include <boost/multiprecision/cpp_dec_float.hpp>
-// define cpp_dec_float_25 for use in both k2 and skvhttpclient
+
 namespace boost::multiprecision {
-    typedef number<cpp_dec_float<25> > cpp_dec_float_25;
+typedef number<cpp_dec_float<25> > cpp_dec_float_25;
 }
 
 namespace k2 {

--- a/src/logging/src/k2/logging/FormattingUtils.h
+++ b/src/logging/src/k2/logging/FormattingUtils.h
@@ -160,13 +160,13 @@ constexpr auto type_name() {
 #include <boost/multiprecision/cpp_dec_float.hpp>
 #include <boost/multiprecision/float128.hpp>
 namespace std {
-inline ostream& operator<<(ostream& os, const decimal::decimal64& d) {
-    decimal::decimal64::__decfloat64 data = const_cast<decimal::decimal64&>(d).__getval();
-    return os << (double)data;
+inline ostream& operator<<(ostream& os, const boost::multiprecision::cpp_dec_float_50& d) {
+    boost::multiprecision::cpp_dec_float_50 data = d; // NOT SURE
+    return os << data.backend().extract_double();
 }
 inline ostream& operator<<(ostream& os, const boost::multiprecision::cpp_dec_float_100& d) {
-    boost::multiprecision::float128 data = double (const_cast<boost::multiprecision::cpp_dec_float_100&>(d)); // NOT SURE
-    return os << (double)data;
+    boost::multiprecision::cpp_dec_float_100 data = d; // NOT SURE
+    return os << data.backend().extract_double();
 }
 }
 #endif

--- a/src/logging/src/k2/logging/FormattingUtils.h
+++ b/src/logging/src/k2/logging/FormattingUtils.h
@@ -155,9 +155,14 @@ constexpr auto type_name() {
     }
 
 // Provide formatting for decimals
-#ifdef _GLIBCXX_USE_DECIMAL_FLOAT
 #include <boost/multiprecision/cpp_dec_float.hpp>
+namespace boost::multiprecision {
+    typedef number<cpp_dec_float<25> > cpp_dec_float_25;
+}
 namespace std {
+inline ostream& operator<<(ostream& os, const boost::multiprecision::cpp_dec_float_25& d) {
+    return os << d.str();
+}
 inline ostream& operator<<(ostream& os, const boost::multiprecision::cpp_dec_float_50& d) {
     return os << d.str();
 }
@@ -165,7 +170,6 @@ inline ostream& operator<<(ostream& os, const boost::multiprecision::cpp_dec_flo
     return os << d.str();
 }
 }
-#endif
 
 // provide support for formatting of stl containers of bool type
 template <>  // fmt support

--- a/src/logging/src/k2/logging/FormattingUtils.h
+++ b/src/logging/src/k2/logging/FormattingUtils.h
@@ -156,11 +156,10 @@ constexpr auto type_name() {
 
 // Provide formatting for decimals
 #ifdef _GLIBCXX_USE_DECIMAL_FLOAT
-#include <decimal/decimal>
 #include <boost/multiprecision/cpp_dec_float.hpp>
 namespace std {
 inline ostream& operator<<(ostream& os, const boost::multiprecision::cpp_dec_float_50& d) {
-    return os << d.str(); // NOT SURE
+    return os << d.str();
 }
 inline ostream& operator<<(ostream& os, const boost::multiprecision::cpp_dec_float_100& d) {
     return os << d.str();

--- a/src/logging/src/k2/logging/FormattingUtils.h
+++ b/src/logging/src/k2/logging/FormattingUtils.h
@@ -44,6 +44,7 @@ Copyright(c) 2021 Futurewei Cloud
 
 #include <boost/multiprecision/cpp_dec_float.hpp>
 
+// define cpp_dec_float_25 for use in both k2 and skvhttpclient
 namespace boost::multiprecision {
 typedef number<cpp_dec_float<25> > cpp_dec_float_25;
 }

--- a/src/logging/src/k2/logging/FormattingUtils.h
+++ b/src/logging/src/k2/logging/FormattingUtils.h
@@ -29,6 +29,7 @@ Copyright(c) 2021 Futurewei Cloud
 #include <fmt/printf.h>
 #include <fmt/ranges.h>
 #include <k2/logging/AutoGenFormattingUtils.h>
+#include <k2/logging/BoostDecimals.h>
 
 #include <iostream>
 #include <optional>
@@ -43,11 +44,6 @@ Copyright(c) 2021 Futurewei Cloud
 #include <vector>
 
 #include <boost/multiprecision/cpp_dec_float.hpp>
-
-// define cpp_dec_float_25 for use in both k2 and skvhttpclient
-namespace boost::multiprecision {
-typedef number<cpp_dec_float<25> > cpp_dec_float_25;
-}
 
 namespace k2 {
 // helper function for converting enum class into an integral type
@@ -163,13 +159,13 @@ constexpr auto type_name() {
 
 // Provide formatting for decimals
 namespace std {
-inline ostream& operator<<(ostream& os, const boost::multiprecision::cpp_dec_float_25& d) {
+inline ostream& operator<<(ostream& os, const k2::DecimalD25& d) {
     return os << d.str();
 }
-inline ostream& operator<<(ostream& os, const boost::multiprecision::cpp_dec_float_50& d) {
+inline ostream& operator<<(ostream& os, const k2::DecimalD50& d) {
     return os << d.str();
 }
-inline ostream& operator<<(ostream& os, const boost::multiprecision::cpp_dec_float_100& d) {
+inline ostream& operator<<(ostream& os, const k2::DecimalD100& d) {
     return os << d.str();
 }
 }

--- a/src/logging/src/k2/logging/FormattingUtils.h
+++ b/src/logging/src/k2/logging/FormattingUtils.h
@@ -29,7 +29,7 @@ Copyright(c) 2021 Futurewei Cloud
 #include <fmt/printf.h>
 #include <fmt/ranges.h>
 #include <k2/logging/AutoGenFormattingUtils.h>
-#include <k2/logging/BoostDecimals.h>
+#include <k2/logging/Decimal.h>
 
 #include <iostream>
 #include <optional>

--- a/src/logging/src/k2/logging/FormattingUtils.h
+++ b/src/logging/src/k2/logging/FormattingUtils.h
@@ -158,15 +158,12 @@ constexpr auto type_name() {
 #ifdef _GLIBCXX_USE_DECIMAL_FLOAT
 #include <decimal/decimal>
 #include <boost/multiprecision/cpp_dec_float.hpp>
-#include <boost/multiprecision/float128.hpp>
 namespace std {
 inline ostream& operator<<(ostream& os, const boost::multiprecision::cpp_dec_float_50& d) {
-    boost::multiprecision::cpp_dec_float_50 data = d; // NOT SURE
-    return os << data.backend().extract_double();
+    return os << d.str(); // NOT SURE
 }
 inline ostream& operator<<(ostream& os, const boost::multiprecision::cpp_dec_float_100& d) {
-    boost::multiprecision::cpp_dec_float_100 data = d; // NOT SURE
-    return os << data.backend().extract_double();
+    return os << d.str();
 }
 }
 #endif

--- a/src/logging/src/k2/logging/FormattingUtils.h
+++ b/src/logging/src/k2/logging/FormattingUtils.h
@@ -42,6 +42,12 @@ Copyright(c) 2021 Futurewei Cloud
 #include <unordered_set>
 #include <vector>
 
+#include <boost/multiprecision/cpp_dec_float.hpp>
+// define cpp_dec_float_25 for use in both k2 and skvhttpclient
+namespace boost::multiprecision {
+    typedef number<cpp_dec_float<25> > cpp_dec_float_25;
+}
+
 namespace k2 {
 // helper function for converting enum class into an integral type
 // e.g. usage: auto integralColor = to_integral(MyEnum::Red);
@@ -155,10 +161,6 @@ constexpr auto type_name() {
     }
 
 // Provide formatting for decimals
-#include <boost/multiprecision/cpp_dec_float.hpp>
-namespace boost::multiprecision {
-    typedef number<cpp_dec_float<25> > cpp_dec_float_25;
-}
 namespace std {
 inline ostream& operator<<(ostream& os, const boost::multiprecision::cpp_dec_float_25& d) {
     return os << d.str();

--- a/src/skvhttpclient/src/skvhttp/common/Common.h
+++ b/src/skvhttpclient/src/skvhttp/common/Common.h
@@ -38,9 +38,9 @@ Copyright(c) 2020 Futurewei Cloud
 #include <decimal/decimal>
 namespace skv::http {
 using Decimal64 = std::decimal::decimal64;
-using Decimal128 = std::decimal::decimal128;
+using Decimal100 = std::decimal::decimal128;
 auto constexpr Decimal64_to_float = std::decimal::decimal64_to_float;
-auto constexpr Decimal128_to_float = std::decimal::decimal128_to_float;
+auto constexpr Decimal100_to_float = std::decimal::decimal128_to_float;
 }
 #endif
 

--- a/src/skvhttpclient/src/skvhttp/common/Common.h
+++ b/src/skvhttpclient/src/skvhttp/common/Common.h
@@ -32,10 +32,7 @@ Copyright(c) 2020 Futurewei Cloud
 #include <skvhttp/common/Serialization.h>
 
 #include <boost/thread/future.hpp>
-#include <boost/multiprecision/cpp_dec_float.hpp>
-namespace boost::multiprecision {
-typedef number<cpp_dec_float<25> > cpp_dec_float_25;
-}
+
 namespace skv::http {
 using DecimalD25 = boost::multiprecision::cpp_dec_float_25;
 using DecimalD50 = boost::multiprecision::cpp_dec_float_50;

--- a/src/skvhttpclient/src/skvhttp/common/Common.h
+++ b/src/skvhttpclient/src/skvhttp/common/Common.h
@@ -32,11 +32,6 @@ Copyright(c) 2020 Futurewei Cloud
 #include <skvhttp/common/Serialization.h>
 
 #include <boost/thread/future.hpp>
-namespace skv::http {
-using DecimalD25 = boost::multiprecision::cpp_dec_float_25;
-using DecimalD50 = boost::multiprecision::cpp_dec_float_50;
-using DecimalD100 = boost::multiprecision::cpp_dec_float_100;
-}
 
 namespace skv::http {
 template <typename T>
@@ -57,6 +52,9 @@ using String = std::string;
 using Duration = k2::Duration;
 using TimePoint = k2::TimePoint;
 using Clock = k2::Clock;
+using DecimalD25 = k2::DecimalD25;
+using DecimalD50 = k2::DecimalD50;
+using DecimalD100 = k2::DecimalD100;
 
 class HexCodec {
    private:

--- a/src/skvhttpclient/src/skvhttp/common/Common.h
+++ b/src/skvhttpclient/src/skvhttp/common/Common.h
@@ -36,13 +36,12 @@ Copyright(c) 2020 Futurewei Cloud
 
 #ifdef _GLIBCXX_USE_DECIMAL_FLOAT
 #include <boost/multiprecision/cpp_dec_float.hpp>
-#include <boost/multiprecision/float128.hpp>
 #include <decimal/decimal>
 namespace skv::http {
 using DecimalD50 = boost::multiprecision::cpp_dec_float_50;
 using DecimalD100 = boost::multiprecision::cpp_dec_float_100;
-auto constexpr DecimalD50_to_float = std::decimal::decimal64_to_float; // NOT SURE
-auto constexpr DecimalD100_to_float = std::decimal::decimal128_to_float; // NOT SURE
+// auto constexpr DecimalD50_to_float = std::decimal::decimal64_to_float; // NOT SURE
+// auto constexpr DecimalD100_to_float = std::decimal::decimal128_to_float; // NOT SURE
 }
 #endif
 

--- a/src/skvhttpclient/src/skvhttp/common/Common.h
+++ b/src/skvhttpclient/src/skvhttp/common/Common.h
@@ -32,16 +32,15 @@ Copyright(c) 2020 Futurewei Cloud
 #include <skvhttp/common/Serialization.h>
 
 #include <boost/thread/future.hpp>
-
-
-#ifdef _GLIBCXX_USE_DECIMAL_FLOAT
 #include <boost/multiprecision/cpp_dec_float.hpp>
+namespace boost::multiprecision {
+typedef number<cpp_dec_float<25> > cpp_dec_float_25;
+}
 namespace skv::http {
+using DecimalD25 = boost::multiprecision::cpp_dec_float_25;
 using DecimalD50 = boost::multiprecision::cpp_dec_float_50;
 using DecimalD100 = boost::multiprecision::cpp_dec_float_100;
 }
-#endif
-
 
 namespace skv::http {
 template <typename T>

--- a/src/skvhttpclient/src/skvhttp/common/Common.h
+++ b/src/skvhttpclient/src/skvhttp/common/Common.h
@@ -36,12 +36,13 @@ Copyright(c) 2020 Futurewei Cloud
 
 #ifdef _GLIBCXX_USE_DECIMAL_FLOAT
 #include <boost/multiprecision/cpp_dec_float.hpp>
+#include <boost/multiprecision/float128.hpp>
 #include <decimal/decimal>
 namespace skv::http {
 using DecimalD50 = std::decimal::decimal64;
-using DecimalD100 = std::decimal::decimal128;
+using DecimalD100 = boost::multiprecision::cpp_dec_float_100;
 auto constexpr DecimalD50_to_float = std::decimal::decimal64_to_float;
-auto constexpr DecimalD100_to_float = std::decimal::decimal128_to_float;
+auto constexpr DecimalD100_to_float = std::decimal::decimal128_to_float; // NOT SURE
 }
 #endif
 

--- a/src/skvhttpclient/src/skvhttp/common/Common.h
+++ b/src/skvhttpclient/src/skvhttp/common/Common.h
@@ -32,7 +32,10 @@ Copyright(c) 2020 Futurewei Cloud
 #include <skvhttp/common/Serialization.h>
 
 #include <boost/thread/future.hpp>
-
+#include <boost/multiprecision/cpp_dec_float.hpp>
+namespace boost::multiprecision {
+typedef number<cpp_dec_float<25> > cpp_dec_float_25;
+}
 namespace skv::http {
 using DecimalD25 = boost::multiprecision::cpp_dec_float_25;
 using DecimalD50 = boost::multiprecision::cpp_dec_float_50;

--- a/src/skvhttpclient/src/skvhttp/common/Common.h
+++ b/src/skvhttpclient/src/skvhttp/common/Common.h
@@ -35,11 +35,12 @@ Copyright(c) 2020 Futurewei Cloud
 
 
 #ifdef _GLIBCXX_USE_DECIMAL_FLOAT
+#include <boost/multiprecision/cpp_dec_float.hpp>
 #include <decimal/decimal>
 namespace skv::http {
-using Decimal64 = std::decimal::decimal64;
+using DecimalD50 = std::decimal::decimal64;
 using DecimalD100 = std::decimal::decimal128;
-auto constexpr Decimal64_to_float = std::decimal::decimal64_to_float;
+auto constexpr DecimalD50_to_float = std::decimal::decimal64_to_float;
 auto constexpr DecimalD100_to_float = std::decimal::decimal128_to_float;
 }
 #endif

--- a/src/skvhttpclient/src/skvhttp/common/Common.h
+++ b/src/skvhttpclient/src/skvhttp/common/Common.h
@@ -39,8 +39,6 @@ Copyright(c) 2020 Futurewei Cloud
 namespace skv::http {
 using DecimalD50 = boost::multiprecision::cpp_dec_float_50;
 using DecimalD100 = boost::multiprecision::cpp_dec_float_100;
-// auto constexpr DecimalD50_to_float = std::decimal::decimal64_to_float; // NOT SURE
-// auto constexpr DecimalD100_to_float = std::decimal::decimal128_to_float; // NOT SURE
 }
 #endif
 

--- a/src/skvhttpclient/src/skvhttp/common/Common.h
+++ b/src/skvhttpclient/src/skvhttp/common/Common.h
@@ -32,10 +32,6 @@ Copyright(c) 2020 Futurewei Cloud
 #include <skvhttp/common/Serialization.h>
 
 #include <boost/thread/future.hpp>
-#include <boost/multiprecision/cpp_dec_float.hpp>
-namespace boost::multiprecision {
-typedef number<cpp_dec_float<25> > cpp_dec_float_25;
-}
 namespace skv::http {
 using DecimalD25 = boost::multiprecision::cpp_dec_float_25;
 using DecimalD50 = boost::multiprecision::cpp_dec_float_50;

--- a/src/skvhttpclient/src/skvhttp/common/Common.h
+++ b/src/skvhttpclient/src/skvhttp/common/Common.h
@@ -36,7 +36,6 @@ Copyright(c) 2020 Futurewei Cloud
 
 #ifdef _GLIBCXX_USE_DECIMAL_FLOAT
 #include <boost/multiprecision/cpp_dec_float.hpp>
-#include <decimal/decimal>
 namespace skv::http {
 using DecimalD50 = boost::multiprecision::cpp_dec_float_50;
 using DecimalD100 = boost::multiprecision::cpp_dec_float_100;

--- a/src/skvhttpclient/src/skvhttp/common/Common.h
+++ b/src/skvhttpclient/src/skvhttp/common/Common.h
@@ -38,9 +38,9 @@ Copyright(c) 2020 Futurewei Cloud
 #include <decimal/decimal>
 namespace skv::http {
 using Decimal64 = std::decimal::decimal64;
-using Decimal100 = std::decimal::decimal128;
+using DecimalD100 = std::decimal::decimal128;
 auto constexpr Decimal64_to_float = std::decimal::decimal64_to_float;
-auto constexpr Decimal100_to_float = std::decimal::decimal128_to_float;
+auto constexpr DecimalD100_to_float = std::decimal::decimal128_to_float;
 }
 #endif
 

--- a/src/skvhttpclient/src/skvhttp/common/Common.h
+++ b/src/skvhttpclient/src/skvhttp/common/Common.h
@@ -39,9 +39,9 @@ Copyright(c) 2020 Futurewei Cloud
 #include <boost/multiprecision/float128.hpp>
 #include <decimal/decimal>
 namespace skv::http {
-using DecimalD50 = std::decimal::decimal64;
+using DecimalD50 = boost::multiprecision::cpp_dec_float_50;
 using DecimalD100 = boost::multiprecision::cpp_dec_float_100;
-auto constexpr DecimalD50_to_float = std::decimal::decimal64_to_float;
+auto constexpr DecimalD50_to_float = std::decimal::decimal64_to_float; // NOT SURE
 auto constexpr DecimalD100_to_float = std::decimal::decimal128_to_float; // NOT SURE
 }
 #endif

--- a/src/skvhttpclient/src/skvhttp/dto/FieldTypes.cpp
+++ b/src/skvhttpclient/src/skvhttp/dto/FieldTypes.cpp
@@ -44,7 +44,7 @@ template <> FieldType TToFieldType<int64_t>() { return FieldType::INT64T; }
 template <> FieldType TToFieldType<float>() { return FieldType::FLOAT; }
 template <> FieldType TToFieldType<double>() { return FieldType::DOUBLE; }
 template <> FieldType TToFieldType<bool>() { return FieldType::BOOL; }
-template <> FieldType TToFieldType<Decimal64>() { return FieldType::DECIMAL64; }
+template <> FieldType TToFieldType<DecimalD50>() { return FieldType::DECIMALD50; }
 template <> FieldType TToFieldType<DecimalD100>() { return FieldType::DECIMALD100; }
 template <> FieldType TToFieldType<FieldType>() { return FieldType::FIELD_TYPE; }
 

--- a/src/skvhttpclient/src/skvhttp/dto/FieldTypes.cpp
+++ b/src/skvhttpclient/src/skvhttp/dto/FieldTypes.cpp
@@ -45,7 +45,7 @@ template <> FieldType TToFieldType<float>() { return FieldType::FLOAT; }
 template <> FieldType TToFieldType<double>() { return FieldType::DOUBLE; }
 template <> FieldType TToFieldType<bool>() { return FieldType::BOOL; }
 template <> FieldType TToFieldType<Decimal64>() { return FieldType::DECIMAL64; }
-template <> FieldType TToFieldType<Decimal100>() { return FieldType::DECIMAL100; }
+template <> FieldType TToFieldType<DecimalD100>() { return FieldType::DECIMALD100; }
 template <> FieldType TToFieldType<FieldType>() { return FieldType::FIELD_TYPE; }
 
 // All conversion assume ascending ordering

--- a/src/skvhttpclient/src/skvhttp/dto/FieldTypes.cpp
+++ b/src/skvhttpclient/src/skvhttp/dto/FieldTypes.cpp
@@ -44,6 +44,7 @@ template <> FieldType TToFieldType<int64_t>() { return FieldType::INT64T; }
 template <> FieldType TToFieldType<float>() { return FieldType::FLOAT; }
 template <> FieldType TToFieldType<double>() { return FieldType::DOUBLE; }
 template <> FieldType TToFieldType<bool>() { return FieldType::BOOL; }
+template <> FieldType TToFieldType<DecimalD25>() { return FieldType::DECIMALD25; }
 template <> FieldType TToFieldType<DecimalD50>() { return FieldType::DECIMALD50; }
 template <> FieldType TToFieldType<DecimalD100>() { return FieldType::DECIMALD100; }
 template <> FieldType TToFieldType<FieldType>() { return FieldType::FIELD_TYPE; }

--- a/src/skvhttpclient/src/skvhttp/dto/FieldTypes.cpp
+++ b/src/skvhttpclient/src/skvhttp/dto/FieldTypes.cpp
@@ -45,7 +45,7 @@ template <> FieldType TToFieldType<float>() { return FieldType::FLOAT; }
 template <> FieldType TToFieldType<double>() { return FieldType::DOUBLE; }
 template <> FieldType TToFieldType<bool>() { return FieldType::BOOL; }
 template <> FieldType TToFieldType<Decimal64>() { return FieldType::DECIMAL64; }
-template <> FieldType TToFieldType<Decimal128>() { return FieldType::DECIMAL128; }
+template <> FieldType TToFieldType<Decimal100>() { return FieldType::DECIMAL100; }
 template <> FieldType TToFieldType<FieldType>() { return FieldType::FIELD_TYPE; }
 
 // All conversion assume ascending ordering

--- a/src/skvhttpclient/src/skvhttp/dto/FieldTypes.h
+++ b/src/skvhttpclient/src/skvhttp/dto/FieldTypes.h
@@ -65,6 +65,7 @@ enum class FieldType : uint8_t {
     FLOAT, // Not supported as key field for now
     DOUBLE,  // Not supported as key field for now
     BOOL,
+    DECIMALD25, // Provides 25 decimal digits of precision
     DECIMALD50, // Provides 50 decimal digits of precision
     DECIMALD100, // Provides 100 decimal digits of precision
     FIELD_TYPE, // The value refers to one of these types. Used in query filters.
@@ -100,6 +101,12 @@ template <typename T>
 bool isNan(const T& field){
     if constexpr (std::is_same_v<T, float> || std::is_same_v<T, double> )  { // handle NaN float and double
         if (std::isnan(field)) {
+            return true;
+        }
+    }
+
+    if constexpr (std::is_same_v<T, DecimalD25>)  { // handle NaN decimal
+        if (field.backend().isnan()) {
             return true;
         }
     }
@@ -153,6 +160,9 @@ auto applyTyped(const FieldT& field, Func&& applier, Args&&... args) {
         case FieldType::BOOL: {
             return applier(AppliedFieldRef<bool, FieldT>(field), std::forward<Args>(args)...);
         }
+        case FieldType::DECIMALD25: {
+            return applier(AppliedFieldRef<DecimalD25, FieldT>(field), std::forward<Args>(args)...);
+        }
         case FieldType::DECIMALD50: {
             return applier(AppliedFieldRef<DecimalD50, FieldT>(field), std::forward<Args>(args)...);
         }
@@ -189,6 +199,8 @@ namespace std {
             return os << "DOUBLE";
         case skv::http::dto::FieldType::BOOL:
             return os << "BOOL";
+        case skv::http::dto::FieldType::DECIMALD25:
+            return os << "DECIMALD25";
         case skv::http::dto::FieldType::DECIMALD50:
             return os << "DECIMALD50";
         case skv::http::dto::FieldType::DECIMALD100:

--- a/src/skvhttpclient/src/skvhttp/dto/FieldTypes.h
+++ b/src/skvhttpclient/src/skvhttp/dto/FieldTypes.h
@@ -105,13 +105,13 @@ bool isNan(const T& field){
     }
 
     if constexpr (std::is_same_v<T, DecimalD50>)  { // handle NaN decimal
-        if (field.backend().isnan()) { // NOT SURE
+        if (field.backend().isnan()) {
             return true;
         }
     }
 
     if constexpr (std::is_same_v<T, DecimalD100> )  { // handle NaN decimal
-        if (field.backend().isnan()) { // NOT SURE
+        if (field.backend().isnan()) {
             return true;
         }
     }

--- a/src/skvhttpclient/src/skvhttp/dto/FieldTypes.h
+++ b/src/skvhttpclient/src/skvhttp/dto/FieldTypes.h
@@ -65,7 +65,7 @@ enum class FieldType : uint8_t {
     FLOAT, // Not supported as key field for now
     DOUBLE,  // Not supported as key field for now
     BOOL,
-    DECIMAL64, // Provides 16 decimal digits of precision
+    DECIMALD50, // Provides 16 decimal digits of precision
     DECIMALD100, // Provides 34 decimal digits of precision
     FIELD_TYPE, // The value refers to one of these types. Used in query filters.
     NOT_KNOWN = 254,
@@ -104,8 +104,8 @@ bool isNan(const T& field){
         }
     }
 
-    if constexpr (std::is_same_v<T, Decimal64>)  { // handle NaN decimal
-        if (std::isnan(Decimal64_to_float(field))) {
+    if constexpr (std::is_same_v<T, DecimalD50>)  { // handle NaN decimal
+        if (std::isnan(DecimalD50_to_float(field))) {
             return true;
         }
     }
@@ -153,8 +153,8 @@ auto applyTyped(const FieldT& field, Func&& applier, Args&&... args) {
         case FieldType::BOOL: {
             return applier(AppliedFieldRef<bool, FieldT>(field), std::forward<Args>(args)...);
         }
-        case FieldType::DECIMAL64: {
-            return applier(AppliedFieldRef<Decimal64, FieldT>(field), std::forward<Args>(args)...);
+        case FieldType::DECIMALD50: {
+            return applier(AppliedFieldRef<DecimalD50, FieldT>(field), std::forward<Args>(args)...);
         }
         case FieldType::DECIMALD100: {
             return applier(AppliedFieldRef<DecimalD100, FieldT>(field), std::forward<Args>(args)...);
@@ -189,8 +189,8 @@ namespace std {
             return os << "DOUBLE";
         case skv::http::dto::FieldType::BOOL:
             return os << "BOOL";
-        case skv::http::dto::FieldType::DECIMAL64:
-            return os << "DECIMAL64";
+        case skv::http::dto::FieldType::DECIMALD50:
+            return os << "DECIMALD50";
         case skv::http::dto::FieldType::DECIMALD100:
             return os << "DECIMALD100";
         case skv::http::dto::FieldType::FIELD_TYPE:

--- a/src/skvhttpclient/src/skvhttp/dto/FieldTypes.h
+++ b/src/skvhttpclient/src/skvhttp/dto/FieldTypes.h
@@ -66,7 +66,7 @@ enum class FieldType : uint8_t {
     DOUBLE,  // Not supported as key field for now
     BOOL,
     DECIMAL64, // Provides 16 decimal digits of precision
-    DECIMAL100, // Provides 34 decimal digits of precision
+    DECIMALD100, // Provides 34 decimal digits of precision
     FIELD_TYPE, // The value refers to one of these types. Used in query filters.
     NOT_KNOWN = 254,
     NULL_LAST = 255
@@ -110,8 +110,8 @@ bool isNan(const T& field){
         }
     }
 
-    if constexpr (std::is_same_v<T, Decimal100> )  { // handle NaN decimal
-        if (std::isnan(Decimal100_to_float(field))) {
+    if constexpr (std::is_same_v<T, DecimalD100> )  { // handle NaN decimal
+        if (std::isnan(DecimalD100_to_float(field))) {
             return true;
         }
     }
@@ -156,8 +156,8 @@ auto applyTyped(const FieldT& field, Func&& applier, Args&&... args) {
         case FieldType::DECIMAL64: {
             return applier(AppliedFieldRef<Decimal64, FieldT>(field), std::forward<Args>(args)...);
         }
-        case FieldType::DECIMAL100: {
-            return applier(AppliedFieldRef<Decimal100, FieldT>(field), std::forward<Args>(args)...);
+        case FieldType::DECIMALD100: {
+            return applier(AppliedFieldRef<DecimalD100, FieldT>(field), std::forward<Args>(args)...);
         }
         case FieldType::FIELD_TYPE: {
             return applier(AppliedFieldRef<FieldType, FieldT>(field), std::forward<Args>(args)...);
@@ -191,8 +191,8 @@ namespace std {
             return os << "BOOL";
         case skv::http::dto::FieldType::DECIMAL64:
             return os << "DECIMAL64";
-        case skv::http::dto::FieldType::DECIMAL100:
-            return os << "DECIMAL100";
+        case skv::http::dto::FieldType::DECIMALD100:
+            return os << "DECIMALD100";
         case skv::http::dto::FieldType::FIELD_TYPE:
             return os << "FIELD_TYPE";
         case skv::http::dto::FieldType::NOT_KNOWN:

--- a/src/skvhttpclient/src/skvhttp/dto/FieldTypes.h
+++ b/src/skvhttpclient/src/skvhttp/dto/FieldTypes.h
@@ -105,13 +105,13 @@ bool isNan(const T& field){
     }
 
     if constexpr (std::is_same_v<T, DecimalD50>)  { // handle NaN decimal
-        if (std::isnan(field.backend().extract_double())) { // NOT SURE
+        if (field.backend().isnan()) { // NOT SURE
             return true;
         }
     }
 
     if constexpr (std::is_same_v<T, DecimalD100> )  { // handle NaN decimal
-        if (std::isnan(field.backend().extract_double())) { // NOT SURE
+        if (field.backend().isnan()) { // NOT SURE
             return true;
         }
     }

--- a/src/skvhttpclient/src/skvhttp/dto/FieldTypes.h
+++ b/src/skvhttpclient/src/skvhttp/dto/FieldTypes.h
@@ -66,7 +66,7 @@ enum class FieldType : uint8_t {
     DOUBLE,  // Not supported as key field for now
     BOOL,
     DECIMAL64, // Provides 16 decimal digits of precision
-    DECIMAL128, // Provides 34 decimal digits of precision
+    DECIMAL100, // Provides 34 decimal digits of precision
     FIELD_TYPE, // The value refers to one of these types. Used in query filters.
     NOT_KNOWN = 254,
     NULL_LAST = 255
@@ -110,8 +110,8 @@ bool isNan(const T& field){
         }
     }
 
-    if constexpr (std::is_same_v<T, Decimal128> )  { // handle NaN decimal
-        if (std::isnan(Decimal128_to_float(field))) {
+    if constexpr (std::is_same_v<T, Decimal100> )  { // handle NaN decimal
+        if (std::isnan(Decimal100_to_float(field))) {
             return true;
         }
     }
@@ -156,8 +156,8 @@ auto applyTyped(const FieldT& field, Func&& applier, Args&&... args) {
         case FieldType::DECIMAL64: {
             return applier(AppliedFieldRef<Decimal64, FieldT>(field), std::forward<Args>(args)...);
         }
-        case FieldType::DECIMAL128: {
-            return applier(AppliedFieldRef<Decimal128, FieldT>(field), std::forward<Args>(args)...);
+        case FieldType::DECIMAL100: {
+            return applier(AppliedFieldRef<Decimal100, FieldT>(field), std::forward<Args>(args)...);
         }
         case FieldType::FIELD_TYPE: {
             return applier(AppliedFieldRef<FieldType, FieldT>(field), std::forward<Args>(args)...);
@@ -191,8 +191,8 @@ namespace std {
             return os << "BOOL";
         case skv::http::dto::FieldType::DECIMAL64:
             return os << "DECIMAL64";
-        case skv::http::dto::FieldType::DECIMAL128:
-            return os << "DECIMAL128";
+        case skv::http::dto::FieldType::DECIMAL100:
+            return os << "DECIMAL100";
         case skv::http::dto::FieldType::FIELD_TYPE:
             return os << "FIELD_TYPE";
         case skv::http::dto::FieldType::NOT_KNOWN:

--- a/src/skvhttpclient/src/skvhttp/dto/FieldTypes.h
+++ b/src/skvhttpclient/src/skvhttp/dto/FieldTypes.h
@@ -111,7 +111,7 @@ bool isNan(const T& field){
     }
 
     if constexpr (std::is_same_v<T, DecimalD100> )  { // handle NaN decimal
-        if (std::isnan(DecimalD100_to_float(field))) {
+        if (std::isnan(double(field))) { // NOT SURE
             return true;
         }
     }

--- a/src/skvhttpclient/src/skvhttp/dto/FieldTypes.h
+++ b/src/skvhttpclient/src/skvhttp/dto/FieldTypes.h
@@ -65,8 +65,8 @@ enum class FieldType : uint8_t {
     FLOAT, // Not supported as key field for now
     DOUBLE,  // Not supported as key field for now
     BOOL,
-    DECIMALD50, // Provides 16 decimal digits of precision
-    DECIMALD100, // Provides 34 decimal digits of precision
+    DECIMALD50, // Provides 50 decimal digits of precision
+    DECIMALD100, // Provides 100 decimal digits of precision
     FIELD_TYPE, // The value refers to one of these types. Used in query filters.
     NOT_KNOWN = 254,
     NULL_LAST = 255
@@ -105,13 +105,13 @@ bool isNan(const T& field){
     }
 
     if constexpr (std::is_same_v<T, DecimalD50>)  { // handle NaN decimal
-        if (std::isnan(DecimalD50_to_float(field))) {
+        if (std::isnan(field.backend().extract_double())) { // NOT SURE
             return true;
         }
     }
 
     if constexpr (std::is_same_v<T, DecimalD100> )  { // handle NaN decimal
-        if (std::isnan(double(field))) { // NOT SURE
+        if (std::isnan(field.backend().extract_double())) { // NOT SURE
             return true;
         }
     }

--- a/src/skvhttpclient/src/skvhttp/mpack/MPackSerialization.h
+++ b/src/skvhttpclient/src/skvhttp/mpack/MPackSerialization.h
@@ -296,8 +296,7 @@ private:
         if (!_readFromNode(binData)) {
             return false;
         }
-        DecimalD50 val = DecimalD50(binData.data());
-        value = val;
+        value = DecimalD50(binData.data());
         return true;
     }
 
@@ -309,8 +308,7 @@ private:
         if (!_readFromNode(binData)) {
             return false;
         }
-        DecimalD100 val = DecimalD100(binData.data());
-        value = val;
+        value = DecimalD100(binData.data());
         return true;
     }
 
@@ -481,13 +479,13 @@ public:
     }
     void write(const DecimalD50& value) {
         K2LOG_V(log::mpack, "writing decimald50 type {}", value);
-        auto shp = std::make_shared<String>(value.str());
-        write(Binary(shp->data(), shp->size() + 1, [shp]() mutable {}));
+        String str = value.str();
+        write(Binary(str.data(), str.size() + 1, []{}));
     }
     void write(const DecimalD100& value) {
         K2LOG_V(log::mpack, "writing decimald100 type {}", value);
-        auto shp = std::make_shared<String>(value.str());
-        write(Binary(shp->data(), shp->size() + 1, [shp]() mutable {}));
+        String str = value.str();
+        write(Binary(str.data(), str.size() + 1, []{}));
     }
     void write(const String& val) {
         K2LOG_V(log::mpack, "writing string type {}", val);

--- a/src/skvhttpclient/src/skvhttp/mpack/MPackSerialization.h
+++ b/src/skvhttpclient/src/skvhttp/mpack/MPackSerialization.h
@@ -288,6 +288,23 @@ private:
         return true;
     }
 
+    bool _readFromNode(DecimalD25& value) {
+        // DecimalD25 is memcpy-ed
+        K2LOG_V(log::mpack, "reading decimald25");
+        size_t sz;
+        const char* data;
+
+        if (!_readData(data, sz)) {
+            return false;
+        }
+        if (sizeof(DecimalD25) != sz) {
+            return false;
+        }
+
+        std::memcpy((void *)&value, data, sizeof(DecimalD25));
+        return true;
+    }
+
     bool _readFromNode(DecimalD50& value) {
         // DecimalD50 is memcpy-ed
         K2LOG_V(log::mpack, "reading decimald50");
@@ -486,6 +503,11 @@ public:
     void write(const Duration& dur) {
         K2LOG_V(log::mpack, "writing duration type {}", dur);
         write(dur.count());  // write the tick count
+    }
+    void write(const DecimalD25& value) {
+        K2LOG_V(log::mpack, "writing decimald25 type {}", value);
+        static_assert(sizeof(DecimalD25) == 44, "check updated implementation for cpp_dec_float_25");
+        mpack_write_bin(&_writer, (const char*)&value, (uint32_t)sizeof(DecimalD25));
     }
     void write(const DecimalD50& value) {
         K2LOG_V(log::mpack, "writing decimald50 type {}", value);

--- a/src/skvhttpclient/src/skvhttp/mpack/MPackSerialization.h
+++ b/src/skvhttpclient/src/skvhttp/mpack/MPackSerialization.h
@@ -305,20 +305,20 @@ private:
         return true;
     }
 
-    bool _readFromNode(Decimal100& value) {
+    bool _readFromNode(DecimalD100& value) {
         // decimal is packed as a BINARY msgpack type
-        K2LOG_V(log::mpack, "reading decimal100");
+        K2LOG_V(log::mpack, "reading decimald100");
         size_t sz;
         const char* data;
 
         if (!_readData(data, sz)) {
             return false;
         }
-        if (sizeof(Decimal100::__decfloat128) != sz) {
+        if (sizeof(DecimalD100::__decfloat128) != sz) {
             return false;
         }
 
-        value.__setval(*((Decimal100::__decfloat128*)data));
+        value.__setval(*((DecimalD100::__decfloat128*)data));
         return true;
     }
 
@@ -492,10 +492,10 @@ public:
         Decimal64::__decfloat64 data = const_cast<Decimal64&>(value).__getval();
         mpack_write_bin(&_writer, (const char*)&data, sizeof(Decimal64::__decfloat64));
     }
-    void write(const Decimal100& value) {
-        K2LOG_V(log::mpack, "writing decimal100 type {}", value);
-        Decimal100::__decfloat128 data = const_cast<Decimal100&>(value).__getval();
-        mpack_write_bin(&_writer, (const char*)&data, sizeof(Decimal100::__decfloat128));
+    void write(const DecimalD100& value) {
+        K2LOG_V(log::mpack, "writing decimald100 type {}", value);
+        DecimalD100::__decfloat128 data = const_cast<DecimalD100&>(value).__getval();
+        mpack_write_bin(&_writer, (const char*)&data, sizeof(DecimalD100::__decfloat128));
     }
     void write(const String& val) {
         K2LOG_V(log::mpack, "writing string type {}", val);

--- a/src/skvhttpclient/src/skvhttp/mpack/MPackSerialization.h
+++ b/src/skvhttpclient/src/skvhttp/mpack/MPackSerialization.h
@@ -314,11 +314,11 @@ private:
         if (!_readData(data, sz)) {
             return false;
         }
-        if (sizeof(DecimalD100::__decfloat128) != sz) {
+        if (sizeof(boost::multiprecision::float128) != sz) {
             return false;
         }
 
-        value.__setval(*((DecimalD100::__decfloat128*)data));
+        value = double(*((boost::multiprecision::float128*)data)); // NOT SURE
         return true;
     }
 
@@ -494,8 +494,8 @@ public:
     }
     void write(const DecimalD100& value) {
         K2LOG_V(log::mpack, "writing decimald100 type {}", value);
-        DecimalD100::__decfloat128 data = const_cast<DecimalD100&>(value).__getval();
-        mpack_write_bin(&_writer, (const char*)&data, sizeof(DecimalD100::__decfloat128));
+        boost::multiprecision::float128 data = double(const_cast<DecimalD100&>(value)); // NOT SURE
+        mpack_write_bin(&_writer, (const char*)&data, sizeof(boost::multiprecision::float128));
     }
     void write(const String& val) {
         K2LOG_V(log::mpack, "writing string type {}", val);

--- a/src/skvhttpclient/src/skvhttp/mpack/MPackSerialization.h
+++ b/src/skvhttpclient/src/skvhttp/mpack/MPackSerialization.h
@@ -297,11 +297,11 @@ private:
         if (!_readData(data, sz)) {
             return false;
         }
-        if (sizeof(DecimalD50::__decfloat64) != sz) {
+        if (sizeof(DecimalD50) != sz) {
             return false;
         }
 
-        value.__setval(*((DecimalD50::__decfloat64*)data));
+        value = *((DecimalD50*)data);
         return true;
     }
 
@@ -314,11 +314,11 @@ private:
         if (!_readData(data, sz)) {
             return false;
         }
-        if (sizeof(boost::multiprecision::float128) != sz) {
+        if (sizeof(DecimalD100) != sz) {
             return false;
         }
 
-        value = double(*((boost::multiprecision::float128*)data)); // NOT SURE
+        value = *((DecimalD100*)data); // NOT SURE
         return true;
     }
 
@@ -489,13 +489,13 @@ public:
     }
     void write(const DecimalD50& value) {
         K2LOG_V(log::mpack, "writing decimald50 type {}", value);
-        DecimalD50::__decfloat64 data = const_cast<DecimalD50&>(value).__getval();
-        mpack_write_bin(&_writer, (const char*)&data, sizeof(DecimalD50::__decfloat64));
+        DecimalD50 data = value; // NOT SURE
+        mpack_write_bin(&_writer, (const char*)&data, sizeof(DecimalD50));
     }
     void write(const DecimalD100& value) {
         K2LOG_V(log::mpack, "writing decimald100 type {}", value);
-        boost::multiprecision::float128 data = double(const_cast<DecimalD100&>(value)); // NOT SURE
-        mpack_write_bin(&_writer, (const char*)&data, sizeof(boost::multiprecision::float128));
+        DecimalD100 data = value; // NOT SURE
+        mpack_write_bin(&_writer, (const char*)&data, sizeof(DecimalD100));
     }
     void write(const String& val) {
         K2LOG_V(log::mpack, "writing string type {}", val);

--- a/src/skvhttpclient/src/skvhttp/mpack/MPackSerialization.h
+++ b/src/skvhttpclient/src/skvhttp/mpack/MPackSerialization.h
@@ -278,7 +278,7 @@ private:
     }
 
     bool _readFromNode(Duration& dur) {
-        K2LOG_V(log::mpack, "reading decimal64");
+        K2LOG_V(log::mpack, "reading decimald50");
         if (typeid(std::remove_reference_t<decltype(dur)>::rep) != typeid(long int)) {
             return false;
         }
@@ -288,20 +288,20 @@ private:
         return true;
     }
 
-    bool _readFromNode(Decimal64& value) {
+    bool _readFromNode(DecimalD50& value) {
         // decimal is packed as a BINARY msgpack type
-        K2LOG_V(log::mpack, "reading decimal64");
+        K2LOG_V(log::mpack, "reading decimald50");
         size_t sz;
         const char* data;
 
         if (!_readData(data, sz)) {
             return false;
         }
-        if (sizeof(Decimal64::__decfloat64) != sz) {
+        if (sizeof(DecimalD50::__decfloat64) != sz) {
             return false;
         }
 
-        value.__setval(*((Decimal64::__decfloat64*)data));
+        value.__setval(*((DecimalD50::__decfloat64*)data));
         return true;
     }
 
@@ -487,10 +487,10 @@ public:
         K2LOG_V(log::mpack, "writing duration type {}", dur);
         write(dur.count());  // write the tick count
     }
-    void write(const Decimal64& value) {
-        K2LOG_V(log::mpack, "writing decimal64 type {}", value);
-        Decimal64::__decfloat64 data = const_cast<Decimal64&>(value).__getval();
-        mpack_write_bin(&_writer, (const char*)&data, sizeof(Decimal64::__decfloat64));
+    void write(const DecimalD50& value) {
+        K2LOG_V(log::mpack, "writing decimald50 type {}", value);
+        DecimalD50::__decfloat64 data = const_cast<DecimalD50&>(value).__getval();
+        mpack_write_bin(&_writer, (const char*)&data, sizeof(DecimalD50::__decfloat64));
     }
     void write(const DecimalD100& value) {
         K2LOG_V(log::mpack, "writing decimald100 type {}", value);

--- a/src/skvhttpclient/src/skvhttp/mpack/MPackSerialization.h
+++ b/src/skvhttpclient/src/skvhttp/mpack/MPackSerialization.h
@@ -489,10 +489,12 @@ public:
     }
     void write(const DecimalD50& value) {
         K2LOG_V(log::mpack, "writing decimald50 type {}", value);
+        static_assert(sizeof(DecimalD50) == 56, "check updated implementation for cpp_dec_float_50");
         mpack_write_bin(&_writer, (const char*)&value, (uint32_t)sizeof(DecimalD50));
     }
     void write(const DecimalD100& value) {
         K2LOG_V(log::mpack, "writing decimald100 type {}", value);
+        static_assert(sizeof(DecimalD100) == 80, "check updated implementation for cpp_dec_float_100");
         mpack_write_bin(&_writer, (const char*)&value, (uint32_t)sizeof(DecimalD100));
     }
     void write(const String& val) {

--- a/src/skvhttpclient/src/skvhttp/mpack/MPackSerialization.h
+++ b/src/skvhttpclient/src/skvhttp/mpack/MPackSerialization.h
@@ -278,7 +278,7 @@ private:
     }
 
     bool _readFromNode(Duration& dur) {
-        K2LOG_V(log::mpack, "reading decimald50");
+        K2LOG_V(log::mpack, "reading duration");
         if (typeid(std::remove_reference_t<decltype(dur)>::rep) != typeid(long int)) {
             return false;
         }
@@ -289,27 +289,31 @@ private:
     }
 
     bool _readFromNode(DecimalD50& value) {
-        // DecimalD50 is serialized as a k2 String
+        // DecimalD50 is serialized as a string and then packed as a Binary
         K2LOG_V(log::mpack, "reading decimald50");
-        String ss;
-        if (_readFromNode(ss)) {
-            DecimalD50 _val = DecimalD50(ss.c_str());
-            value = _val; // NOT SURE
-            return true;
+        Binary binData;
+
+        if (!_readFromNode(binData)) {
+            return false;
         }
-        return false;
+        String str(binData.data(), binData.size());
+        DecimalD50 _val = DecimalD50(str.c_str());
+        value = _val;
+        return true;
     }
 
     bool _readFromNode(DecimalD100& value) {
-        // DecimalD100 is serialized as a k2 String
+        // DecimalD100 is serialized as a string and then packed as a Binary
         K2LOG_V(log::mpack, "reading decimald100");
-        String ss;
-        if (_readFromNode(ss)) {
-            DecimalD100 _val = DecimalD100(ss.c_str());
-            value = _val; // NOT SURE
-            return true;
+        Binary binData;
+
+        if (!_readFromNode(binData)) {
+            return false;
         }
-        return false;
+        String str(binData.data(), binData.size());
+        DecimalD100 _val = DecimalD100(str.c_str());
+        value = _val;
+        return true;
     }
 
     template <typename T>
@@ -479,13 +483,13 @@ public:
     }
     void write(const DecimalD50& value) {
         K2LOG_V(log::mpack, "writing decimald50 type {}", value);
-        String ss(value.str());
-        write(ss); // NOT SURE
+        Binary binData(value.str());
+        write(binData);
     }
     void write(const DecimalD100& value) {
         K2LOG_V(log::mpack, "writing decimald100 type {}", value);
-        String ss(value.str());
-        write(ss); // NOT SURE
+        Binary binData(value.str());
+        write(binData);
     }
     void write(const String& val) {
         K2LOG_V(log::mpack, "writing string type {}", val);

--- a/src/skvhttpclient/src/skvhttp/mpack/MPackSerialization.h
+++ b/src/skvhttpclient/src/skvhttp/mpack/MPackSerialization.h
@@ -305,20 +305,20 @@ private:
         return true;
     }
 
-    bool _readFromNode(Decimal128& value) {
+    bool _readFromNode(Decimal100& value) {
         // decimal is packed as a BINARY msgpack type
-        K2LOG_V(log::mpack, "reading decimal128");
+        K2LOG_V(log::mpack, "reading decimal100");
         size_t sz;
         const char* data;
 
         if (!_readData(data, sz)) {
             return false;
         }
-        if (sizeof(Decimal128::__decfloat128) != sz) {
+        if (sizeof(Decimal100::__decfloat128) != sz) {
             return false;
         }
 
-        value.__setval(*((Decimal128::__decfloat128*)data));
+        value.__setval(*((Decimal100::__decfloat128*)data));
         return true;
     }
 
@@ -492,10 +492,10 @@ public:
         Decimal64::__decfloat64 data = const_cast<Decimal64&>(value).__getval();
         mpack_write_bin(&_writer, (const char*)&data, sizeof(Decimal64::__decfloat64));
     }
-    void write(const Decimal128& value) {
-        K2LOG_V(log::mpack, "writing decimal128 type {}", value);
-        Decimal128::__decfloat128 data = const_cast<Decimal128&>(value).__getval();
-        mpack_write_bin(&_writer, (const char*)&data, sizeof(Decimal128::__decfloat128));
+    void write(const Decimal100& value) {
+        K2LOG_V(log::mpack, "writing decimal100 type {}", value);
+        Decimal100::__decfloat128 data = const_cast<Decimal100&>(value).__getval();
+        mpack_write_bin(&_writer, (const char*)&data, sizeof(Decimal100::__decfloat128));
     }
     void write(const String& val) {
         K2LOG_V(log::mpack, "writing string type {}", val);

--- a/src/skvhttpclient/src/skvhttp/mpack/MPackSerialization.h
+++ b/src/skvhttpclient/src/skvhttp/mpack/MPackSerialization.h
@@ -289,37 +289,27 @@ private:
     }
 
     bool _readFromNode(DecimalD50& value) {
-        // decimal is packed as a BINARY msgpack type
+        // DecimalD50 is serialized as a k2 String
         K2LOG_V(log::mpack, "reading decimald50");
-        size_t sz;
-        const char* data;
-
-        if (!_readData(data, sz)) {
-            return false;
+        String ss;
+        if (_readFromNode(ss)) {
+            DecimalD50 _val = DecimalD50(ss.c_str());
+            value = _val; // NOT SURE
+            return true;
         }
-        if (sizeof(DecimalD50) != sz) {
-            return false;
-        }
-
-        value = *((DecimalD50*)data);
-        return true;
+        return false;
     }
 
     bool _readFromNode(DecimalD100& value) {
-        // decimal is packed as a BINARY msgpack type
+        // DecimalD100 is serialized as a k2 String
         K2LOG_V(log::mpack, "reading decimald100");
-        size_t sz;
-        const char* data;
-
-        if (!_readData(data, sz)) {
-            return false;
+        String ss;
+        if (_readFromNode(ss)) {
+            DecimalD100 _val = DecimalD100(ss.c_str());
+            value = _val; // NOT SURE
+            return true;
         }
-        if (sizeof(DecimalD100) != sz) {
-            return false;
-        }
-
-        value = *((DecimalD100*)data); // NOT SURE
-        return true;
+        return false;
     }
 
     template <typename T>
@@ -489,13 +479,13 @@ public:
     }
     void write(const DecimalD50& value) {
         K2LOG_V(log::mpack, "writing decimald50 type {}", value);
-        DecimalD50 data = value; // NOT SURE
-        mpack_write_bin(&_writer, (const char*)&data, sizeof(DecimalD50));
+        String ss(value.str());
+        write(ss); // NOT SURE
     }
     void write(const DecimalD100& value) {
         K2LOG_V(log::mpack, "writing decimald100 type {}", value);
-        DecimalD100 data = value; // NOT SURE
-        mpack_write_bin(&_writer, (const char*)&data, sizeof(DecimalD100));
+        String ss(value.str());
+        write(ss); // NOT SURE
     }
     void write(const String& val) {
         K2LOG_V(log::mpack, "writing string type {}", val);

--- a/src/skvhttpclient/src/skvhttp/mpack/MPackSerialization.h
+++ b/src/skvhttpclient/src/skvhttp/mpack/MPackSerialization.h
@@ -289,26 +289,36 @@ private:
     }
 
     bool _readFromNode(DecimalD50& value) {
-        // DecimalD50 is serialized as a string and then packed as a Binary
+        // DecimalD50 is memcpy-ed
         K2LOG_V(log::mpack, "reading decimald50");
-        Binary binData;
+        size_t sz;
+        const char* data;
 
-        if (!_readFromNode(binData)) {
+        if (!_readData(data, sz)) {
             return false;
         }
-        value = DecimalD50(binData.data());
+        if (sizeof(DecimalD50) != sz) {
+            return false;
+        }
+
+        std::memcpy((void *)&value, data, sizeof(DecimalD50));
         return true;
     }
 
     bool _readFromNode(DecimalD100& value) {
-        // DecimalD100 is serialized as a string and then packed as a Binary
+        // DecimalD100 is memcpy-ed
         K2LOG_V(log::mpack, "reading decimald100");
-        Binary binData;
+        size_t sz;
+        const char* data;
 
-        if (!_readFromNode(binData)) {
+        if (!_readData(data, sz)) {
             return false;
         }
-        value = DecimalD100(binData.data());
+        if (sizeof(DecimalD100) != sz) {
+            return false;
+        }
+
+        std::memcpy((void *)&value, data, sizeof(DecimalD100));
         return true;
     }
 
@@ -479,13 +489,11 @@ public:
     }
     void write(const DecimalD50& value) {
         K2LOG_V(log::mpack, "writing decimald50 type {}", value);
-        String str = value.str();
-        write(Binary(str.data(), str.size() + 1, []{}));
+        mpack_write_bin(&_writer, (const char*)&value, (uint32_t)sizeof(DecimalD50));
     }
     void write(const DecimalD100& value) {
         K2LOG_V(log::mpack, "writing decimald100 type {}", value);
-        String str = value.str();
-        write(Binary(str.data(), str.size() + 1, []{}));
+        mpack_write_bin(&_writer, (const char*)&value, (uint32_t)sizeof(DecimalD100));
     }
     void write(const String& val) {
         K2LOG_V(log::mpack, "writing string type {}", val);

--- a/src/skvhttpclient/src/skvhttp/mpack/MPackSerialization.h
+++ b/src/skvhttpclient/src/skvhttp/mpack/MPackSerialization.h
@@ -296,9 +296,8 @@ private:
         if (!_readFromNode(binData)) {
             return false;
         }
-        String str(binData.data(), binData.size());
-        DecimalD50 _val = DecimalD50(str.c_str());
-        value = _val;
+        DecimalD50 val = DecimalD50(binData.data());
+        value = val;
         return true;
     }
 
@@ -310,9 +309,8 @@ private:
         if (!_readFromNode(binData)) {
             return false;
         }
-        String str(binData.data(), binData.size());
-        DecimalD100 _val = DecimalD100(str.c_str());
-        value = _val;
+        DecimalD100 val = DecimalD100(binData.data());
+        value = val;
         return true;
     }
 
@@ -483,13 +481,13 @@ public:
     }
     void write(const DecimalD50& value) {
         K2LOG_V(log::mpack, "writing decimald50 type {}", value);
-        Binary binData(value.str());
-        write(binData);
+        auto shp = std::make_shared<String>(value.str());
+        write(Binary(shp->data(), shp->size() + 1, [shp]() mutable {}));
     }
     void write(const DecimalD100& value) {
         K2LOG_V(log::mpack, "writing decimald100 type {}", value);
-        Binary binData(value.str());
-        write(binData);
+        auto shp = std::make_shared<String>(value.str());
+        write(Binary(shp->data(), shp->size() + 1, [shp]() mutable {}));
     }
     void write(const String& val) {
         K2LOG_V(log::mpack, "writing string type {}", val);

--- a/src/skvhttpclient/test/ExpressionTest.cpp
+++ b/src/skvhttpclient/test/ExpressionTest.cpp
@@ -216,8 +216,8 @@ TEST_CASE("Float expressions"){
         .expectedResult = {false},
         .expectedException = {}});
 
-    DecimalD50 v1(101.5001);
-    DecimalD50 v2(101.5002);
+    DecimalD50 v1("101.5001");
+    DecimalD50 v2("101.5002");
     cases.push_back(TestCase{
         .name = "gt: two decimals not gt",
         .expr = {k2e::makeExpression(k2e::Operation::GT, make_vec<K2Val>(k2e::makeValueLiteral<DecimalD50>(std::move(v1)), k2e::makeValueLiteral<DecimalD50>(std::move(v2))), {})},
@@ -225,8 +225,8 @@ TEST_CASE("Float expressions"){
         .expectedResult = {false},
         .expectedException = {}});
 
-    DecimalD100 x1(101.5002);
-    DecimalD100 x2(101.5001);
+    DecimalD100 x1("101.5002");
+    DecimalD100 x2("101.5001");
     cases.push_back(TestCase{
         .name = "gt: two decimals gt",
         .expr = {k2e::makeExpression(k2e::Operation::GT, make_vec<K2Val>(k2e::makeValueLiteral<DecimalD100>(std::move(x1)), k2e::makeValueLiteral<DecimalD100>(std::move(x2))), {})},

--- a/src/skvhttpclient/test/ExpressionTest.cpp
+++ b/src/skvhttpclient/test/ExpressionTest.cpp
@@ -185,6 +185,14 @@ TEST_CASE("NaN expressions"){
     }
 
     try{
+        DecimalD25 y(nan("1"));
+        k2e::makeValueLiteral<DecimalD25>(std::move(y));
+        REQUIRE(false);
+    }catch(k2d::NaNError &){
+        std::cout << "Expression with NaN decimald25 literal cannot be made." << std::endl;
+    }
+
+    try{
         DecimalD50 y(nan("1"));
         k2e::makeValueLiteral<DecimalD50>(std::move(y));
         REQUIRE(false);
@@ -212,6 +220,15 @@ TEST_CASE("Float expressions"){
     cases.push_back(TestCase{
         .name = "gt: two floats not gt",
         .expr = {k2e::makeExpression(k2e::Operation::GT, make_vec<K2Val>(k2e::makeValueLiteral<float>(0.5), k2e::makeValueLiteral<float>(1.1)), {})},
+        .rec = makeRec(),
+        .expectedResult = {false},
+        .expectedException = {}});
+
+    DecimalD25 d1("101.5001");
+    DecimalD25 d2("101.5002");
+    cases.push_back(TestCase{
+        .name = "gt: two decimals not gt",
+        .expr = {k2e::makeExpression(k2e::Operation::GT, make_vec<K2Val>(k2e::makeValueLiteral<DecimalD25>(std::move(d1)), k2e::makeValueLiteral<DecimalD25>(std::move(d2))), {})},
         .rec = makeRec(),
         .expectedResult = {false},
         .expectedException = {}});

--- a/src/skvhttpclient/test/ExpressionTest.cpp
+++ b/src/skvhttpclient/test/ExpressionTest.cpp
@@ -229,7 +229,7 @@ TEST_CASE("Float expressions"){
     DecimalD100 x2(101.5001);
     cases.push_back(TestCase{
         .name = "gt: two decimals gt",
-        .expr = {k2e::makeExpression(k2e::Operation::GT, make_vec<K2Val>(k2e::makeValueLiteral<DecimalD100>(std::move(x1)), k2e::makeValueLiteral<Decimal100>(std::move(x2))), {})},
+        .expr = {k2e::makeExpression(k2e::Operation::GT, make_vec<K2Val>(k2e::makeValueLiteral<DecimalD100>(std::move(x1)), k2e::makeValueLiteral<DecimalD100>(std::move(x2))), {})},
         .rec = makeRec(),
         .expectedResult = {true},
         .expectedException = {}});

--- a/src/skvhttpclient/test/ExpressionTest.cpp
+++ b/src/skvhttpclient/test/ExpressionTest.cpp
@@ -193,11 +193,11 @@ TEST_CASE("NaN expressions"){
     }
 
     try{
-        Decimal100 y(nan("1"));
-        k2e::makeValueLiteral<Decimal100>(std::move(y));
+        DecimalD100 y(nan("1"));
+        k2e::makeValueLiteral<DecimalD100>(std::move(y));
         REQUIRE(false);
     }catch(k2d::NaNError &){
-        std::cout << "Expression with NaN decimal100 literal cannot be made." << std::endl;
+        std::cout << "Expression with NaN decimald100 literal cannot be made." << std::endl;
     }
 }
 
@@ -225,11 +225,11 @@ TEST_CASE("Float expressions"){
         .expectedResult = {false},
         .expectedException = {}});
 
-    Decimal100 x1(101.5002);
-    Decimal100 x2(101.5001);
+    DecimalD100 x1(101.5002);
+    DecimalD100 x2(101.5001);
     cases.push_back(TestCase{
         .name = "gt: two decimals gt",
-        .expr = {k2e::makeExpression(k2e::Operation::GT, make_vec<K2Val>(k2e::makeValueLiteral<Decimal100>(std::move(x1)), k2e::makeValueLiteral<Decimal100>(std::move(x2))), {})},
+        .expr = {k2e::makeExpression(k2e::Operation::GT, make_vec<K2Val>(k2e::makeValueLiteral<DecimalD100>(std::move(x1)), k2e::makeValueLiteral<Decimal100>(std::move(x2))), {})},
         .rec = makeRec(),
         .expectedResult = {true},
         .expectedException = {}});

--- a/src/skvhttpclient/test/ExpressionTest.cpp
+++ b/src/skvhttpclient/test/ExpressionTest.cpp
@@ -193,11 +193,11 @@ TEST_CASE("NaN expressions"){
     }
 
     try{
-        Decimal128 y(nan("1"));
-        k2e::makeValueLiteral<Decimal128>(std::move(y));
+        Decimal100 y(nan("1"));
+        k2e::makeValueLiteral<Decimal100>(std::move(y));
         REQUIRE(false);
     }catch(k2d::NaNError &){
-        std::cout << "Expression with NaN decimal128 literal cannot be made." << std::endl;
+        std::cout << "Expression with NaN decimal100 literal cannot be made." << std::endl;
     }
 }
 
@@ -225,11 +225,11 @@ TEST_CASE("Float expressions"){
         .expectedResult = {false},
         .expectedException = {}});
 
-    Decimal128 x1(101.5002);
-    Decimal128 x2(101.5001);
+    Decimal100 x1(101.5002);
+    Decimal100 x2(101.5001);
     cases.push_back(TestCase{
         .name = "gt: two decimals gt",
-        .expr = {k2e::makeExpression(k2e::Operation::GT, make_vec<K2Val>(k2e::makeValueLiteral<Decimal128>(std::move(x1)), k2e::makeValueLiteral<Decimal128>(std::move(x2))), {})},
+        .expr = {k2e::makeExpression(k2e::Operation::GT, make_vec<K2Val>(k2e::makeValueLiteral<Decimal100>(std::move(x1)), k2e::makeValueLiteral<Decimal100>(std::move(x2))), {})},
         .rec = makeRec(),
         .expectedResult = {true},
         .expectedException = {}});

--- a/src/skvhttpclient/test/ExpressionTest.cpp
+++ b/src/skvhttpclient/test/ExpressionTest.cpp
@@ -185,11 +185,11 @@ TEST_CASE("NaN expressions"){
     }
 
     try{
-        Decimal64 y(nan("1"));
-        k2e::makeValueLiteral<Decimal64>(std::move(y));
+        DecimalD50 y(nan("1"));
+        k2e::makeValueLiteral<DecimalD50>(std::move(y));
         REQUIRE(false);
     }catch(k2d::NaNError &){
-        std::cout << "Expression with NaN decimal64 literal cannot be made." << std::endl;
+        std::cout << "Expression with NaN decimald50 literal cannot be made." << std::endl;
     }
 
     try{
@@ -216,11 +216,11 @@ TEST_CASE("Float expressions"){
         .expectedResult = {false},
         .expectedException = {}});
 
-    Decimal64 v1(101.5001);
-    Decimal64 v2(101.5002);
+    DecimalD50 v1(101.5001);
+    DecimalD50 v2(101.5002);
     cases.push_back(TestCase{
         .name = "gt: two decimals not gt",
-        .expr = {k2e::makeExpression(k2e::Operation::GT, make_vec<K2Val>(k2e::makeValueLiteral<Decimal64>(std::move(v1)), k2e::makeValueLiteral<Decimal64>(std::move(v2))), {})},
+        .expr = {k2e::makeExpression(k2e::Operation::GT, make_vec<K2Val>(k2e::makeValueLiteral<DecimalD50>(std::move(v1)), k2e::makeValueLiteral<DecimalD50>(std::move(v2))), {})},
         .rec = makeRec(),
         .expectedResult = {false},
         .expectedException = {}});

--- a/src/skvhttpclient/test/mpacktest.cpp
+++ b/src/skvhttpclient/test/mpacktest.cpp
@@ -101,7 +101,7 @@ struct Ex3 {
     uint64_t i;
     int64_t j;
     skv::http::Decimal64 k;
-    skv::http::Decimal128 l;
+    skv::http::Decimal100 l;
     skv::http::Binary m;
     Ex4 e4;
     K2_DEF_ENUM_IC(Action, A1, A2);

--- a/src/skvhttpclient/test/mpacktest.cpp
+++ b/src/skvhttpclient/test/mpacktest.cpp
@@ -100,7 +100,7 @@ struct Ex3 {
     int32_t h;
     uint64_t i;
     int64_t j;
-    skv::http::Decimal64 k;
+    skv::http::DecimalD50 k;
     skv::http::DecimalD100 l;
     skv::http::Binary m;
     Ex4 e4;

--- a/src/skvhttpclient/test/mpacktest.cpp
+++ b/src/skvhttpclient/test/mpacktest.cpp
@@ -101,7 +101,7 @@ struct Ex3 {
     uint64_t i;
     int64_t j;
     skv::http::Decimal64 k;
-    skv::http::Decimal100 l;
+    skv::http::DecimalD100 l;
     skv::http::Binary m;
     Ex4 e4;
     K2_DEF_ENUM_IC(Action, A1, A2);

--- a/src/skvhttpclient/test/mpacktest.cpp
+++ b/src/skvhttpclient/test/mpacktest.cpp
@@ -100,6 +100,7 @@ struct Ex3 {
     int32_t h;
     uint64_t i;
     int64_t j;
+    skv::http::DecimalD25 k0;
     skv::http::DecimalD50 k;
     skv::http::DecimalD100 l;
     skv::http::Binary m;
@@ -108,7 +109,7 @@ struct Ex3 {
     Action n;
     std::optional<int> o;
     std::optional<skv::http::Duration> p;
-    K2_SERIALIZABLE_FMT(Ex3, a, a1, a2, b, b1, b2, b3, b4, b5, c, d, e, f, g, h, i, j, k, l, m, e4, n, o, p);
+    K2_SERIALIZABLE_FMT(Ex3, a, a1, a2, b, b1, b2, b3, b4, b5, c, d, e, f, g, h, i, j, k0, k, l, m, e4, n, o, p);
 };
 
 SCENARIO("Test 02: test struct") {
@@ -194,6 +195,7 @@ SCENARIO("Test 05: test complex embedded struct with data") {
         .h=95,
         .i=96,
         .j=99,
+        .k0=10,
         .k=50,
         .l=100,
         .m=skv::http::Binary(skv::http::String("abcd")),
@@ -432,6 +434,7 @@ SCENARIO("Test 05: test complex embedded struct with data") {
         REQUIRE(ex.h == 95);
         REQUIRE(ex.i == 96);
         REQUIRE(ex.j == 99);
+        REQUIRE(ex.k0 == 10);
         REQUIRE(ex.k == 50);
         REQUIRE(ex.l == 100);
         REQUIRE(ex.m.size() == 4);

--- a/test/integration/skvclient.py
+++ b/test/integration/skvclient.py
@@ -69,13 +69,15 @@ class Status:
 class FieldType(int, Enum):
     NULL_T:     int     = 0
     STRING:     int     = 1
-    INT32T:     int     = 2
-    INT64T:     int     = 3
-    FLOAT:      int     = 4
-    DOUBLE:     int     = 5
-    BOOL:       int     = 6
-    DECIMALD50:  int     = 7
-    DECIMALD100: int     = 8
+    INT16T:     int     = 2
+    INT32T:     int     = 3
+    INT64T:     int     = 4
+    FLOAT:      int     = 5
+    DOUBLE:     int     = 6
+    BOOL:       int     = 7
+    DECIMALD25:  int     = 8
+    DECIMALD50:  int     = 9
+    DECIMALD100: int     = 10
 
     def serialize(self):
         return self.value

--- a/test/integration/skvclient.py
+++ b/test/integration/skvclient.py
@@ -69,15 +69,13 @@ class Status:
 class FieldType(int, Enum):
     NULL_T:     int     = 0
     STRING:     int     = 1
-    INT16T:     int     = 2
-    INT32T:     int     = 3
-    INT64T:     int     = 4
-    FLOAT:      int     = 5
-    DOUBLE:     int     = 6
-    BOOL:       int     = 7
-    DECIMALD25: int     = 8
-    DECIMALD50: int     = 9
-    DECIMALD100:int     = 10
+    INT32T:     int     = 2
+    INT64T:     int     = 3
+    FLOAT:      int     = 4
+    DOUBLE:     int     = 5
+    BOOL:       int     = 6
+    DECIMALD50:  int     = 7
+    DECIMALD100: int     = 8
 
     def serialize(self):
         return self.value

--- a/test/integration/skvclient.py
+++ b/test/integration/skvclient.py
@@ -74,8 +74,8 @@ class FieldType(int, Enum):
     FLOAT:      int     = 4
     DOUBLE:     int     = 5
     BOOL:       int     = 6
-    DECIMAL64:  int     = 7
-    DECIMAL168: int     = 8
+    DECIMALD50:  int     = 7
+    DECIMALD100: int     = 8
 
     def serialize(self):
         return self.value

--- a/test/integration/skvclient.py
+++ b/test/integration/skvclient.py
@@ -69,13 +69,15 @@ class Status:
 class FieldType(int, Enum):
     NULL_T:     int     = 0
     STRING:     int     = 1
-    INT32T:     int     = 2
-    INT64T:     int     = 3
-    FLOAT:      int     = 4
-    DOUBLE:     int     = 5
-    BOOL:       int     = 6
-    DECIMALD50:  int     = 7
-    DECIMALD100: int     = 8
+    INT16T:     int     = 2
+    INT32T:     int     = 3
+    INT64T:     int     = 4
+    FLOAT:      int     = 5
+    DOUBLE:     int     = 6
+    BOOL:       int     = 7
+    DECIMALD25: int     = 8
+    DECIMALD50: int     = 9
+    DECIMALD100:int     = 10
 
     def serialize(self):
         return self.value

--- a/test/k23si/ExpressionTest.cpp
+++ b/test/k23si/ExpressionTest.cpp
@@ -190,7 +190,7 @@ TEST_CASE("NaN expressions"){
         k2e::makeValueLiteral<std::decimal::decimal128>(std::move(y));
         REQUIRE(false);
     }catch(k2d::NaNError &){
-        std::cout << "Expression with NaN decimal100 literal cannot be made." << std::endl;
+        std::cout << "Expression with NaN decimald100 literal cannot be made." << std::endl;
     }
 }
 

--- a/test/k23si/ExpressionTest.cpp
+++ b/test/k23si/ExpressionTest.cpp
@@ -220,10 +220,10 @@ TEST_CASE("Float expressions"){
     boost::multiprecision::cpp_dec_float_25 d1("100.5001");
     boost::multiprecision::cpp_dec_float_25 d2("100.5002");
     cases.push_back(TestCase{
-        .name = "gt: two decimals not gt",
-        .expr = {k2e::makeExpression(k2e::Operation::GT, k2::make_vec<K2Val>(k2e::makeValueLiteral<boost::multiprecision::cpp_dec_float_25>(std::move(d1)), k2e::makeValueLiteral<boost::multiprecision::cpp_dec_float_25>(std::move(d2))), {})},
+        .name = "gt: two decimals lt",
+        .expr = {k2e::makeExpression(k2e::Operation::LT, k2::make_vec<K2Val>(k2e::makeValueLiteral<boost::multiprecision::cpp_dec_float_25>(std::move(d1)), k2e::makeValueLiteral<boost::multiprecision::cpp_dec_float_25>(std::move(d2))), {})},
         .rec = makeRec(),
-        .expectedResult = {false},
+        .expectedResult = {true},
         .expectedException = {}});  
 
     boost::multiprecision::cpp_dec_float_50 v1("101.5001");

--- a/test/k23si/ExpressionTest.cpp
+++ b/test/k23si/ExpressionTest.cpp
@@ -178,6 +178,14 @@ TEST_CASE("NaN expressions"){
     }
 
     try{
+        boost::multiprecision::cpp_dec_float_25 y(nan("1"));
+        k2e::makeValueLiteral<boost::multiprecision::cpp_dec_float_25>(std::move(y));
+        REQUIRE(false);
+    }catch(k2d::NaNError &){
+        std::cout << "Expression with NaN decimald25 literal cannot be made." << std::endl;
+    }
+
+    try{
         boost::multiprecision::cpp_dec_float_50 y(nan("1"));
         k2e::makeValueLiteral<boost::multiprecision::cpp_dec_float_50>(std::move(y));
         REQUIRE(false);
@@ -208,6 +216,15 @@ TEST_CASE("Float expressions"){
         .rec = makeRec(),
         .expectedResult = {false},
         .expectedException = {}});
+
+    boost::multiprecision::cpp_dec_float_25 d1("100.5001");
+    boost::multiprecision::cpp_dec_float_25 d2("100.5002");
+    cases.push_back(TestCase{
+        .name = "gt: two decimals not gt",
+        .expr = {k2e::makeExpression(k2e::Operation::GT, k2::make_vec<K2Val>(k2e::makeValueLiteral<boost::multiprecision::cpp_dec_float_25>(std::move(d1)), k2e::makeValueLiteral<boost::multiprecision::cpp_dec_float_25>(std::move(d2))), {})},
+        .rec = makeRec(),
+        .expectedResult = {false},
+        .expectedException = {}});  
 
     boost::multiprecision::cpp_dec_float_50 v1("101.5001");
     boost::multiprecision::cpp_dec_float_50 v2("101.5002");

--- a/test/k23si/ExpressionTest.cpp
+++ b/test/k23si/ExpressionTest.cpp
@@ -209,8 +209,8 @@ TEST_CASE("Float expressions"){
         .expectedResult = {false},
         .expectedException = {}});
 
-    boost::multiprecision::cpp_dec_float_50 v1(101.5001);
-    boost::multiprecision::cpp_dec_float_50 v2(101.5002);
+    boost::multiprecision::cpp_dec_float_50 v1("101.5001");
+    boost::multiprecision::cpp_dec_float_50 v2("101.5002");
     cases.push_back(TestCase{
         .name = "gt: two decimals not gt",
         .expr = {k2e::makeExpression(k2e::Operation::GT, k2::make_vec<K2Val>(k2e::makeValueLiteral<boost::multiprecision::cpp_dec_float_50>(std::move(v1)), k2e::makeValueLiteral<boost::multiprecision::cpp_dec_float_50>(std::move(v2))), {})},
@@ -218,8 +218,8 @@ TEST_CASE("Float expressions"){
         .expectedResult = {false},
         .expectedException = {}});
 
-    boost::multiprecision::cpp_dec_float_100 x1(101.5002);
-    boost::multiprecision::cpp_dec_float_100 x2(101.5001);
+    boost::multiprecision::cpp_dec_float_100 x1("101.5002");
+    boost::multiprecision::cpp_dec_float_100 x2("101.5001");
     cases.push_back(TestCase{
         .name = "gt: two decimals gt",
         .expr = {k2e::makeExpression(k2e::Operation::GT, k2::make_vec<K2Val>(k2e::makeValueLiteral<boost::multiprecision::cpp_dec_float_100>(std::move(x1)), k2e::makeValueLiteral<boost::multiprecision::cpp_dec_float_100>(std::move(x2))), {})},

--- a/test/k23si/ExpressionTest.cpp
+++ b/test/k23si/ExpressionTest.cpp
@@ -190,7 +190,7 @@ TEST_CASE("NaN expressions"){
         k2e::makeValueLiteral<std::decimal::decimal128>(std::move(y));
         REQUIRE(false);
     }catch(k2d::NaNError &){
-        std::cout << "Expression with NaN decimal128 literal cannot be made." << std::endl;
+        std::cout << "Expression with NaN decimal100 literal cannot be made." << std::endl;
     }
 }
 

--- a/test/k23si/ExpressionTest.cpp
+++ b/test/k23si/ExpressionTest.cpp
@@ -182,7 +182,7 @@ TEST_CASE("NaN expressions"){
         k2e::makeValueLiteral<std::decimal::decimal64>(std::move(y));
         REQUIRE(false);
     }catch(k2d::NaNError &){
-        std::cout << "Expression with NaN decimal64 literal cannot be made." << std::endl;
+        std::cout << "Expression with NaN decimald50 literal cannot be made." << std::endl;
     }
 
     try{

--- a/test/k23si/ExpressionTest.cpp
+++ b/test/k23si/ExpressionTest.cpp
@@ -186,7 +186,7 @@ TEST_CASE("NaN expressions"){
     }
 
     try{
-        boost::multiprecision::cpp_dec_float_100 y(nan("1")); // NOT SURE
+        boost::multiprecision::cpp_dec_float_100 y(nan("1"));
         k2e::makeValueLiteral<boost::multiprecision::cpp_dec_float_100>(std::move(y));
         REQUIRE(false);
     }catch(k2d::NaNError &){

--- a/test/k23si/ExpressionTest.cpp
+++ b/test/k23si/ExpressionTest.cpp
@@ -178,24 +178,24 @@ TEST_CASE("NaN expressions"){
     }
 
     try{
-        boost::multiprecision::cpp_dec_float_25 y(nan("1"));
-        k2e::makeValueLiteral<boost::multiprecision::cpp_dec_float_25>(std::move(y));
+        DecimalD25 y(nan("1"));
+        k2e::makeValueLiteral<DecimalD25>(std::move(y));
         REQUIRE(false);
     }catch(k2d::NaNError &){
         std::cout << "Expression with NaN decimald25 literal cannot be made." << std::endl;
     }
 
     try{
-        boost::multiprecision::cpp_dec_float_50 y(nan("1"));
-        k2e::makeValueLiteral<boost::multiprecision::cpp_dec_float_50>(std::move(y));
+        DecimalD50 y(nan("1"));
+        k2e::makeValueLiteral<DecimalD50>(std::move(y));
         REQUIRE(false);
     }catch(k2d::NaNError &){
         std::cout << "Expression with NaN decimald50 literal cannot be made." << std::endl;
     }
 
     try{
-        boost::multiprecision::cpp_dec_float_100 y(nan("1"));
-        k2e::makeValueLiteral<boost::multiprecision::cpp_dec_float_100>(std::move(y));
+        DecimalD100 y(nan("1"));
+        k2e::makeValueLiteral<DecimalD100>(std::move(y));
         REQUIRE(false);
     }catch(k2d::NaNError &){
         std::cout << "Expression with NaN decimald100 literal cannot be made." << std::endl;
@@ -217,29 +217,29 @@ TEST_CASE("Float expressions"){
         .expectedResult = {false},
         .expectedException = {}});
 
-    boost::multiprecision::cpp_dec_float_25 d1("100.5001");
-    boost::multiprecision::cpp_dec_float_25 d2("100.5002");
+    DecimalD25 d1("100.5001");
+    DecimalD25 d2("100.5002");
     cases.push_back(TestCase{
         .name = "gt: two decimals lt",
-        .expr = {k2e::makeExpression(k2e::Operation::LT, k2::make_vec<K2Val>(k2e::makeValueLiteral<boost::multiprecision::cpp_dec_float_25>(std::move(d1)), k2e::makeValueLiteral<boost::multiprecision::cpp_dec_float_25>(std::move(d2))), {})},
+        .expr = {k2e::makeExpression(k2e::Operation::LT, k2::make_vec<K2Val>(k2e::makeValueLiteral<DecimalD25>(std::move(d1)), k2e::makeValueLiteral<DecimalD25>(std::move(d2))), {})},
         .rec = makeRec(),
         .expectedResult = {true},
         .expectedException = {}});  
 
-    boost::multiprecision::cpp_dec_float_50 v1("101.5001");
-    boost::multiprecision::cpp_dec_float_50 v2("101.5002");
+    DecimalD50 v1("101.5001");
+    DecimalD50 v2("101.5002");
     cases.push_back(TestCase{
         .name = "gt: two decimals not gt",
-        .expr = {k2e::makeExpression(k2e::Operation::GT, k2::make_vec<K2Val>(k2e::makeValueLiteral<boost::multiprecision::cpp_dec_float_50>(std::move(v1)), k2e::makeValueLiteral<boost::multiprecision::cpp_dec_float_50>(std::move(v2))), {})},
+        .expr = {k2e::makeExpression(k2e::Operation::GT, k2::make_vec<K2Val>(k2e::makeValueLiteral<DecimalD50>(std::move(v1)), k2e::makeValueLiteral<DecimalD50>(std::move(v2))), {})},
         .rec = makeRec(),
         .expectedResult = {false},
         .expectedException = {}});
 
-    boost::multiprecision::cpp_dec_float_100 x1("101.5002");
-    boost::multiprecision::cpp_dec_float_100 x2("101.5001");
+    DecimalD100 x1("101.5002");
+    DecimalD100 x2("101.5001");
     cases.push_back(TestCase{
         .name = "gt: two decimals gt",
-        .expr = {k2e::makeExpression(k2e::Operation::GT, k2::make_vec<K2Val>(k2e::makeValueLiteral<boost::multiprecision::cpp_dec_float_100>(std::move(x1)), k2e::makeValueLiteral<boost::multiprecision::cpp_dec_float_100>(std::move(x2))), {})},
+        .expr = {k2e::makeExpression(k2e::Operation::GT, k2::make_vec<K2Val>(k2e::makeValueLiteral<DecimalD100>(std::move(x1)), k2e::makeValueLiteral<DecimalD100>(std::move(x2))), {})},
         .rec = makeRec(),
         .expectedResult = {true},
         .expectedException = {}});

--- a/test/k23si/ExpressionTest.cpp
+++ b/test/k23si/ExpressionTest.cpp
@@ -178,8 +178,8 @@ TEST_CASE("NaN expressions"){
     }
 
     try{
-        std::decimal::decimal64 y(nan("1"));
-        k2e::makeValueLiteral<std::decimal::decimal64>(std::move(y));
+        boost::multiprecision::cpp_dec_float_50 y(nan("1"));
+        k2e::makeValueLiteral<boost::multiprecision::cpp_dec_float_50>(std::move(y));
         REQUIRE(false);
     }catch(k2d::NaNError &){
         std::cout << "Expression with NaN decimald50 literal cannot be made." << std::endl;
@@ -209,11 +209,11 @@ TEST_CASE("Float expressions"){
         .expectedResult = {false},
         .expectedException = {}});
 
-    std::decimal::decimal64 v1(101.5001);
-    std::decimal::decimal64 v2(101.5002);
+    boost::multiprecision::cpp_dec_float_50 v1(101.5001);
+    boost::multiprecision::cpp_dec_float_50 v2(101.5002);
     cases.push_back(TestCase{
         .name = "gt: two decimals not gt",
-        .expr = {k2e::makeExpression(k2e::Operation::GT, k2::make_vec<K2Val>(k2e::makeValueLiteral<std::decimal::decimal64>(std::move(v1)), k2e::makeValueLiteral<std::decimal::decimal64>(std::move(v2))), {})},
+        .expr = {k2e::makeExpression(k2e::Operation::GT, k2::make_vec<K2Val>(k2e::makeValueLiteral<boost::multiprecision::cpp_dec_float_50>(std::move(v1)), k2e::makeValueLiteral<boost::multiprecision::cpp_dec_float_50>(std::move(v2))), {})},
         .rec = makeRec(),
         .expectedResult = {false},
         .expectedException = {}});

--- a/test/k23si/ExpressionTest.cpp
+++ b/test/k23si/ExpressionTest.cpp
@@ -186,8 +186,8 @@ TEST_CASE("NaN expressions"){
     }
 
     try{
-        std::decimal::decimal128 y(nan("1"));
-        k2e::makeValueLiteral<std::decimal::decimal128>(std::move(y));
+        boost::multiprecision::cpp_dec_float_100 y(nan("1")); // NOT SURE
+        k2e::makeValueLiteral<boost::multiprecision::cpp_dec_float_100>(std::move(y));
         REQUIRE(false);
     }catch(k2d::NaNError &){
         std::cout << "Expression with NaN decimald100 literal cannot be made." << std::endl;
@@ -218,11 +218,11 @@ TEST_CASE("Float expressions"){
         .expectedResult = {false},
         .expectedException = {}});
 
-    std::decimal::decimal128 x1(101.5002);
-    std::decimal::decimal128 x2(101.5001);
+    boost::multiprecision::cpp_dec_float_100 x1(101.5002);
+    boost::multiprecision::cpp_dec_float_100 x2(101.5001);
     cases.push_back(TestCase{
         .name = "gt: two decimals gt",
-        .expr = {k2e::makeExpression(k2e::Operation::GT, k2::make_vec<K2Val>(k2e::makeValueLiteral<std::decimal::decimal128>(std::move(x1)), k2e::makeValueLiteral<std::decimal::decimal128>(std::move(x2))), {})},
+        .expr = {k2e::makeExpression(k2e::Operation::GT, k2::make_vec<K2Val>(k2e::makeValueLiteral<boost::multiprecision::cpp_dec_float_100>(std::move(x1)), k2e::makeValueLiteral<boost::multiprecision::cpp_dec_float_100>(std::move(x2))), {})},
         .rec = makeRec(),
         .expectedResult = {true},
         .expectedException = {}});

--- a/test/k23si/SKVSerTest.cpp
+++ b/test/k23si/SKVSerTest.cpp
@@ -492,7 +492,7 @@ TEST_CASE("Test13: serialiaze float, double and decimal fields") {
             {k2::dto::FieldType::DOUBLE, "Balance", false, false},
             {k2::dto::FieldType::FLOAT, "Salary", false, false},
             {k2::dto::FieldType::DECIMAL64, "CreditLimit", false, false},
-            {k2::dto::FieldType::DECIMAL100, "CreditBalance", false, false},
+            {k2::dto::FieldType::DECIMALD100, "CreditBalance", false, false},
     };
 
     schema.setPartitionKeyFieldsByName(std::vector<k2::String>{"LastName", "FirstName"});

--- a/test/k23si/SKVSerTest.cpp
+++ b/test/k23si/SKVSerTest.cpp
@@ -505,6 +505,7 @@ TEST_CASE("Test13: serialiaze float, double and decimal fields") {
             {k2::dto::FieldType::STRING, "FirstName", false, true},
             {k2::dto::FieldType::DOUBLE, "Balance", false, false},
             {k2::dto::FieldType::FLOAT, "Salary", false, false},
+            {k2::dto::FieldType::DECIMALD25, "OtherIncome", false, false},
             {k2::dto::FieldType::DECIMALD50, "CreditLimit", false, false},
             {k2::dto::FieldType::DECIMALD100, "CreditBalance", false, false},
     };

--- a/test/k23si/SKVSerTest.cpp
+++ b/test/k23si/SKVSerTest.cpp
@@ -449,22 +449,8 @@ TEST_CASE("Test11: serialize decimal NaN field") {
     doc.serializeNext<double>(100.1);
 
     try{
-        boost::multiprecision::cpp_dec_float_25 y(nan("1"));
-        doc.serializeNext<boost::multiprecision::cpp_dec_float_25>(y);
-        REQUIRE(false);
-    }catch(k2::dto::NaNError &){
-        std::cout << "Test11: Tried to serialize decimal NaN field" << std::endl;
-    }
-    try{
         boost::multiprecision::cpp_dec_float_50 y(nan("1"));
         doc.serializeNext<boost::multiprecision::cpp_dec_float_50>(y);
-        REQUIRE(false);
-    }catch(k2::dto::NaNError &){
-        std::cout << "Test11: Tried to serialize decimal NaN field" << std::endl;
-    }
-    try{
-        boost::multiprecision::cpp_dec_float_100 y(nan("1"));
-        doc.serializeNext<boost::multiprecision::cpp_dec_float_100>(y);
         REQUIRE(false);
     }catch(k2::dto::NaNError &){
         std::cout << "Test11: Tried to serialize decimal NaN field" << std::endl;

--- a/test/k23si/SKVSerTest.cpp
+++ b/test/k23si/SKVSerTest.cpp
@@ -449,8 +449,8 @@ TEST_CASE("Test11: serialize decimal NaN field") {
     doc.serializeNext<double>(100.1);
 
     try{
-        boost::multiprecision::cpp_dec_float_50 y(nan("1"));
-        doc.serializeNext<boost::multiprecision::cpp_dec_float_50>(y);
+        k2::DecimalD50 y(nan("1"));
+        doc.serializeNext<k2::DecimalD50>(y);
         REQUIRE(false);
     }catch(k2::dto::NaNError &){
         std::cout << "Test11: Tried to serialize decimal NaN field" << std::endl;
@@ -505,14 +505,14 @@ TEST_CASE("Test13: serialiaze float, double and decimal fields") {
     doc.serializeNext<double>(1000.1);
     doc.serializeNext<float>(100.2);
 
-    boost::multiprecision::cpp_dec_float_25 z("100.5001");
-    doc.serializeNext<boost::multiprecision::cpp_dec_float_25>(z);
+    k2::DecimalD25 z("100.5001");
+    doc.serializeNext<k2::DecimalD25>(z);
 
-    boost::multiprecision::cpp_dec_float_50 y("101.5001");
-    doc.serializeNext<boost::multiprecision::cpp_dec_float_50>(y);
+    k2::DecimalD50 y("101.5001");
+    doc.serializeNext<k2::DecimalD50>(y);
 
-    boost::multiprecision::cpp_dec_float_100  x("101.5002");
-    doc.serializeNext<boost::multiprecision::cpp_dec_float_100>(x);
+    k2::DecimalD100  x("101.5002");
+    doc.serializeNext<k2::DecimalD100>(x);
     
     std::cout << "Test13: Serialize float and double fields." << std::endl;
 }

--- a/test/k23si/SKVSerTest.cpp
+++ b/test/k23si/SKVSerTest.cpp
@@ -449,8 +449,8 @@ TEST_CASE("Test11: serialize decimal NaN field") {
     doc.serializeNext<double>(100.1);
 
     try{
-        std::decimal::decimal64 y(nan("1"));
-        doc.serializeNext<std::decimal::decimal64>(y);
+        boost::multiprecision::cpp_dec_float_50 y(nan("1"));
+        doc.serializeNext<boost::multiprecision::cpp_dec_float_50>(y);
         REQUIRE(false);
     }catch(k2::dto::NaNError &){
         std::cout << "Test11: Tried to serialize decimal NaN field" << std::endl;
@@ -504,8 +504,8 @@ TEST_CASE("Test13: serialiaze float, double and decimal fields") {
     doc.serializeNext<double>(1000.1);
     doc.serializeNext<float>(100.2);
 
-    std::decimal::decimal64 y(101.5001);
-    doc.serializeNext<std::decimal::decimal64>(y);
+    boost::multiprecision::cpp_dec_float_50 y(101.5001);
+    doc.serializeNext<boost::multiprecision::cpp_dec_float_50>(y);
 
     boost::multiprecision::cpp_dec_float_100  x(101.5002);
     doc.serializeNext<boost::multiprecision::cpp_dec_float_100>(x);

--- a/test/k23si/SKVSerTest.cpp
+++ b/test/k23si/SKVSerTest.cpp
@@ -449,8 +449,22 @@ TEST_CASE("Test11: serialize decimal NaN field") {
     doc.serializeNext<double>(100.1);
 
     try{
+        boost::multiprecision::cpp_dec_float_25 y(nan("1"));
+        doc.serializeNext<boost::multiprecision::cpp_dec_float_25>(y);
+        REQUIRE(false);
+    }catch(k2::dto::NaNError &){
+        std::cout << "Test11: Tried to serialize decimal NaN field" << std::endl;
+    }
+    try{
         boost::multiprecision::cpp_dec_float_50 y(nan("1"));
         doc.serializeNext<boost::multiprecision::cpp_dec_float_50>(y);
+        REQUIRE(false);
+    }catch(k2::dto::NaNError &){
+        std::cout << "Test11: Tried to serialize decimal NaN field" << std::endl;
+    }
+    try{
+        boost::multiprecision::cpp_dec_float_100 y(nan("1"));
+        doc.serializeNext<boost::multiprecision::cpp_dec_float_100>(y);
         REQUIRE(false);
     }catch(k2::dto::NaNError &){
         std::cout << "Test11: Tried to serialize decimal NaN field" << std::endl;
@@ -503,6 +517,9 @@ TEST_CASE("Test13: serialiaze float, double and decimal fields") {
     doc.serializeNext<k2::String>("Bilbo");
     doc.serializeNext<double>(1000.1);
     doc.serializeNext<float>(100.2);
+
+    boost::multiprecision::cpp_dec_float_25 z("100.5001");
+    doc.serializeNext<boost::multiprecision::cpp_dec_float_25>(z);
 
     boost::multiprecision::cpp_dec_float_50 y("101.5001");
     doc.serializeNext<boost::multiprecision::cpp_dec_float_50>(y);

--- a/test/k23si/SKVSerTest.cpp
+++ b/test/k23si/SKVSerTest.cpp
@@ -437,7 +437,7 @@ TEST_CASE("Test11: serialize decimal NaN field") {
             {k2::dto::FieldType::STRING, "LastName", false, false},
             {k2::dto::FieldType::STRING, "FirstName", false, true},
             {k2::dto::FieldType::DOUBLE, "Balance", false, false}, 
-            {k2::dto::FieldType::DECIMAL64, "CreditLimit", false, false},
+            {k2::dto::FieldType::DECIMALD50, "CreditLimit", false, false},
     };
 
     schema.setPartitionKeyFieldsByName(std::vector<k2::String>{"LastName", "FirstName"});
@@ -491,7 +491,7 @@ TEST_CASE("Test13: serialiaze float, double and decimal fields") {
             {k2::dto::FieldType::STRING, "FirstName", false, true},
             {k2::dto::FieldType::DOUBLE, "Balance", false, false},
             {k2::dto::FieldType::FLOAT, "Salary", false, false},
-            {k2::dto::FieldType::DECIMAL64, "CreditLimit", false, false},
+            {k2::dto::FieldType::DECIMALD50, "CreditLimit", false, false},
             {k2::dto::FieldType::DECIMALD100, "CreditBalance", false, false},
     };
 

--- a/test/k23si/SKVSerTest.cpp
+++ b/test/k23si/SKVSerTest.cpp
@@ -492,7 +492,7 @@ TEST_CASE("Test13: serialiaze float, double and decimal fields") {
             {k2::dto::FieldType::DOUBLE, "Balance", false, false},
             {k2::dto::FieldType::FLOAT, "Salary", false, false},
             {k2::dto::FieldType::DECIMAL64, "CreditLimit", false, false},
-            {k2::dto::FieldType::DECIMAL128, "CreditBalance", false, false},
+            {k2::dto::FieldType::DECIMAL100, "CreditBalance", false, false},
     };
 
     schema.setPartitionKeyFieldsByName(std::vector<k2::String>{"LastName", "FirstName"});

--- a/test/k23si/SKVSerTest.cpp
+++ b/test/k23si/SKVSerTest.cpp
@@ -504,10 +504,10 @@ TEST_CASE("Test13: serialiaze float, double and decimal fields") {
     doc.serializeNext<double>(1000.1);
     doc.serializeNext<float>(100.2);
 
-    boost::multiprecision::cpp_dec_float_50 y(101.5001);
+    boost::multiprecision::cpp_dec_float_50 y("101.5001");
     doc.serializeNext<boost::multiprecision::cpp_dec_float_50>(y);
 
-    boost::multiprecision::cpp_dec_float_100  x(101.5002);
+    boost::multiprecision::cpp_dec_float_100  x("101.5002");
     doc.serializeNext<boost::multiprecision::cpp_dec_float_100>(x);
     
     std::cout << "Test13: Serialize float and double fields." << std::endl;

--- a/test/k23si/SKVSerTest.cpp
+++ b/test/k23si/SKVSerTest.cpp
@@ -507,8 +507,8 @@ TEST_CASE("Test13: serialiaze float, double and decimal fields") {
     std::decimal::decimal64 y(101.5001);
     doc.serializeNext<std::decimal::decimal64>(y);
 
-    std::decimal::decimal128 x(101.5002);
-    doc.serializeNext<std::decimal::decimal128>(x);
+    boost::multiprecision::cpp_dec_float_100  x(101.5002);
+    doc.serializeNext<boost::multiprecision::cpp_dec_float_100>(x);
     
     std::cout << "Test13: Serialize float and double fields." << std::endl;
 }

--- a/test/transport/PayloadTest.cpp
+++ b/test/transport/PayloadTest.cpp
@@ -417,7 +417,7 @@ SCENARIO("test getSerializedSizeOf method") {
     src.skip<char>();
     REQUIRE(src.getSerializedSizeOf<String>() == sizeof(uint32_t) + b.size() + 1);
     src.skip<String>();
-    REQUIRE(src.getSerializedSizeOf<boost::multiprecision::cpp_dec_float_50>() == sizeof(boost::multiprecision::float128)); // NOT SURE
+    REQUIRE(src.getSerializedSizeOf<boost::multiprecision::cpp_dec_float_50>() == sizeof(uint32_t) + c.str().size() + 1; // NOT SURE
     src.skip<boost::multiprecision::cpp_dec_float_50>();
     REQUIRE(src.getSerializedSizeOf<std::set<int16_t>>() == sizeof(uint32_t) + d.size() * sizeof(int16_t));
     src.skip<std::set<int16_t>>();

--- a/test/transport/PayloadTest.cpp
+++ b/test/transport/PayloadTest.cpp
@@ -419,9 +419,9 @@ SCENARIO("test getSerializedSizeOf method") {
     src.skip<char>();
     REQUIRE(src.getSerializedSizeOf<String>() == sizeof(uint32_t) + b.size() + 1);
     src.skip<String>();
-    REQUIRE(src.getSerializedSizeOf<boost::multiprecision::cpp_dec_float_50>() == sizeof(size_t) + c.str().size());
+    REQUIRE(src.getSerializedSizeOf<boost::multiprecision::cpp_dec_float_50>() == sizeof(size_t) + c.str().size() + 1);
     src.skip<boost::multiprecision::cpp_dec_float_50>();
-    REQUIRE(src.getSerializedSizeOf<boost::multiprecision::cpp_dec_float_100>() == sizeof(size_t) + c1.str().size());
+    REQUIRE(src.getSerializedSizeOf<boost::multiprecision::cpp_dec_float_100>() == sizeof(size_t) + c1.str().size() + 1);
     src.skip<boost::multiprecision::cpp_dec_float_100>();
     REQUIRE(src.getSerializedSizeOf<std::set<int16_t>>() == sizeof(uint32_t) + d.size() * sizeof(int16_t));
     src.skip<std::set<int16_t>>();

--- a/test/transport/PayloadTest.cpp
+++ b/test/transport/PayloadTest.cpp
@@ -417,7 +417,7 @@ SCENARIO("test getSerializedSizeOf method") {
     src.skip<char>();
     REQUIRE(src.getSerializedSizeOf<String>() == sizeof(uint32_t) + b.size() + 1);
     src.skip<String>();
-    REQUIRE(src.getSerializedSizeOf<boost::multiprecision::cpp_dec_float_50>() == sizeof(uint32_t) + c.str().size() + 1; // NOT SURE
+    REQUIRE(src.getSerializedSizeOf<boost::multiprecision::cpp_dec_float_50>() == sizeof(uint32_t) + c.str().size() + 1); // NOT SURE
     src.skip<boost::multiprecision::cpp_dec_float_50>();
     REQUIRE(src.getSerializedSizeOf<std::set<int16_t>>() == sizeof(uint32_t) + d.size() * sizeof(int16_t));
     src.skip<std::set<int16_t>>();

--- a/test/transport/PayloadTest.cpp
+++ b/test/transport/PayloadTest.cpp
@@ -372,10 +372,12 @@ SCENARIO("test getSerializedSizeOf method") {
     Payload src(Payload::DefaultAllocator(32));
     char a = 'a';
     String b = "test getSerializedSizeOf method";
-    boost::multiprecision::cpp_dec_float_50 c("1333666666.0000001111");
-    boost::multiprecision::cpp_dec_float_100 c1("1333666666.00000011114444");
-    boost::multiprecision::cpp_dec_float_50 c2 = std::numeric_limits<boost::multiprecision::cpp_dec_float_50>::min();
-    boost::multiprecision::cpp_dec_float_50 c3 = std::numeric_limits<boost::multiprecision::cpp_dec_float_50>::max();
+    
+    boost::multiprecision::cpp_dec_float_25 c0("122333.0000001111");
+    boost::multiprecision::cpp_dec_float_50 c1("1333666666.0000001111");
+    boost::multiprecision::cpp_dec_float_100 c2("1333666666.00000011114444");
+    boost::multiprecision::cpp_dec_float_50 c3 = std::numeric_limits<boost::multiprecision::cpp_dec_float_50>::min();
+    boost::multiprecision::cpp_dec_float_50 c4 = std::numeric_limits<boost::multiprecision::cpp_dec_float_50>::max();
     
     std::set<int16_t> d{
         1, 2, 3, 4, 5
@@ -408,10 +410,11 @@ SCENARIO("test getSerializedSizeOf method") {
 
     src.write(a);
     src.write(b);
-    src.write(c);
+    src.write(c0);
     src.write(c1);
     src.write(c2);
     src.write(c3);
+    src.write(c4);
     src.write(d);
     src.write(e);
     src.write(f);
@@ -424,6 +427,8 @@ SCENARIO("test getSerializedSizeOf method") {
     src.skip<char>();
     REQUIRE(src.getSerializedSizeOf<String>() == sizeof(uint32_t) + b.size() + 1);
     src.skip<String>();
+    REQUIRE(src.getSerializedSizeOf<boost::multiprecision::cpp_dec_float_25>() == sizeof(boost::multiprecision::cpp_dec_float_25));
+    src.skip<boost::multiprecision::cpp_dec_float_25>();
     REQUIRE(src.getSerializedSizeOf<boost::multiprecision::cpp_dec_float_50>() == sizeof(boost::multiprecision::cpp_dec_float_50));
     src.skip<boost::multiprecision::cpp_dec_float_50>();
     REQUIRE(src.getSerializedSizeOf<boost::multiprecision::cpp_dec_float_100>() == sizeof(boost::multiprecision::cpp_dec_float_100));

--- a/test/transport/PayloadTest.cpp
+++ b/test/transport/PayloadTest.cpp
@@ -374,8 +374,6 @@ SCENARIO("test getSerializedSizeOf method") {
     String b = "test getSerializedSizeOf method";
     boost::multiprecision::cpp_dec_float_50 c("1333666666.0000001111");
     boost::multiprecision::cpp_dec_float_100 c1("1333666666.00000011114444");
-    Binary c2("abcd", 4); // can't create a float with this string
-    Binary c3("aaaa", 4);
     std::set<int16_t> d{
         1, 2, 3, 4, 5
     };
@@ -409,8 +407,6 @@ SCENARIO("test getSerializedSizeOf method") {
     src.write(b);
     src.write(c);
     src.write(c1);
-    src.write(c2);
-    src.write(c3);
     src.write(d);
     src.write(e);
     src.write(f);
@@ -423,15 +419,10 @@ SCENARIO("test getSerializedSizeOf method") {
     src.skip<char>();
     REQUIRE(src.getSerializedSizeOf<String>() == sizeof(uint32_t) + b.size() + 1);
     src.skip<String>();
-    REQUIRE(src.getSerializedSizeOf<boost::multiprecision::cpp_dec_float_50>() == sizeof(size_t) + c.str().size() + 1);
+    REQUIRE(src.getSerializedSizeOf<boost::multiprecision::cpp_dec_float_50>() == sizeof(boost::multiprecision::cpp_dec_float_50));
     src.skip<boost::multiprecision::cpp_dec_float_50>();
-    REQUIRE(src.getSerializedSizeOf<boost::multiprecision::cpp_dec_float_100>() == sizeof(size_t) + c1.str().size() + 1);
+    REQUIRE(src.getSerializedSizeOf<boost::multiprecision::cpp_dec_float_100>() == sizeof(boost::multiprecision::cpp_dec_float_100));
     src.skip<boost::multiprecision::cpp_dec_float_100>();
-    boost::multiprecision::cpp_dec_float_50 c2Read;
-    boost::multiprecision::cpp_dec_float_100 c3Read;
-    REQUIRE(src.read(c2Read) == false);
-    REQUIRE(src.read(c3Read) == false);
-
     REQUIRE(src.getSerializedSizeOf<std::set<int16_t>>() == sizeof(uint32_t) + d.size() * sizeof(int16_t));
     src.skip<std::set<int16_t>>();
     REQUIRE(src.getSerializedSizeOf<std::map<int16_t, String>>() == sizeof(uint32_t) + 2 + 9 + 2 + 24 + 2 + 11);

--- a/test/transport/PayloadTest.cpp
+++ b/test/transport/PayloadTest.cpp
@@ -372,7 +372,8 @@ SCENARIO("test getSerializedSizeOf method") {
     Payload src(Payload::DefaultAllocator(32));
     char a = 'a';
     String b = "test getSerializedSizeOf method";
-    boost::multiprecision::cpp_dec_float_50 c(323.435);
+    boost::multiprecision::cpp_dec_float_50 c("1333666666.0000001111");
+    boost::multiprecision::cpp_dec_float_100 c1("1333666666.00000011114444");
     std::set<int16_t> d{
         1, 2, 3, 4, 5
     };
@@ -405,6 +406,7 @@ SCENARIO("test getSerializedSizeOf method") {
     src.write(a);
     src.write(b);
     src.write(c);
+    src.write(c1);
     src.write(d);
     src.write(e);
     src.write(f);
@@ -417,8 +419,10 @@ SCENARIO("test getSerializedSizeOf method") {
     src.skip<char>();
     REQUIRE(src.getSerializedSizeOf<String>() == sizeof(uint32_t) + b.size() + 1);
     src.skip<String>();
-    REQUIRE(src.getSerializedSizeOf<boost::multiprecision::cpp_dec_float_50>() == sizeof(uint32_t) + c.str().size() + 1); // NOT SURE
+    REQUIRE(src.getSerializedSizeOf<boost::multiprecision::cpp_dec_float_50>() == sizeof(size_t) + c.str().size());
     src.skip<boost::multiprecision::cpp_dec_float_50>();
+    REQUIRE(src.getSerializedSizeOf<boost::multiprecision::cpp_dec_float_100>() == sizeof(size_t) + c1.str().size());
+    src.skip<boost::multiprecision::cpp_dec_float_100>();
     REQUIRE(src.getSerializedSizeOf<std::set<int16_t>>() == sizeof(uint32_t) + d.size() * sizeof(int16_t));
     src.skip<std::set<int16_t>>();
     REQUIRE(src.getSerializedSizeOf<std::map<int16_t, String>>() == sizeof(uint32_t) + 2 + 9 + 2 + 24 + 2 + 11);

--- a/test/transport/PayloadTest.cpp
+++ b/test/transport/PayloadTest.cpp
@@ -372,7 +372,7 @@ SCENARIO("test getSerializedSizeOf method") {
     Payload src(Payload::DefaultAllocator(32));
     char a = 'a';
     String b = "test getSerializedSizeOf method";
-    std::decimal::decimal64 c(323.435);
+    boost::multiprecision::cpp_dec_float_50 c(323.435);
     std::set<int16_t> d{
         1, 2, 3, 4, 5
     };
@@ -417,8 +417,8 @@ SCENARIO("test getSerializedSizeOf method") {
     src.skip<char>();
     REQUIRE(src.getSerializedSizeOf<String>() == sizeof(uint32_t) + b.size() + 1);
     src.skip<String>();
-    REQUIRE(src.getSerializedSizeOf<std::decimal::decimal64>() == sizeof(std::decimal::decimal64::__decfloat64));
-    src.skip<std::decimal::decimal64>();
+    REQUIRE(src.getSerializedSizeOf<boost::multiprecision::cpp_dec_float_50>() == sizeof(boost::multiprecision::float128)); // NOT SURE
+    src.skip<boost::multiprecision::cpp_dec_float_50>();
     REQUIRE(src.getSerializedSizeOf<std::set<int16_t>>() == sizeof(uint32_t) + d.size() * sizeof(int16_t));
     src.skip<std::set<int16_t>>();
     REQUIRE(src.getSerializedSizeOf<std::map<int16_t, String>>() == sizeof(uint32_t) + 2 + 9 + 2 + 24 + 2 + 11);

--- a/test/transport/PayloadTest.cpp
+++ b/test/transport/PayloadTest.cpp
@@ -374,6 +374,8 @@ SCENARIO("test getSerializedSizeOf method") {
     String b = "test getSerializedSizeOf method";
     boost::multiprecision::cpp_dec_float_50 c("1333666666.0000001111");
     boost::multiprecision::cpp_dec_float_100 c1("1333666666.00000011114444");
+    Binary c2("abcd", 4); // can't create a float with this string
+    Binary c3("aaaa", 4);
     std::set<int16_t> d{
         1, 2, 3, 4, 5
     };
@@ -407,6 +409,8 @@ SCENARIO("test getSerializedSizeOf method") {
     src.write(b);
     src.write(c);
     src.write(c1);
+    src.write(c2);
+    src.write(c3);
     src.write(d);
     src.write(e);
     src.write(f);
@@ -423,6 +427,11 @@ SCENARIO("test getSerializedSizeOf method") {
     src.skip<boost::multiprecision::cpp_dec_float_50>();
     REQUIRE(src.getSerializedSizeOf<boost::multiprecision::cpp_dec_float_100>() == sizeof(size_t) + c1.str().size() + 1);
     src.skip<boost::multiprecision::cpp_dec_float_100>();
+    boost::multiprecision::cpp_dec_float_50 c2Read;
+    boost::multiprecision::cpp_dec_float_100 c3Read;
+    REQUIRE(src.read(c2Read) == false);
+    REQUIRE(src.read(c3Read) == false);
+
     REQUIRE(src.getSerializedSizeOf<std::set<int16_t>>() == sizeof(uint32_t) + d.size() * sizeof(int16_t));
     src.skip<std::set<int16_t>>();
     REQUIRE(src.getSerializedSizeOf<std::map<int16_t, String>>() == sizeof(uint32_t) + 2 + 9 + 2 + 24 + 2 + 11);

--- a/test/transport/PayloadTest.cpp
+++ b/test/transport/PayloadTest.cpp
@@ -373,11 +373,11 @@ SCENARIO("test getSerializedSizeOf method") {
     char a = 'a';
     String b = "test getSerializedSizeOf method";
     
-    boost::multiprecision::cpp_dec_float_25 c0("122333.0000001111");
-    boost::multiprecision::cpp_dec_float_50 c1("1333666666.0000001111");
-    boost::multiprecision::cpp_dec_float_100 c2("1333666666.00000011114444");
-    boost::multiprecision::cpp_dec_float_50 c3 = std::numeric_limits<boost::multiprecision::cpp_dec_float_50>::min();
-    boost::multiprecision::cpp_dec_float_50 c4 = std::numeric_limits<boost::multiprecision::cpp_dec_float_50>::max();
+    DecimalD25 c0("122333.0000001111");
+    DecimalD50 c1("1333666666.0000001111");
+    DecimalD100 c2("1333666666.00000011114444");
+    DecimalD50 c3 = std::numeric_limits<DecimalD50>::min();
+    DecimalD50 c4 = std::numeric_limits<DecimalD50>::max();
     
     std::set<int16_t> d{
         1, 2, 3, 4, 5
@@ -427,16 +427,16 @@ SCENARIO("test getSerializedSizeOf method") {
     src.skip<char>();
     REQUIRE(src.getSerializedSizeOf<String>() == sizeof(uint32_t) + b.size() + 1);
     src.skip<String>();
-    REQUIRE(src.getSerializedSizeOf<boost::multiprecision::cpp_dec_float_25>() == sizeof(boost::multiprecision::cpp_dec_float_25));
-    src.skip<boost::multiprecision::cpp_dec_float_25>();
-    REQUIRE(src.getSerializedSizeOf<boost::multiprecision::cpp_dec_float_50>() == sizeof(boost::multiprecision::cpp_dec_float_50));
-    src.skip<boost::multiprecision::cpp_dec_float_50>();
-    REQUIRE(src.getSerializedSizeOf<boost::multiprecision::cpp_dec_float_100>() == sizeof(boost::multiprecision::cpp_dec_float_100));
-    src.skip<boost::multiprecision::cpp_dec_float_100>();
-    REQUIRE(src.getSerializedSizeOf<boost::multiprecision::cpp_dec_float_50>() == sizeof(boost::multiprecision::cpp_dec_float_50));
-    src.skip<boost::multiprecision::cpp_dec_float_50>();
-    REQUIRE(src.getSerializedSizeOf<boost::multiprecision::cpp_dec_float_50>() == sizeof(boost::multiprecision::cpp_dec_float_50));
-    src.skip<boost::multiprecision::cpp_dec_float_50>();
+    REQUIRE(src.getSerializedSizeOf<DecimalD25>() == sizeof(DecimalD25));
+    src.skip<DecimalD25>();
+    REQUIRE(src.getSerializedSizeOf<DecimalD50>() == sizeof(DecimalD50));
+    src.skip<DecimalD50>();
+    REQUIRE(src.getSerializedSizeOf<DecimalD100>() == sizeof(DecimalD100));
+    src.skip<DecimalD100>();
+    REQUIRE(src.getSerializedSizeOf<DecimalD50>() == sizeof(DecimalD50));
+    src.skip<DecimalD50>();
+    REQUIRE(src.getSerializedSizeOf<DecimalD50>() == sizeof(DecimalD50));
+    src.skip<DecimalD50>();
     REQUIRE(src.getSerializedSizeOf<std::set<int16_t>>() == sizeof(uint32_t) + d.size() * sizeof(int16_t));
     src.skip<std::set<int16_t>>();
     REQUIRE(src.getSerializedSizeOf<std::map<int16_t, String>>() == sizeof(uint32_t) + 2 + 9 + 2 + 24 + 2 + 11);

--- a/test/transport/PayloadTest.cpp
+++ b/test/transport/PayloadTest.cpp
@@ -374,6 +374,9 @@ SCENARIO("test getSerializedSizeOf method") {
     String b = "test getSerializedSizeOf method";
     boost::multiprecision::cpp_dec_float_50 c("1333666666.0000001111");
     boost::multiprecision::cpp_dec_float_100 c1("1333666666.00000011114444");
+    boost::multiprecision::cpp_dec_float_50 c2 = std::numeric_limits<boost::multiprecision::cpp_dec_float_50>::min();
+    boost::multiprecision::cpp_dec_float_50 c3 = std::numeric_limits<boost::multiprecision::cpp_dec_float_50>::max();
+    
     std::set<int16_t> d{
         1, 2, 3, 4, 5
     };
@@ -407,6 +410,8 @@ SCENARIO("test getSerializedSizeOf method") {
     src.write(b);
     src.write(c);
     src.write(c1);
+    src.write(c2);
+    src.write(c3);
     src.write(d);
     src.write(e);
     src.write(f);
@@ -423,6 +428,10 @@ SCENARIO("test getSerializedSizeOf method") {
     src.skip<boost::multiprecision::cpp_dec_float_50>();
     REQUIRE(src.getSerializedSizeOf<boost::multiprecision::cpp_dec_float_100>() == sizeof(boost::multiprecision::cpp_dec_float_100));
     src.skip<boost::multiprecision::cpp_dec_float_100>();
+    REQUIRE(src.getSerializedSizeOf<boost::multiprecision::cpp_dec_float_50>() == sizeof(boost::multiprecision::cpp_dec_float_50));
+    src.skip<boost::multiprecision::cpp_dec_float_50>();
+    REQUIRE(src.getSerializedSizeOf<boost::multiprecision::cpp_dec_float_50>() == sizeof(boost::multiprecision::cpp_dec_float_50));
+    src.skip<boost::multiprecision::cpp_dec_float_50>();
     REQUIRE(src.getSerializedSizeOf<std::set<int16_t>>() == sizeof(uint32_t) + d.size() * sizeof(int16_t));
     src.skip<std::set<int16_t>>();
     REQUIRE(src.getSerializedSizeOf<std::map<int16_t, String>>() == sizeof(uint32_t) + 2 + 9 + 2 + 24 + 2 + 11);


### PR DESCRIPTION
Using memcpy to directly write and read cpp_dec_float types.

Assert sizeof(cpp_dec_float_50) == 56 and sizeof(cpp_dec_float_100) == 80
when write the float types.