### PR TITLE
Add unsigned integer types

### DIFF
--- a/docs/design/FILTER_EXPRESSIONS.md
+++ b/docs/design/FILTER_EXPRESSIONS.md
@@ -9,8 +9,8 @@ Operator := EQ | GT | GTE | LT | LTE | IS_NULL | IS_EXACT_TYPE | STARTS_WITH | C
 Operand := Value | Expression
 Value := Reference | Literal
 Literal := FieldType, CPPBuiltInValueOfType
-FieldType := "INT16T" | "INT32T" | "INT64_T" | "FLOAT" | "DOUBLE" | "BOOL" | "STRING" | "DECIMALD25" | "DECIMALD50" | "DECIMALD100" | "FIELD_TYPE" | "NULL_T"
-CPPBuiltInValueOfType := int16_t | int32_t | int64_t | float | double | bool | string | boost::multiprecision::number<cpp_dec_float<25> > | boost::multiprecision::cpp_dec_float_50 | boost::multiprecision::cpp_dec_float_100 | k2::dto::FieldType | null
+FieldType := "INT16T" | "INT32T" | "INT64T" | "UINT16T" | "UINT32T" | "UINT64T" | "FLOAT" | "DOUBLE" | "BOOL" | "STRING" | "DECIMALD25" | "DECIMALD50" | "DECIMALD100" | "FIELD_TYPE" | "NULL_T"
+CPPBuiltInValueOfType := int16_t | int32_t | int64_t | uint16_t | uint32_t | uint64_t | float | double | bool | string | boost::multiprecision::number<cpp_dec_float<25> > | boost::multiprecision::cpp_dec_float_50 | boost::multiprecision::cpp_dec_float_100 | k2::dto::FieldType | null
 Reference := FieldName
 FieldName := string
 ```

--- a/src/k2/dto/Expression.cpp
+++ b/src/k2/dto/Expression.cpp
@@ -79,55 +79,16 @@ struct is_comparable : std::false_type {};
 template <typename T1, typename T2>
 struct is_comparable<T1, T2,
                      decltype(
-                         (std::declval<T1>() == std::declval<T2>()) &&
-                         (std::declval<T1>() < std::declval<T2>()) &&
-                         (std::declval<T1>() <= std::declval<T2>()) &&
-                         (std::declval<T1>() >= std::declval<T2>()) &&
-                         (std::declval<T1>() > std::declval<T2>()),
-                         void())>
+                        (std::declval<T1>() == std::declval<T2>()) &&
+                        (std::declval<T1>() < std::declval<T2>()) &&
+                        (std::declval<T1>() <= std::declval<T2>()) &&
+                        (std::declval<T1>() >= std::declval<T2>()) &&
+                        (std::declval<T1>() > std::declval<T2>()),
+                        std::enable_if_t<
+                            std::is_same_v<typename std::is_signed<T1>::type, typename std::is_signed<T2>::type> &&
+                            std::is_floating_point_v<T1> == std::is_floating_point_v<T2>, 
+                            void>())>
     : std::true_type {};
-
-
-/*
-template <> struct is_comparable<int16_t, int16_t> : std::true_type {};
-template <> struct is_comparable<int16_t, int32_t> : std::true_type {};
-template <> struct is_comparable<int16_t, int64_t> : std::true_type {};
-template <> struct is_comparable<int32_t, int16_t> : std::true_type {};
-template <> struct is_comparable<int32_t, int32_t> : std::true_type {};
-template <> struct is_comparable<int32_t, int64_t> : std::true_type {};
-template <> struct is_comparable<int64_t, int16_t> : std::true_type {};
-template <> struct is_comparable<int64_t, int32_t> : std::true_type {};
-template <> struct is_comparable<int64_t, int64_t> : std::true_type {};
-template <> struct is_comparable<uint16_t, uint16_t> : std::true_type {};
-template <> struct is_comparable<uint16_t, uint32_t> : std::true_type {};
-template <> struct is_comparable<uint16_t, uint64_t> : std::true_type {};
-template <> struct is_comparable<uint32_t, uint16_t> : std::true_type {};
-template <> struct is_comparable<uint32_t, uint32_t> : std::true_type {};
-template <> struct is_comparable<uint32_t, uint64_t> : std::true_type {};
-template <> struct is_comparable<uint64_t, uint16_t> : std::true_type {};
-template <> struct is_comparable<uint64_t, uint32_t> : std::true_type {};
-template <> struct is_comparable<uint64_t, uint64_t> : std::true_type {};
-*/
-
-template <> struct is_comparable<int16_t, uint16_t> : std::false_type {};
-template <> struct is_comparable<int16_t, uint32_t> : std::false_type {};
-template <> struct is_comparable<int16_t, uint64_t> : std::false_type {};
-template <> struct is_comparable<int32_t, uint16_t> : std::false_type {};
-template <> struct is_comparable<int32_t, uint32_t> : std::false_type {};
-template <> struct is_comparable<int32_t, uint64_t> : std::false_type {};
-template <> struct is_comparable<int64_t, uint16_t> : std::false_type {};
-template <> struct is_comparable<int64_t, uint32_t> : std::false_type {};
-template <> struct is_comparable<int64_t, uint64_t> : std::false_type {};
-
-template <> struct is_comparable<uint16_t, int16_t> : std::false_type {};
-template <> struct is_comparable<uint16_t, int32_t> : std::false_type {};
-template <> struct is_comparable<uint16_t, int64_t> : std::false_type {};
-template <> struct is_comparable<uint32_t, int16_t> : std::false_type {};
-template <> struct is_comparable<uint32_t, int32_t> : std::false_type {};
-template <> struct is_comparable<uint32_t, int64_t> : std::false_type {};
-template <> struct is_comparable<uint64_t, int16_t> : std::false_type {};
-template <> struct is_comparable<uint64_t, int32_t> : std::false_type {};
-template <> struct is_comparable<uint64_t, int64_t> : std::false_type {};
 
 // template specialization comparing two optionals of non-comparable types
 template <typename T1, typename T2>

--- a/src/k2/dto/Expression.cpp
+++ b/src/k2/dto/Expression.cpp
@@ -87,6 +87,48 @@ struct is_comparable<T1, T2,
                          void())>
     : std::true_type {};
 
+
+/*
+template <> struct is_comparable<int16_t, int16_t> : std::true_type {};
+template <> struct is_comparable<int16_t, int32_t> : std::true_type {};
+template <> struct is_comparable<int16_t, int64_t> : std::true_type {};
+template <> struct is_comparable<int32_t, int16_t> : std::true_type {};
+template <> struct is_comparable<int32_t, int32_t> : std::true_type {};
+template <> struct is_comparable<int32_t, int64_t> : std::true_type {};
+template <> struct is_comparable<int64_t, int16_t> : std::true_type {};
+template <> struct is_comparable<int64_t, int32_t> : std::true_type {};
+template <> struct is_comparable<int64_t, int64_t> : std::true_type {};
+template <> struct is_comparable<uint16_t, uint16_t> : std::true_type {};
+template <> struct is_comparable<uint16_t, uint32_t> : std::true_type {};
+template <> struct is_comparable<uint16_t, uint64_t> : std::true_type {};
+template <> struct is_comparable<uint32_t, uint16_t> : std::true_type {};
+template <> struct is_comparable<uint32_t, uint32_t> : std::true_type {};
+template <> struct is_comparable<uint32_t, uint64_t> : std::true_type {};
+template <> struct is_comparable<uint64_t, uint16_t> : std::true_type {};
+template <> struct is_comparable<uint64_t, uint32_t> : std::true_type {};
+template <> struct is_comparable<uint64_t, uint64_t> : std::true_type {};
+*/
+
+template <> struct is_comparable<int16_t, uint16_t> : std::false_type {};
+template <> struct is_comparable<int16_t, uint32_t> : std::false_type {};
+template <> struct is_comparable<int16_t, uint64_t> : std::false_type {};
+template <> struct is_comparable<int32_t, uint16_t> : std::false_type {};
+template <> struct is_comparable<int32_t, uint32_t> : std::false_type {};
+template <> struct is_comparable<int32_t, uint64_t> : std::false_type {};
+template <> struct is_comparable<int64_t, uint16_t> : std::false_type {};
+template <> struct is_comparable<int64_t, uint32_t> : std::false_type {};
+template <> struct is_comparable<int64_t, uint64_t> : std::false_type {};
+
+template <> struct is_comparable<uint16_t, int16_t> : std::false_type {};
+template <> struct is_comparable<uint16_t, int32_t> : std::false_type {};
+template <> struct is_comparable<uint16_t, int64_t> : std::false_type {};
+template <> struct is_comparable<uint32_t, int16_t> : std::false_type {};
+template <> struct is_comparable<uint32_t, int32_t> : std::false_type {};
+template <> struct is_comparable<uint32_t, int64_t> : std::false_type {};
+template <> struct is_comparable<uint64_t, int16_t> : std::false_type {};
+template <> struct is_comparable<uint64_t, int32_t> : std::false_type {};
+template <> struct is_comparable<uint64_t, int64_t> : std::false_type {};
+
 // template specialization comparing two optionals of non-comparable types
 template <typename T1, typename T2>
 std::enable_if_t<!is_comparable<T1, T2>::value, int>

--- a/src/k2/dto/FieldTypes.cpp
+++ b/src/k2/dto/FieldTypes.cpp
@@ -44,6 +44,9 @@ template <> FieldType TToFieldType<String>() { return FieldType::STRING; }
 template <> FieldType TToFieldType<int16_t>() { return FieldType::INT16T; }
 template <> FieldType TToFieldType<int32_t>() { return FieldType::INT32T; }
 template <> FieldType TToFieldType<int64_t>() { return FieldType::INT64T; }
+template <> FieldType TToFieldType<uint16_t>() { return FieldType::UINT16T; }
+template <> FieldType TToFieldType<uint32_t>() { return FieldType::UINT32T; }
+template <> FieldType TToFieldType<uint64_t>() { return FieldType::UINT64T; }
 template <> FieldType TToFieldType<float>() { return FieldType::FLOAT; }
 template <> FieldType TToFieldType<double>() { return FieldType::DOUBLE; }
 template <> FieldType TToFieldType<bool>() { return FieldType::BOOL; }
@@ -181,6 +184,47 @@ template <> String FieldToKeyString<int32_t>(const int32_t& field) {
     s[6] = ESCAPE;
     s[7] = TERM;
 
+    return s;
+}
+
+template <> String FieldToKeyString<uint16_t>(const uint16_t& field) {
+    // type byte + 2 bytes + ESCAPE + TERM
+    String s(String::initialized_later(), 5);
+    s[0] = (char) FieldType::UINT16T;
+    s[1] = (char)(field >> 8);
+    s[2] = (char)(field);
+    s[3] = ESCAPE;
+    s[4] = TERM;
+    return s;
+}
+
+template <> String FieldToKeyString<uint32_t>(const uint32_t& field) {
+    // type byte + 4 bytes + ESCAPE + TERM
+    String s(String::initialized_later(), 7);
+    s[0] = (char) FieldType::UINT32T;
+    s[1] = (char)(field >> 24);
+    s[2] = (char)(field >> 16);
+    s[3] = (char)(field >> 8);
+    s[4] = (char)(field);
+    s[5] = ESCAPE;
+    s[6] = TERM;
+    return s;
+}
+
+template <> String FieldToKeyString<uint64_t>(const uint64_t& field) {
+    // type byte + 8 bytes + ESCAPE + TERM
+    String s(String::initialized_later(), 11);
+    s[0] = (char) FieldType::UINT64T;
+    s[1] = (char)(field >> 56);
+    s[2] = (char)(field >> 48);
+    s[3] = (char)(field >> 40);
+    s[4] = (char)(field >> 32);
+    s[5] = (char)(field >> 24);
+    s[6] = (char)(field >> 16);
+    s[7] = (char)(field >> 8);
+    s[8] = (char)(field);
+    s[9] = ESCAPE;
+    s[10] = TERM;
     return s;
 }
 

--- a/src/k2/dto/FieldTypes.h
+++ b/src/k2/dto/FieldTypes.h
@@ -63,6 +63,9 @@ enum class FieldType : uint8_t {
     INT16T,
     INT32T,
     INT64T,
+    UINT16T,
+    UINT32T,
+    UINT64T,
     FLOAT, // Not supported as key field for now
     DOUBLE,  // Not supported as key field for now
     BOOL,
@@ -85,6 +88,9 @@ String FieldToKeyString(const T&);
 template<> String FieldToKeyString<int16_t>(const int16_t&);
 template<> String FieldToKeyString<int32_t>(const int32_t&);
 template<> String FieldToKeyString<int64_t>(const int64_t&);
+template<> String FieldToKeyString<uint16_t>(const uint16_t&);
+template<> String FieldToKeyString<uint32_t>(const uint32_t&);
+template<> String FieldToKeyString<uint64_t>(const uint64_t&);
 template<> String FieldToKeyString<String>(const String&);
 template<> String FieldToKeyString<bool>(const bool&);
 
@@ -135,6 +141,15 @@ bool isNan(const T& field){
             case k2::dto::FieldType::INT64T: {                      \
                 func<int64_t>((a), __VA_ARGS__);                    \
             } break;                                                \
+            case k2::dto::FieldType::UINT16T: {                     \
+                func<uint16_t>((a), __VA_ARGS__);                   \
+            } break;                                                \
+            case k2::dto::FieldType::UINT32T: {                     \
+                func<uint32_t>((a), __VA_ARGS__);                   \
+            } break;                                                \
+            case k2::dto::FieldType::UINT64T: {                     \
+                func<uint64_t>((a), __VA_ARGS__);                   \
+            } break;                                                \
             case k2::dto::FieldType::FLOAT: {                       \
                 func<float>((a), __VA_ARGS__);                      \
             } break;                                                \
@@ -176,6 +191,12 @@ namespace std {
             return os << "INT32T";
         case k2::dto::FieldType::INT64T:
             return os << "INT64T";
+        case k2::dto::FieldType::UINT16T:
+            return os << "UINT16T";
+        case k2::dto::FieldType::UINT32T:
+            return os << "UINT32T";
+        case k2::dto::FieldType::UINT64T:
+            return os << "UINT64T";
         case k2::dto::FieldType::FLOAT:
             return os << "FLOAT";
         case k2::dto::FieldType::DOUBLE:

--- a/src/k2/dto/SKVRecord.h
+++ b/src/k2/dto/SKVRecord.h
@@ -278,6 +278,18 @@ private:
                 std::optional<int64_t> value = (record).deserializeNext<int64_t>();                                   \
                 func<int64_t>(std::move(value), field.name, __VA_ARGS__);                                             \
             } break;                                                                                                  \
+            case k2::dto::FieldType::UINT16T: {                                                                        \
+                std::optional<uint16_t> value = (record).deserializeNext<uint16_t>();                                   \
+                func<uint16_t>(std::move(value), field.name, __VA_ARGS__);                                             \
+            } break;                                                                                                  \
+            case k2::dto::FieldType::UINT32T: {                                                                        \
+                std::optional<uint32_t> value = (record).deserializeNext<uint32_t>();                                   \
+                func<uint32_t>(std::move(value), field.name, __VA_ARGS__);                                             \
+            } break;                                                                                                  \
+            case k2::dto::FieldType::UINT64T: {                                                                        \
+                std::optional<uint64_t> value = (record).deserializeNext<uint64_t>();                                   \
+                func<uint64_t>(std::move(value), field.name, __VA_ARGS__);                                             \
+            } break;                                                                                                  \
             case k2::dto::FieldType::FLOAT: {                                                                         \
                 std::optional<float> value = (record).deserializeNext<float>();                                       \
                 func<float>(std::move(value), field.name, __VA_ARGS__);                                               \

--- a/src/skvhttpclient/src/skvhttp/dto/Expression.cpp
+++ b/src/skvhttpclient/src/skvhttp/dto/Expression.cpp
@@ -72,56 +72,16 @@ struct is_comparable : std::false_type {};
 template <typename T1, typename T2>
 struct is_comparable<T1, T2,
                      decltype(
-                         (std::declval<T1>() == std::declval<T2>()) &&
-                         (std::declval<T1>() < std::declval<T2>()) &&
-                         (std::declval<T1>() <= std::declval<T2>()) &&
-                         (std::declval<T1>() >= std::declval<T2>()) &&
-                         (std::declval<T1>() > std::declval<T2>()) &&
-                         (std::is_signed<T1>::value == std::is_signed<T2>::value),
-                         void())>
+                        (std::declval<T1>() == std::declval<T2>()) &&
+                        (std::declval<T1>() < std::declval<T2>()) &&
+                        (std::declval<T1>() <= std::declval<T2>()) &&
+                        (std::declval<T1>() >= std::declval<T2>()) &&
+                        (std::declval<T1>() > std::declval<T2>()),
+                        std::enable_if_t<
+                            std::is_same_v<typename std::is_signed<T1>::type, typename std::is_signed<T2>::type> &&
+                            std::is_floating_point_v<T1> == std::is_floating_point_v<T2>, 
+                            void>())>
     : std::true_type {};
-
-
-/*
-template <> struct is_comparable<int16_t, int16_t> : std::true_type {};
-template <> struct is_comparable<int16_t, int32_t> : std::true_type {};
-template <> struct is_comparable<int16_t, int64_t> : std::true_type {};
-template <> struct is_comparable<int32_t, int16_t> : std::true_type {};
-template <> struct is_comparable<int32_t, int32_t> : std::true_type {};
-template <> struct is_comparable<int32_t, int64_t> : std::true_type {};
-template <> struct is_comparable<int64_t, int16_t> : std::true_type {};
-template <> struct is_comparable<int64_t, int32_t> : std::true_type {};
-template <> struct is_comparable<int64_t, int64_t> : std::true_type {};
-template <> struct is_comparable<uint16_t, uint16_t> : std::true_type {};
-template <> struct is_comparable<uint16_t, uint32_t> : std::true_type {};
-template <> struct is_comparable<uint16_t, uint64_t> : std::true_type {};
-template <> struct is_comparable<uint32_t, uint16_t> : std::true_type {};
-template <> struct is_comparable<uint32_t, uint32_t> : std::true_type {};
-template <> struct is_comparable<uint32_t, uint64_t> : std::true_type {};
-template <> struct is_comparable<uint64_t, uint16_t> : std::true_type {};
-template <> struct is_comparable<uint64_t, uint32_t> : std::true_type {};
-template <> struct is_comparable<uint64_t, uint64_t> : std::true_type {};
-*/
-
-template <> struct is_comparable<int16_t, uint16_t> : std::false_type {};
-template <> struct is_comparable<int16_t, uint32_t> : std::false_type {};
-template <> struct is_comparable<int16_t, uint64_t> : std::false_type {};
-template <> struct is_comparable<int32_t, uint16_t> : std::false_type {};
-template <> struct is_comparable<int32_t, uint32_t> : std::false_type {};
-template <> struct is_comparable<int32_t, uint64_t> : std::false_type {};
-template <> struct is_comparable<int64_t, uint16_t> : std::false_type {};
-template <> struct is_comparable<int64_t, uint32_t> : std::false_type {};
-template <> struct is_comparable<int64_t, uint64_t> : std::false_type {};
-
-template <> struct is_comparable<uint16_t, int16_t> : std::false_type {};
-template <> struct is_comparable<uint16_t, int32_t> : std::false_type {};
-template <> struct is_comparable<uint16_t, int64_t> : std::false_type {};
-template <> struct is_comparable<uint32_t, int16_t> : std::false_type {};
-template <> struct is_comparable<uint32_t, int32_t> : std::false_type {};
-template <> struct is_comparable<uint32_t, int64_t> : std::false_type {};
-template <> struct is_comparable<uint64_t, int16_t> : std::false_type {};
-template <> struct is_comparable<uint64_t, int32_t> : std::false_type {};
-template <> struct is_comparable<uint64_t, int64_t> : std::false_type {};
 
 // template specialization comparing two optionals of non-comparable types
 template <typename T1, typename T2>

--- a/src/skvhttpclient/src/skvhttp/dto/Expression.cpp
+++ b/src/skvhttpclient/src/skvhttp/dto/Expression.cpp
@@ -76,9 +76,52 @@ struct is_comparable<T1, T2,
                          (std::declval<T1>() < std::declval<T2>()) &&
                          (std::declval<T1>() <= std::declval<T2>()) &&
                          (std::declval<T1>() >= std::declval<T2>()) &&
-                         (std::declval<T1>() > std::declval<T2>()),
+                         (std::declval<T1>() > std::declval<T2>()) &&
+                         (std::is_signed<T1>::value == std::is_signed<T2>::value),
                          void())>
     : std::true_type {};
+
+
+/*
+template <> struct is_comparable<int16_t, int16_t> : std::true_type {};
+template <> struct is_comparable<int16_t, int32_t> : std::true_type {};
+template <> struct is_comparable<int16_t, int64_t> : std::true_type {};
+template <> struct is_comparable<int32_t, int16_t> : std::true_type {};
+template <> struct is_comparable<int32_t, int32_t> : std::true_type {};
+template <> struct is_comparable<int32_t, int64_t> : std::true_type {};
+template <> struct is_comparable<int64_t, int16_t> : std::true_type {};
+template <> struct is_comparable<int64_t, int32_t> : std::true_type {};
+template <> struct is_comparable<int64_t, int64_t> : std::true_type {};
+template <> struct is_comparable<uint16_t, uint16_t> : std::true_type {};
+template <> struct is_comparable<uint16_t, uint32_t> : std::true_type {};
+template <> struct is_comparable<uint16_t, uint64_t> : std::true_type {};
+template <> struct is_comparable<uint32_t, uint16_t> : std::true_type {};
+template <> struct is_comparable<uint32_t, uint32_t> : std::true_type {};
+template <> struct is_comparable<uint32_t, uint64_t> : std::true_type {};
+template <> struct is_comparable<uint64_t, uint16_t> : std::true_type {};
+template <> struct is_comparable<uint64_t, uint32_t> : std::true_type {};
+template <> struct is_comparable<uint64_t, uint64_t> : std::true_type {};
+*/
+
+template <> struct is_comparable<int16_t, uint16_t> : std::false_type {};
+template <> struct is_comparable<int16_t, uint32_t> : std::false_type {};
+template <> struct is_comparable<int16_t, uint64_t> : std::false_type {};
+template <> struct is_comparable<int32_t, uint16_t> : std::false_type {};
+template <> struct is_comparable<int32_t, uint32_t> : std::false_type {};
+template <> struct is_comparable<int32_t, uint64_t> : std::false_type {};
+template <> struct is_comparable<int64_t, uint16_t> : std::false_type {};
+template <> struct is_comparable<int64_t, uint32_t> : std::false_type {};
+template <> struct is_comparable<int64_t, uint64_t> : std::false_type {};
+
+template <> struct is_comparable<uint16_t, int16_t> : std::false_type {};
+template <> struct is_comparable<uint16_t, int32_t> : std::false_type {};
+template <> struct is_comparable<uint16_t, int64_t> : std::false_type {};
+template <> struct is_comparable<uint32_t, int16_t> : std::false_type {};
+template <> struct is_comparable<uint32_t, int32_t> : std::false_type {};
+template <> struct is_comparable<uint32_t, int64_t> : std::false_type {};
+template <> struct is_comparable<uint64_t, int16_t> : std::false_type {};
+template <> struct is_comparable<uint64_t, int32_t> : std::false_type {};
+template <> struct is_comparable<uint64_t, int64_t> : std::false_type {};
 
 // template specialization comparing two optionals of non-comparable types
 template <typename T1, typename T2>

--- a/src/skvhttpclient/src/skvhttp/dto/FieldTypes.cpp
+++ b/src/skvhttpclient/src/skvhttp/dto/FieldTypes.cpp
@@ -41,6 +41,9 @@ template <> FieldType TToFieldType<String>() { return FieldType::STRING; }
 template <> FieldType TToFieldType<int16_t>() { return FieldType::INT16T; }
 template <> FieldType TToFieldType<int32_t>() { return FieldType::INT32T; }
 template <> FieldType TToFieldType<int64_t>() { return FieldType::INT64T; }
+template <> FieldType TToFieldType<uint16_t>() { return FieldType::UINT16T; }
+template <> FieldType TToFieldType<uint32_t>() { return FieldType::UINT32T; }
+template <> FieldType TToFieldType<uint64_t>() { return FieldType::UINT64T; }
 template <> FieldType TToFieldType<float>() { return FieldType::FLOAT; }
 template <> FieldType TToFieldType<double>() { return FieldType::DOUBLE; }
 template <> FieldType TToFieldType<bool>() { return FieldType::BOOL; }
@@ -182,6 +185,50 @@ template <> String FieldToKeyString<int32_t>(const int32_t& field) {
     s[6] = ESCAPE;
     s[7] = TERM;
 
+    return s;
+}
+
+template <> String FieldToKeyString<uint16_t>(const uint16_t& field) {
+    // type byte + 2 bytes + ESCAPE + TERM
+    String s;
+    s.resize(5);
+    s[0] = (char) FieldType::UINT16T;
+    s[1] = (char)(field >> 8);
+    s[2] = (char)(field);
+    s[3] = ESCAPE;
+    s[4] = TERM;
+    return s;
+}
+
+template <> String FieldToKeyString<uint32_t>(const uint32_t& field) {
+    // type byte + 4 bytes + ESCAPE + TERM
+    String s;
+    s.resize(7);
+    s[0] = (char) FieldType::UINT32T;
+    s[1] = (char)(field >> 24);
+    s[2] = (char)(field >> 16);
+    s[3] = (char)(field >> 8);
+    s[4] = (char)(field);
+    s[5] = ESCAPE;
+    s[6] = TERM;
+    return s;
+}
+
+template <> String FieldToKeyString<uint64_t>(const uint64_t& field) {
+    // type byte + 8 bytes + ESCAPE + TERM
+    String s;
+    s.resize(11);
+    s[0] = (char) FieldType::UINT64T;
+    s[1] = (char)(field >> 56);
+    s[2] = (char)(field >> 48);
+    s[3] = (char)(field >> 40);
+    s[4] = (char)(field >> 32);
+    s[5] = (char)(field >> 24);
+    s[6] = (char)(field >> 16);
+    s[7] = (char)(field >> 8);
+    s[8] = (char)(field);
+    s[9] = ESCAPE;
+    s[10] = TERM;
     return s;
 }
 

--- a/src/skvhttpclient/src/skvhttp/dto/FieldTypes.h
+++ b/src/skvhttpclient/src/skvhttp/dto/FieldTypes.h
@@ -62,6 +62,9 @@ enum class FieldType : uint8_t {
     INT16T,
     INT32T,
     INT64T,
+    UINT16T,
+    UINT32T,
+    UINT64T,
     FLOAT, // Not supported as key field for now
     DOUBLE,  // Not supported as key field for now
     BOOL,
@@ -84,6 +87,9 @@ String FieldToKeyString(const T&);
 template<> String FieldToKeyString<int16_t>(const int16_t&);
 template<> String FieldToKeyString<int32_t>(const int32_t&);
 template<> String FieldToKeyString<int64_t>(const int64_t&);
+template<> String FieldToKeyString<uint16_t>(const uint16_t&);
+template<> String FieldToKeyString<uint32_t>(const uint32_t&);
+template<> String FieldToKeyString<uint64_t>(const uint64_t&);
 template<> String FieldToKeyString<String>(const String&);
 template<> String FieldToKeyString<bool>(const bool&);
 
@@ -151,6 +157,15 @@ auto applyTyped(const FieldT& field, Func&& applier, Args&&... args) {
         case FieldType::INT64T: {
             return applier(AppliedFieldRef<int64_t, FieldT>(field), std::forward<Args>(args)...);
         }
+        case FieldType::UINT16T: {
+            return applier(AppliedFieldRef<uint16_t, FieldT>(field), std::forward<Args>(args)...);
+        }
+        case FieldType::UINT32T: {
+            return applier(AppliedFieldRef<uint32_t, FieldT>(field), std::forward<Args>(args)...);
+        }
+        case FieldType::UINT64T: {
+            return applier(AppliedFieldRef<uint64_t, FieldT>(field), std::forward<Args>(args)...);
+        }
         case FieldType::FLOAT: {
             return applier(AppliedFieldRef<float, FieldT>(field), std::forward<Args>(args)...);
         }
@@ -193,6 +208,12 @@ namespace std {
             return os << "INT32T";
         case skv::http::dto::FieldType::INT64T:
             return os << "INT64T";
+        case skv::http::dto::FieldType::UINT16T:
+            return os << "UINT16T";
+        case skv::http::dto::FieldType::UINT32T:
+            return os << "UINT32T";
+        case skv::http::dto::FieldType::UINT64T:
+            return os << "UINT64T";
         case skv::http::dto::FieldType::FLOAT:
             return os << "FLOAT";
         case skv::http::dto::FieldType::DOUBLE:

--- a/test/k23si/KeyEncodingTest.cpp
+++ b/test/k23si/KeyEncodingTest.cpp
@@ -319,3 +319,64 @@ TEST_CASE("Test7: int32 and NULL key ordering with NULL last key order") {
     REQUIRE(smallKey < bigKey);
     REQUIRE(bigKey < nullKey);
 }
+
+TEST_CASE("Test8: unsigned int key ordering") {
+    k2::dto::Schema schema;
+    schema.name = "uint16";
+    schema.version = 1;
+    schema.fields = std::vector<k2::dto::SchemaField> {
+            {k2::dto::FieldType::UINT16T, "ID", false, false},
+    };
+    schema.setPartitionKeyFieldsByName(std::vector<k2::String>{"ID"});
+    std::shared_ptr<k2::dto::Schema> schemau16 = std::make_shared<k2::dto::Schema>(std::move(schema));
+
+    schema.name = "uint32";
+    schema.version = 1;
+    schema.fields = std::vector<k2::dto::SchemaField> {
+            {k2::dto::FieldType::UINT32T, "ID", false, false},
+    };
+    schema.setPartitionKeyFieldsByName(std::vector<k2::String>{"ID"});
+    std::shared_ptr<k2::dto::Schema> schemau32 = std::make_shared<k2::dto::Schema>(std::move(schema));
+
+    schema.name = "uint64";
+    schema.version = 1;
+    schema.fields = std::vector<k2::dto::SchemaField> {
+            {k2::dto::FieldType::UINT64T, "ID", false, false},
+    };
+    schema.setPartitionKeyFieldsByName(std::vector<k2::String>{"ID"});
+    std::shared_ptr<k2::dto::Schema> schemau64 = std::make_shared<k2::dto::Schema>(std::move(schema));
+
+    std::vector<std::shared_ptr<k2::dto::Schema>> schemas;
+    schemas.push_back(schemau16);
+    schemas.push_back(schemau32);
+    schemas.push_back(schemau64);
+
+    for (std::shared_ptr<k2::dto::Schema>& s : schemas) {
+        k2::dto::SKVRecord zero("collection", s);
+        k2::dto::SKVRecord small("collection", s);
+        k2::dto::SKVRecord large("collection", s);
+
+        if (s->name == "uint16") {
+            zero.serializeNext<uint16_t>(0);
+            large.serializeNext<uint16_t>(1001);
+            small.serializeNext<uint16_t>(21);
+        }
+        else if (s->name == "uint32") {
+            zero.serializeNext<uint32_t>(0);
+            large.serializeNext<uint32_t>(10010);
+            small.serializeNext<uint32_t>(21);
+        }
+        else if (s->name == "uint64") {
+            zero.serializeNext<uint64_t>(0);
+            large.serializeNext<uint64_t>(100100);
+            small.serializeNext<uint64_t>(21);
+        }
+
+        k2::String zero_s = zero.getPartitionKey();
+        k2::String large_s = large.getPartitionKey();
+        k2::String small_s = small.getPartitionKey();
+
+        REQUIRE(zero_s < small_s);
+        REQUIRE(small_s < large_s);
+    }
+}

--- a/test/k23si/QueryTest.cpp
+++ b/test/k23si/QueryTest.cpp
@@ -90,7 +90,7 @@ public:  // application lifespan
                     {k2::dto::FieldType::STRING, "range", false, false},
                     {k2::dto::FieldType::INT32T, "data1", false, false},
                     {k2::dto::FieldType::INT32T, "data2", false, false},
-                    {k2::dto::FieldType::UINT32T, "data2", false, false}
+                    {k2::dto::FieldType::UINT32T, "data3", false, false}
             };
 
             schema.setPartitionKeyFieldsByName(std::vector<k2::String>{"partition", "partition2"});

--- a/test/k23si/QueryTest.cpp
+++ b/test/k23si/QueryTest.cpp
@@ -89,7 +89,8 @@ public:  // application lifespan
                     {k2::dto::FieldType::STRING, "partition2", false, false},
                     {k2::dto::FieldType::STRING, "range", false, false},
                     {k2::dto::FieldType::INT32T, "data1", false, false},
-                    {k2::dto::FieldType::INT32T, "data2", false, false}
+                    {k2::dto::FieldType::INT32T, "data2", false, false},
+                    {k2::dto::FieldType::UINT32T, "data2", false, false}
             };
 
             schema.setPartitionKeyFieldsByName(std::vector<k2::String>{"partition", "partition2"});
@@ -251,6 +252,7 @@ seastar::future<> runSetup() {
             record.serializeNext<k2::String>("");
             record.serializeNext<int32_t>(data);
             record.serializeNext<int32_t>(data);
+            record.serializeNext<uint32_t>(0);
             write_futs.push_back(txn.write<k2::dto::SKVRecord>(record)
                 .then([] (auto&& response) {
                     K2EXPECT(log::k23si, response.status, k2::dto::K23SIStatus::Created);
@@ -266,6 +268,7 @@ seastar::future<> runSetup() {
         record.serializeNext<k2::String>("");
         record.serializeNull();
         record.serializeNext<int32_t>(777);
+        record.serializeNext<uint32_t>(111);
         write_futs.push_back(txn.write<k2::dto::SKVRecord>(record)
             .then([] (auto&& response) {
                 K2EXPECT(log::k23si, response.status, k2::dto::K23SIStatus::Created);
@@ -279,6 +282,7 @@ seastar::future<> runSetup() {
         record2.serializeNext<k2::String>("");
         record2.serializeNull();
         record2.serializeNext<int32_t>(777);
+        record2.serializeNext<uint32_t>(111);
         write_futs.push_back(txn.write<k2::dto::SKVRecord>(record2)
             .then([] (auto&& response) {
                 K2EXPECT(log::k23si, response.status, k2::dto::K23SIStatus::Created);
@@ -569,6 +573,7 @@ seastar::future<> runScenario06() {
         record.serializeNext<k2::String>("");
         record.serializeNull();
         record.serializeNull();
+        record.serializeNull();
         return writeTxn.write<k2::dto::SKVRecord>(record);
     })
     .then([this] (auto&& response) {
@@ -599,6 +604,7 @@ seastar::future<> runScenario06() {
         record.serializeNext<k2::String>("default");
         record.serializeNext<k2::String>("az");
         record.serializeNext<k2::String>("");
+        record.serializeNull();
         record.serializeNull();
         record.serializeNull();
         return writeTxn.write<k2::dto::SKVRecord>(record);
@@ -636,6 +642,7 @@ seastar::future<> runScenario06() {
         record.serializeNext<k2::String>("default");
         record.serializeNext<k2::String>("bz");
         record.serializeNext<k2::String>("");
+        record.serializeNull();
         record.serializeNull();
         record.serializeNull();
         return writeTxn.write<k2::dto::SKVRecord>(record);
@@ -682,6 +689,7 @@ seastar::future<> runScenario07() {
         record.serializeNext<k2::String>("");
         record.serializeNull();
         record.serializeNull();
+        record.serializeNull();
         return writeTxn.write<k2::dto::SKVRecord>(record);
     })
     .then([this] (auto&& response) {
@@ -696,6 +704,7 @@ seastar::future<> runScenario07() {
         record.serializeNext<k2::String>("default");
         record.serializeNext<k2::String>("scenario07");
         record.serializeNext<k2::String>("");
+        record.serializeNull();
         record.serializeNull();
         record.serializeNull();
         return writeTxn.write(record, true /* isDelete */);
@@ -811,6 +820,7 @@ seastar::future<> writeAdditionalData() {
             record.serializeNext<k2::String>("");
             record.serializeNext<int32_t>(i);
             record.serializeNext<int32_t>(data);
+            record.serializeNext<uint32_t>(0);
             write_futs.push_back(txn.write<k2::dto::SKVRecord>(record)
                 .then([] (auto&& response) {
                     K2EXPECT(log::k23si, response.status, k2::dto::K23SIStatus::Created);

--- a/test/k23si/SKVClientTest.cpp
+++ b/test/k23si/SKVClientTest.cpp
@@ -132,6 +132,7 @@ public:  // application lifespan
                         {dto::FieldType::STRING, "2_range", false, false},
                         {dto::FieldType::STRING, "f2_1", false, false},
                         {dto::FieldType::STRING, "f2_2", false, false},
+                        {dto::FieldType::UINT32T, "f2_3", false, false},
                 };
 
                 schema.setPartitionKeyFieldsByName(std::vector<String>{"2_partition"});
@@ -1390,6 +1391,7 @@ seastar::future<> runScenario10() {
                     r2.serializeNext<String>("rangekey10");
                     r2.serializeNext<String>("2_data1");
                     r2.serializeNext<String>("2_data2");
+                    r2.serializeNext<uint32_t>(20);
 
                     K2LOG_D(log::k23si, "serialize r3");
                     dto::SKVRecord r3(collname3, sc3);
@@ -1437,6 +1439,7 @@ seastar::future<> runScenario10() {
                     dto::SKVRecord r2(collname2, sc2);
                     r2.serializeNext<int32_t>(10);
                     r2.serializeNext<String>("rangekey10");
+                    r2.serializeNull();
                     r2.serializeNull();
                     r2.serializeNull();
                     dto::SKVRecord r3(collname3, sc3);

--- a/test/k23si/SKVRecordTest.cpp
+++ b/test/k23si/SKVRecordTest.cpp
@@ -222,14 +222,16 @@ TEST_CASE("Test4: getSKVKeyRecord test") {
     schema.fields = std::vector<k2::dto::SchemaField> {
             {k2::dto::FieldType::STRING, "LastName", false, false},
             {k2::dto::FieldType::STRING, "FirstName", false, false},
-            {k2::dto::FieldType::INT32T, "Balance", false, false}
+            {k2::dto::FieldType::UINT32T, "Due", false, false},
+            {k2::dto::FieldType::INT32T, "Balance", false, false},
     };
     schema.setPartitionKeyFieldsByName(std::vector<k2::String>{"LastName"});
-    schema.setRangeKeyFieldsByName(std::vector<k2::String>{"FirstName"});
+    schema.setRangeKeyFieldsByName(std::vector<k2::String>{"FirstName", "Due"});
 
     k2::dto::SKVRecord doc("collection", std::make_shared<k2::dto::Schema>(schema));
     doc.serializeNull();
     doc.serializeNext<k2::String>("b");
+    doc.serializeNext<uint32_t>(10);
     doc.serializeNext<int32_t>(12);
 
     // Testing a typical use-case of getSKVKeyRecord where the storage is serialized
@@ -249,6 +251,9 @@ TEST_CASE("Test4: getSKVKeyRecord test") {
     std::optional<k2::String> first = reconstructed.deserializeNext<k2::String>();
     REQUIRE(first.has_value());
     REQUIRE(first == "b");
+    std::optional<uint32_t> due = reconstructed.deserializeNext<uint32_t>();
+    REQUIRE(due.has_value());
+    REQUIRE(due == 10);
     std::optional<int32_t> balance = reconstructed.deserializeNext<int32_t>();
     REQUIRE(!balance.has_value());
 }


### PR DESCRIPTION
- Add unsigned integers types, uint16_t, uint32_t, and uint64_t.
- Unsigned integers can serve as key fields.
- Unsigned ints and signed ints are not comparable.
- Floats and (signed/unsigned) ints are not comparable.
- Add unsigned cases in KeyEncodingTest, QueryTest, SKVClientTest, SKVRecordTest.

