### PR TITLE
Fixes for ARM support

### DIFF
--- a/src/k2/cmd/ycsb/data.h
+++ b/src/k2/cmd/ycsb/data.h
@@ -23,7 +23,6 @@ Copyright(c) 2021 Futurewei Cloud
 
 #pragma once
 
-#include <decimal/decimal>
 #include <string>
 
 #include <k2/common/Common.h>

--- a/src/k2/tso/service/Clock.h
+++ b/src/k2/tso/service/Clock.h
@@ -113,16 +113,12 @@ private:
     uint64_t _gpsNow();
     uint64_t _steadyNow();
 
-    // the last time we observed a new atomic clock value
-    // the following, combined with the spin-lock guard should guarantee coherency across threads on X86/64
-    // For other archs, don't compile for now, but we should use an std::atomic instead
-#ifdef __x86_64__
+    // the following, combined with the spin-lock guard should guarantee coherency across threads
     // the current timestamp we use for vending timestamps
-    volatile _GPSNanos _useTs;
+    _GPSNanos _useTs;
 
     // to prevent r-w races when modifying _useTs
     SpinMutex _mutex;
-#endif
 };
 
 // Global instance, shareable among threads


### PR DESCRIPTION
- Remove leftover include of gnu decimal library
- Remove x86 guard around the tso poller synchronization. The spinlock should ensure correctness on ARM as well
- Fix some unspecified execution order bugs in 3si test

Integration and unit tests passing on Mac M1