### PR TITLE
Fix drop collection taking long time in test

### DIFF
--- a/src/k2/cmd/nodepool/nodepool_main.cpp
+++ b/src/k2/cmd/nodepool/nodepool_main.cpp
@@ -42,6 +42,7 @@ int main(int argc, char** argv) {
         ("k23si_query_push_limit", bpo::value<uint32_t>(), "Min records in response needed to avoid a push during query processing")
         ("k23si_max_push_count", bpo::value<uint32_t>(), "Max push count in handleRead and handleWrite")
         ("k23si_read_cache_size", bpo::value<uint64_t>(), "Max size of read cache")
+        ("k23si_autoflush_deadline", bpo::value<k2::ParseableDuration>(), "Auto flush interval")
         ("k23si_persistence_endpoints", bpo::value<std::vector<k2::String>>()->multitoken()->default_value(std::vector<k2::String>()), "A space-delimited list of k2 persistence endpoints, each core will pick one endpoint");
 
     app.addApplet<k2::cpo::HeartbeatResponder>();

--- a/src/k2/tso/service/Service.cpp
+++ b/src/k2/tso/service/Service.cpp
@@ -139,6 +139,7 @@ seastar::future<bool> TSOService::_assign(uint64_t tsoID, k2::Duration errBound)
                     isValidErrorBound = true;
                     return true;
                 }
+                K2LOG_W(log::tsoserver, "GPS clock with error {} cannot meet the requested error bound {}", now.error, _CPOErrorBound);
                 isValidErrorBound = false;
                 ++_failedErrorBounds;
                 return Clock::now() - assignStart > _assignTimeout();

--- a/test/integration/run_k2_cluster.sh
+++ b/test/integration/run_k2_cluster.sh
@@ -22,7 +22,7 @@ cpo_main ${COMMON_ARGS} -c1 --tcp_endpoints ${CPO}  --data_dir ${CPODIR} --prome
 cpo_child_pid=$!
 
 # start nodepool
-nodepool ${COMMON_ARGS} -c${#EPS[@]} --tcp_endpoints ${EPS[@]} --k23si_persistence_endpoint ${PERSISTENCE} --prometheus_port $(($PROMETHEUS_PORT_START+1)) --memory=1G --partition_request_timeout=6s &
+nodepool ${COMMON_ARGS} -c${#EPS[@]} --tcp_endpoints ${EPS[@]} --k23si_persistence_endpoint ${PERSISTENCE} --prometheus_port $(($PROMETHEUS_PORT_START+1)) --memory=1G --partition_request_timeout=6s  --k23si_query_pagination_limit=3000&
 nodepool_child_pid=$!
 
 # start persistence

--- a/test/integration/test_http_client.sh
+++ b/test/integration/test_http_client.sh
@@ -5,11 +5,11 @@ source ${topname}/common_defs.sh
 cd ${topname}/../..
 
 # start CPO
-./build/src/k2/cmd/controlPlaneOracle/cpo_main ${COMMON_ARGS} -c1 --tcp_endpoints ${CPO} 9001 --data_dir ${CPODIR} --prometheus_port 63000 --assignment_timeout=3s --txn_heartbeat_deadline=1s --nodepool_endpoints ${EPS[@]} --tso_endpoints ${TSO} --tso_error_bound=100us --persistence_endpoints ${PERSISTENCE}&
+./build/src/k2/cmd/controlPlaneOracle/cpo_main ${COMMON_ARGS} -c1 --tcp_endpoints ${CPO} 9001 --data_dir ${CPODIR} --prometheus_port 63000 --assignment_timeout=1s --txn_heartbeat_deadline=1s --nodepool_endpoints ${EPS[@]} --tso_endpoints ${TSO} --tso_error_bound=100us --persistence_endpoints ${PERSISTENCE} &
 cpo_child_pid=$!
 
 # start nodepool
-./build/src/k2/cmd/nodepool/nodepool ${COMMON_ARGS} -c${#EPS[@]} --tcp_endpoints ${EPS[@]} --k23si_persistence_endpoint ${PERSISTENCE} --prometheus_port 63001 --memory=1G --partition_request_timeout=6s &
+./build/src/k2/cmd/nodepool/nodepool ${COMMON_ARGS} -c${#EPS[@]} --tcp_endpoints ${EPS[@]} --k23si_persistence_endpoint ${PERSISTENCE} --prometheus_port 63001 --memory=1G --partition_request_timeout=2s --k23si_autoflush_deadline=50ms &
 nodepool_child_pid=$!
 
 # start persistence
@@ -23,7 +23,7 @@ tso_child_pid=$!
 sleep 1
 
 # start http proxy with increased cpo request timeout as delete collection takes more time
-./build/src/k2/cmd/httpproxy/http_proxy ${COMMON_ARGS} -c1 --tcp_endpoints ${HTTP} --memory=1G --cpo ${CPO} --httpproxy_txn_timeout=100ms --httpproxy_expiry_timer_interval=50ms --cpo_request_timeout=6s&
+./build/src/k2/cmd/httpproxy/http_proxy ${COMMON_ARGS} -c1 --tcp_endpoints ${HTTP} --memory=1G --cpo ${CPO} --httpproxy_txn_timeout=100ms --httpproxy_expiry_timer_interval=50ms --cpo_request_timeout=2s&
 http_child_pid=$!
 
 function finish {

--- a/test/integration/test_http_client.sh
+++ b/test/integration/test_http_client.sh
@@ -4,6 +4,10 @@ topname=$(dirname "$0")
 source ${topname}/common_defs.sh
 cd ${topname}/../..
 
+# start tso
+./build/src/k2/cmd/tso/tso ${COMMON_ARGS} -c1 --tcp_endpoints ${TSO} --prometheus_port 63003 --tso.clock_poller_cpu=${TSO_POLLER_CORE} &
+tso_child_pid=$!
+
 # start CPO
 ./build/src/k2/cmd/controlPlaneOracle/cpo_main ${COMMON_ARGS} -c1 --tcp_endpoints ${CPO} 9001 --data_dir ${CPODIR} --prometheus_port 63000 --assignment_timeout=1s --txn_heartbeat_deadline=1s --nodepool_endpoints ${EPS[@]} --tso_endpoints ${TSO} --tso_error_bound=100us --persistence_endpoints ${PERSISTENCE} &
 cpo_child_pid=$!
@@ -15,10 +19,6 @@ nodepool_child_pid=$!
 # start persistence
 ./build/src/k2/cmd/persistence/persistence ${COMMON_ARGS} -c1 --tcp_endpoints ${PERSISTENCE} --prometheus_port 63002 &
 persistence_child_pid=$!
-
-# start tso
-./build/src/k2/cmd/tso/tso ${COMMON_ARGS} -c1 --tcp_endpoints ${TSO} --prometheus_port 63003 --tso.clock_poller_cpu=${TSO_POLLER_CORE} &
-tso_child_pid=$!
 
 sleep 1
 

--- a/test/integration/test_http_cpp_client.sh
+++ b/test/integration/test_http_cpp_client.sh
@@ -4,6 +4,10 @@ topname=$(dirname "$0")
 source ${topname}/common_defs.sh
 cd ${topname}/../..
 
+# start tso
+./build/src/k2/cmd/tso/tso ${COMMON_ARGS} -c1 --tcp_endpoints ${TSO} --prometheus_port 63003 --tso.clock_poller_cpu=${TSO_POLLER_CORE} &
+tso_child_pid=$!
+
 # start CPO
 ./build/src/k2/cmd/controlPlaneOracle/cpo_main ${COMMON_ARGS} -c1 --tcp_endpoints ${CPO} 9001 --data_dir ${CPODIR} --prometheus_port 63000 --assignment_timeout=3s --txn_heartbeat_deadline=1s --nodepool_endpoints ${EPS[@]} --tso_endpoints ${TSO} --tso_error_bound=100us --persistence_endpoints ${PERSISTENCE}&
 cpo_child_pid=$!
@@ -15,10 +19,6 @@ nodepool_child_pid=$!
 # start persistence
 ./build/src/k2/cmd/persistence/persistence ${COMMON_ARGS} -c1 --tcp_endpoints ${PERSISTENCE} --prometheus_port 63002 &
 persistence_child_pid=$!
-
-# start tso
-./build/src/k2/cmd/tso/tso ${COMMON_ARGS} -c1 --tcp_endpoints ${TSO} --prometheus_port 63003 --tso.clock_poller_cpu=${TSO_POLLER_CORE} &
-tso_child_pid=$!
 
 sleep 1
 # start http proxy with increased cpo request timeout as delete collection takes more time

--- a/test/integration/test_http_cpp_client.sh
+++ b/test/integration/test_http_cpp_client.sh
@@ -9,7 +9,7 @@ cd ${topname}/../..
 cpo_child_pid=$!
 
 # start nodepool
-./build/src/k2/cmd/nodepool/nodepool ${COMMON_ARGS} -c${#EPS[@]} --tcp_endpoints ${EPS[@]} --k23si_persistence_endpoint ${PERSISTENCE} --prometheus_port 63001 --memory=1G --partition_request_timeout=6s &
+./build/src/k2/cmd/nodepool/nodepool ${COMMON_ARGS} -c${#EPS[@]} --tcp_endpoints ${EPS[@]} --k23si_persistence_endpoint ${PERSISTENCE} --prometheus_port 63001 --memory=1G --partition_request_timeout=6s --k23si_autoflush_deadline=50ms&
 nodepool_child_pid=$!
 
 # start persistence


### PR DESCRIPTION
When drop collection, it by default waits 1s to flush remaining transactions that are left. Transactions are not flushed immediately when committed as they are created with sync finalize=false.